### PR TITLE
additions

### DIFF
--- a/openCL/ocl_azim_kernel_2.cl
+++ b/openCL/ocl_azim_kernel_2.cl
@@ -299,14 +299,12 @@ create_histo_binarray(const __global float    *tth,
   int    cbin;
   float  fbin;
   float  a0, b0, center;
-//  float epsilon = 1e-6f;
-  int spread, N, Nbins;
+  int spread;
 
   float x_interp;
   float I_interp;
   float fbinsize;
   float inrange;
-  //histogram[1023] = 0;
   gid=get_global_id(0);
 
   //Load tth min and max from slow global to fast register cache
@@ -315,16 +313,13 @@ create_histo_binarray(const __global float    *tth,
   tth_rmin= tth_range[0];
   tth_rmax= tth_range[1];
 
-  N = NN;
-  Nbins = BINS;
-
   if(gid < NN)
   {
     if(!mask[gid])
     {
       center = tth[gid];
 
-      fbinsize = (tth_rmax - tth_rmin)/Nbins;
+      fbinsize = (tth_rmax - tth_rmin)/BINS;
 
       a0=center + dtth[gid];
       b0=center - dtth[gid];
@@ -334,6 +329,7 @@ create_histo_binarray(const __global float    *tth,
       {
         if(b0 < tth_rmin) b0 = center;
         if(a0 > tth_rmax) a0 = center;
+        //As of 20/06/12 The range problem is expected to be handled at input level
         fbin0_min=(b0 - tth_rmin) * (BINS) / (tth_rmax - tth_rmin);
         fbin0_max=(a0 - tth_rmin) * (BINS) / (tth_rmax - tth_rmin);
         bin0_min = (int)fbin0_min;

--- a/openCL/ocl_base.cpp
+++ b/openCL/ocl_base.cpp
@@ -99,6 +99,8 @@ ocl::ocl(){
 ocl::~ocl(){
   clean();
   delete oclconfig;
+  ocl_platform_info_del(platform_info);
+  ocl_device_info_del(device_info);
   delete sgs;
   if(!usesStdout) fclose(stream);
   delete[] docstr;
@@ -136,6 +138,8 @@ void ocl::ContructorInit()
   oclconfig->Nkernels=0;
   oclconfig->oclmemref =NULL;
   oclconfig->oclkernels=NULL;
+  ocl_platform_info_init(platform_info);
+  ocl_device_info_init(device_info);
   sgs->Nx = 0;
   sgs->Nimage = 0;
   sgs->Nbins = 0;
@@ -154,6 +158,44 @@ void ocl::show_devices(){
   //Print all the probed devices to stream
   ocl_check_platforms(stream);
 return;
+}
+
+void ocl::print_active_platform_info()
+{
+  if(hasActiveContext)
+  {
+    ocl_current_platform_info(oclconfig, platform_info);
+  }
+    std::cout<<"Platform name: " << platform_info.name<<std::endl;
+    std::cout<<"Platform version: " << platform_info.version<<std::endl;
+    std::cout<<"Platform vendor: " << platform_info.vendor<<std::endl;
+    std::cout<<"Platform extensions: " << platform_info.extensions<<std::endl;
+  //}
+return;  
+}
+
+void ocl::print_active_device_info()
+{
+  if(hasActiveContext)
+  {
+    ocl_current_device_info(oclconfig, device_info);
+  }
+    std::cout<<"Device name: " << device_info.name<<std::endl;
+    std::cout<<"Device type: " << device_info.type<<std::endl;
+    std::cout<<"Device version: " << device_info.version<<std::endl;
+    std::cout<<"Device driver version: " << device_info.driver_version<<std::endl;
+    std::cout<<"Device extensions: " << device_info.extensions<<std::endl;
+    std::cout<<"Device Max Memory: " << device_info.global_mem<<std::endl;
+  //}
+return;
+}
+
+void ocl::return_pair(int &platform, int &device)
+{
+  platform = oclconfig->platfid;
+  device   = oclconfig->devid;
+
+return;  
 }
 
 /**
@@ -395,7 +437,6 @@ void ocl::setDocstring(const char *default_text, const char *filename)
 
   ifstream readme;
   int len=0;
-  size_t count;
 
   readme.open(filename,ios::in);
 

--- a/openCL/ocl_base.hpp
+++ b/openCL/ocl_base.hpp
@@ -162,10 +162,19 @@ public:
    * bit 7: use dummy value
    */
   int get_status();
+
+  void print_active_platform_info();
+  void print_active_device_info();
+
+  void return_pair(int &platform, int &device);
+  
 /**
  * \brief Holds the documentation message
  */  
   char *docstr;
+
+  ocl_plat_t platform_info;
+  ocl_dev_t device_info; 
 protected:
 
   /**

--- a/openCL/ocl_tools.h
+++ b/openCL/ocl_tools.h
@@ -18,7 +18,7 @@
  *                                 Grenoble, France
  *
  *   Principal authors: D. Karkoulis (karkouli@esrf.fr)
- *   Last revision: 26/04/2012
+ *   Last revision: 20/06/2012
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Lesser General Public License as published
@@ -61,6 +61,39 @@
 #define OCL_MAX_DEVICES 5
 
 /**
+ * \brief OpenCL tools platform information struct
+ *
+ * It can be passed to ocl_platform_info to
+ * retrieve and save platform information
+ * for the currect context
+ */
+typedef struct
+{
+  char *name;
+  char *vendor;
+  char *version;
+  char *extensions;
+}ocl_plat_t;
+
+/**
+ * \brief OpenCL tools platform information struct
+ *
+ * It can be passed to ocl_device_info to
+ * retrieve and save device information
+ * for the currect context
+ */
+typedef struct
+{
+  char *name;
+  char type[4];
+  char *refcount;
+  char *version;
+  char *driver_version;
+  char *extensions;
+  unsigned long global_mem;
+}ocl_dev_t;
+
+/**
  * \brief OpenCL tools cl_program structure
  * 
  * Substruct of ocl_configuration_parameters.
@@ -89,6 +122,9 @@ typedef struct ocl_configuration_parameters{
   cl_command_queue  oclcmdqueue;
   cl_mem            *oclmemref;
 
+  int devid;
+  int platfid;
+  
   //If single .cl file:
   cl_program        oclprogram;
   size_t            *kernelstring_lens;
@@ -128,7 +164,7 @@ int ocl_find_devicetype(cl_device_type device_type, cl_platform_id &platform, cl
 /**
  * \brief Simple check for a "device_type" device. Returns the first occurance that supports double precision only
  */
-int ocl_find_devicetype_FP64(cl_device_type device_type, cl_platform_id &platform, cl_device_id &devid,FILE *stream=stdout);
+int ocl_find_devicetype_FP64(cl_device_type device_type, cl_platform_id& platform, cl_device_id& devid);
 
 /**
  * \brief Probes OpenCL platforms & devices of a given cl_device_type. Keeps the selected device in oclconfig
@@ -169,22 +205,14 @@ int ocl_init_context(ocl_config_type *oclconfig,cl_platform_id platform,cl_devic
 /**
  * \brief Destroy an OpenCL context
  */
-int ocl_destroy_context(cl_context oclcontext,FILE *stream=stdout);
-
-/**
- * \brief deprecated eval_Fp64. Use ocl_eval_FP64 instead
- */
-/*WARNING this is a deprecated function as this way may not always fail under different OpenCL compilers*/
-/* Use the new ocl_eval_FP64 instead*/
-/* Used fixed minimal kernels to check if FP64 is supported. Returns 0 on successful FP64 evaluation and -1 if only FP32. Exits on failure*/
-int _deprec_ocl_eval_FP64(ocl_config_type *oclconfig,int *eval_res,FILE *stream=stdout);
+int ocl_destroy_context(cl_context oclcontext);
 
 /**
  * \brief Queries the fp64 capability of an OpenCL device that has been selected by ocl_probe
  */
 /* Queries device capabilities to figure if it meets the minimum requirement for double precision*/
 /* Returns 0 on successful FP64 evaluation and -1 if only FP32 */
-int ocl_eval_FP64(ocl_config_type *oclconfig,int *eval_res, FILE *stream);
+int ocl_eval_FP64(ocl_config_type *oclconfig, FILE *stream);
 
 /**
  * \brief Queries the fp64 capability of an OpenCL device directly via the cl_device_id
@@ -236,6 +264,14 @@ float ocl_get_profT(cl_event *start, cl_event *stop);
  */
 int ocl_string_to_cldevtype(const char *devicetype, cl_device_type &ocldevtype);
 
+void ocl_platform_info_init(ocl_plat_t &platinfo);
+void ocl_platform_info_del(ocl_plat_t &platinfo);
+void ocl_device_info_init(ocl_dev_t &devinfo);
+void ocl_device_info_del(ocl_dev_t &devinfo);
+
+int ocl_current_platform_info(ocl_config_type *oclconfig, ocl_plat_t &platinfo);
+int ocl_current_device_info(ocl_config_type *oclconfig, ocl_dev_t &devinfo);
+
 /**
  * \brief Translate error code to error message
  */
@@ -248,7 +284,7 @@ int ocl_string_to_cldevtype(const char *devicetype, cl_device_type &ocldevtype);
  */
 /* Opencl error function. Some Opencl functions allow pfn_notify to report errors, by passing it as pointer.
       Consult the OpenCL reference card for these functions. */
-void __call_compat pfn_notify(const char *errinfo, const void *private_info, size_t cb, void *user_data);
+void __call_compat pfn_notify(const char *errinfo);
 
 /* Basic function to handle error messages */
 void ocl_errmsg(const char *userstring, const char *file, const int line);

--- a/openCL/ocl_xrpd1d_fullsplit.cpp
+++ b/openCL/ocl_xrpd1d_fullsplit.cpp
@@ -279,7 +279,7 @@ int ocl_xrpd1D_fullsplit::configure(const char* kernel_path)
   CR(
     clEnqueueNDRangeKernel(oclconfig->oclcmdqueue,oclconfig->oclkernels[CLKERN_IMEMSET],1,0,wdim,tdim,0,0,&oclconfig->t_s[0]) );
 
-  execTime_ms += ocl_get_profT(&oclconfig->t_s[0], &oclconfig->t_s[0],  "Initialise Mask to 0");
+  execTime_ms += ocl_get_profT(&oclconfig->t_s[0], &oclconfig->t_s[0],  "Initialise Mask to 0", stream);
   clReleaseEvent(oclconfig->t_s[0]);
   
 return 0;


### PR DESCRIPTION
Added functionality for ocl_tools and ocl_base to report information on current device and platform and also the (Platform.Device) pair
Small fixes in 1D kernel (SVN 260)

Some comments are still missing

Check the ocl_base.hpp for the new stuff.
Here is an example from C++:

  test.print_active_platform_info();
  test.print_active_device_info();

  int a,b;
  test.return_pair(a,b);
  std::cout<< "Platform " << a << " Device " << b << std::endl;

The last should be exactly what you want. Returns the Platform.Device pair.
The first two print information. This info is also saved in these two structs defined by ocl_tools.h

  ocl_plat_t platform_info;
  ocl_dev_t device_info; 

typedef struct
{
  char *name;
  char *vendor;
  char *version;
  char *extensions;
}ocl_plat_t;

typedef struct
{
  char *name;
  char type[4];
  char *refcount;
  char *version;
  char *driver_version;
  char *extensions;
  unsigned long global_mem;
}ocl_dev_t;
