### PR TITLE
Tidying up the OpenCL implementation lib

### DIFF
--- a/openCL/ocl_azim.pyx
+++ b/openCL/ocl_azim.pyx
@@ -303,12 +303,6 @@ cdef class Integrator1d:
         "Prints a list of OpenCL capable devices, their platforms and their ids"
         self.cpp_integrator.show_devices()
 
-
-    def print_devices(self):
-        """Same as show_devices but displays the results always on stdout even
-        if the stream is set to a file"""
-        self.cpp_integrator. print_devices()
-
     def  show_device_details(self):
         "Print details of a selected device"
         self.cpp_integrator.show_device_details()
@@ -337,26 +331,12 @@ cdef class Integrator1d:
             out[v]=bool(int(retbin[i]))
         return out
 
-    def print_active_platform_info(self):
-        """
-        Print (on stdout) information of the current platform
-        Todo: return the string by modifying stdout if can be done
-        """
-        self.cpp_integrator.print_active_platform_info()
-
-    def print_active_device_info(self):
-        """
-        Print (on stdout) information of the current device
-        Todo: return the string by modifying stdout if can be done
-        """
-        self.cpp_integrator.print_active_device_info()
-
     def get_ids(self):
         """
         @return: 2-tuple of integers corresponding to (platform_id, device_id)
         """
         cdef int platform = -1, device = -1
-        self.cpp_integrator.return_pair(platform, device)
+        self.cpp_integrator.get_contexed_Ids(platform, device)
         return (platform, device)
 
 _INTEGRATORS_1D={} #key=(Nimage,NBins), value=instance of Integrator1d

--- a/openCL/ocl_base.hpp
+++ b/openCL/ocl_base.hpp
@@ -20,7 +20,7 @@
  *                             Grenoble, France
  *
  *   Principal authors: D. Karkoulis (karkouli@esrf.fr)
- *   Last revision: 11/05/2012
+ *   Last revision: 21/06/2012
  *    
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Lesser General Public License as published
@@ -51,7 +51,10 @@
 #define OCL_BASE_H
 
 #ifdef _WIN32
-#define _CRT_SECURE_NO_WARNINGS 1
+	#ifndef _CRT_SECURE_NO_WARNINGS
+		#define _CRT_SECURE_NO_WARNINGS
+	#endif
+	#pragma warning(disable : 4996)
 #endif
 
 #include <iostream>
@@ -112,18 +115,12 @@ public:
 /*
  * Prints a list of OpenCL capable devices, their platforms and their ids
  */  
-  void show_devices();
+  void show_devices(int ignoreStream=1);
 
 /*
- * Same as show_devices but displays the results always on stdout even
- * if the stream is set to a file
- */
- void print_devices();
-
-/*
- * Print details of a selected device
+ * Prints some basic information about the device in use
  */  
-  void show_device_details();
+  void show_device_details(int ignoreStream=1);
 
 /*
  * Provide help message for interactive environments
@@ -163,11 +160,16 @@ public:
    */
   int get_status();
 
-  void print_active_platform_info();
-  void print_active_device_info();
+ /*
+  *Returns the pair ID (platform.device) of the active device
+  */
+  void get_contexed_Ids(int &platform, int &device);
 
-  void return_pair(int &platform, int &device);
-  
+ /*
+  *Returns the -C++- pair ID (platform.device) of the active device
+  */
+  std::pair<int,int> get_contexed_Ids()  ;
+
 /**
  * \brief Holds the documentation message
  */  
@@ -266,6 +268,8 @@ protected:
  *
  */  
   void setDocstring(const char *default_text, const char *filename);
+
+  void promote_device_details();
 };
 
 #endif

--- a/openCL/ocl_tools.h
+++ b/openCL/ocl_tools.h
@@ -18,7 +18,7 @@
  *                                 Grenoble, France
  *
  *   Principal authors: D. Karkoulis (karkouli@esrf.fr)
- *   Last revision: 20/06/2012
+ *   Last revision: 21/06/2012
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU Lesser General Public License as published
@@ -48,6 +48,10 @@
   #define __call_compat __stdcall
 #else
   #define __call_compat 
+	#ifndef _CRT_SECURE_NO_WARNINGS
+		#define _CRT_SECURE_NO_WARNINGS
+	#endif
+	#pragma warning(disable : 4996)
 #endif
 
 /**
@@ -122,9 +126,12 @@ typedef struct ocl_configuration_parameters{
   cl_command_queue  oclcmdqueue;
   cl_mem            *oclmemref;
 
+  //Active device and platform info
   int devid;
   int platfid;
-  
+  ocl_plat_t		platform_info;
+  ocl_dev_t			device_info;
+
   //If single .cl file:
   cl_program        oclprogram;
   size_t            *kernelstring_lens;
@@ -150,6 +157,9 @@ typedef struct ocl_configuration_parameters{
 /* All production functions return 0 on success, -1 on OpenCL error and -2 on other errors.
     when an error is encountered internally, it will print the message to stderr and fallback.
     It is important for the user to decide how to continue.*/
+
+void ocl_tools_initialise(ocl_config_type *oclconfig);
+void ocl_tools_destroy(ocl_config_type *oclconfig);
 
 /**
  * \brief Simple check all platforms and devices and print information
@@ -269,8 +279,8 @@ void ocl_platform_info_del(ocl_plat_t &platinfo);
 void ocl_device_info_init(ocl_dev_t &devinfo);
 void ocl_device_info_del(ocl_dev_t &devinfo);
 
-int ocl_current_platform_info(ocl_config_type *oclconfig, ocl_plat_t &platinfo);
-int ocl_current_device_info(ocl_config_type *oclconfig, ocl_dev_t &devinfo);
+int ocl_current_platform_info(ocl_config_type *oclconfig);
+int ocl_current_device_info(ocl_config_type *oclconfig);
 
 /**
  * \brief Translate error code to error message

--- a/openCL/ocl_xrpd1d.hpp
+++ b/openCL/ocl_xrpd1d.hpp
@@ -41,7 +41,10 @@
 #define OCL_XRPD1D_H
  
 #ifdef _WIN32
-#define _CRT_SECURE_NO_WARNINGS 1
+	#ifndef _CRT_SECURE_NO_WARNINGS
+		#define _CRT_SECURE_NO_WARNINGS
+	#endif
+	#pragma warning(disable : 4996)
 #endif
 
 #include <iostream>

--- a/openCL/ocl_xrpd1d_fullsplit.cpp
+++ b/openCL/ocl_xrpd1d_fullsplit.cpp
@@ -53,10 +53,6 @@
 #define CER CL_CHECK_ERR_PR_RET
 #define CR  CL_CHECK_PR_RET
 
-#ifdef _WIN32
-#define _CRT_SECURE_NO_WARNINGS 1
-#endif
-
 //#define silent
 #ifdef _SILENT
   #define fprintf(stream,...)


### PR DESCRIPTION
Placed the new functions in their place and rearranged a few things.

Some small changes on the ocl_base header, cython interface updated accordingly.

Fixed warnings from Visual Studio (11) as well
