### PR TITLE
Appveyor without pip install cython

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -62,7 +62,7 @@ build_script:
     - python -m pip install --upgrade pip
     - "pip install --upgrade setuptools wheel"
     # Install build dependencies
-    - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ numpy cython --upgrade"
+    - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ numpy --upgrade"
     - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyparsing scipy --upgrade"
     - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ -r ci/requirements_appveyor.txt --upgrade"
 


### PR DESCRIPTION
Only to try appveyor compilation.
Silx project does not install cython, let see if it works