### PR TITLE
Try setuptools 23 (do not merge)

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -76,6 +76,7 @@ build_script:
     - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ numpy cython --upgrade"
     - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyparsing scipy --upgrade"
     - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ -r ci/requirements_appveyor.txt --upgrade"
+    - "pip install --upgrade setuptools==23"
 
     # Print Python info
     - "python ci\\info_platform.py"


### PR DESCRIPTION
Appveyor is not compiling again with Windows, Python 3.5.
- https://ci.appveyor.com/project/ESRF/pyfai/build/0.13.157/job/t1lcjvoyttsoeadg

I was not able to reproduce the same problem on our windows machine.
Then let see if we can avoid the problem with an older version of setuptools