### PR TITLE
Avoid to generate profile.log default tests (improve #283)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Generated
 /package
+/profile.log
 
 # Packages
 *.egg

--- a/run_tests.py
+++ b/run_tests.py
@@ -138,9 +138,11 @@ def _copy_files(source, dest, extn):
 
 
 class TestResult(unittest.TestResult):
-    logger = logging.getLogger("memProf")
-    logger.setLevel(logging.DEBUG)
-    logger.handlers.append(logging.FileHandler("profile.log"))
+
+    def __init__(self):
+        self.logger = logging.getLogger("memProf")
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.handlers.append(logging.FileHandler("profile.log"))
 
     def startTest(self, test):
         if resource:


### PR DESCRIPTION
- Avoid generateing the log files for default tests
- Ignore the file in other cases