### PR TITLE
Fix global on RELEASE_LEVEL_VALUE

### DIFF
--- a/version.py
+++ b/version.py
@@ -98,6 +98,7 @@ def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):
     :param serial: integer
     :return: integerm always increasing with revision numbers  
     """
+    global RELEASE_LEVEL_VALUE
     try:
         releaselevel = int(releaselevel)
     except ValueError:


### PR DESCRIPTION
Reveled when using `./bootstrap.py ./version.py` from make_man

No idea why it was not spotted before.