### PR TITLE
Clean up compatibility code for setuptools (do not merge)

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -71,16 +71,6 @@ build_script:
           & "C:\\Program Files\\Microsoft SDKs\\Windows\\v7.1\\Bin\\SetEnv.cmd" /x64
         }
 
-    # Workaround to fix pyfai compilation on Python 3.5
-    # Last setuptools on virtualenv create linking error: fatal error LNK1181: cannot open input file 'Files.obj'
-    # It can be reproduced in our windows computer
-    # setuptools 24.* and 25.* have this problem
-    # Still need to investigate
-    - ps: >-
-        If ($env:PYTHON_VERSION -Like "3.5.*") {
-          pip install --upgrade setuptools==23
-        }
-
     # Install build dependencies
     - "pip install --upgrade wheel"
     - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ numpy cython --upgrade"


### PR DESCRIPTION
- It is not possible to use setuptools version >23 and <25.1.4 to compile the project with Python 3.5 on Windows
- setuptools 25.1.4 was patched and is now released