### PR TITLE
Convenient PATH fix to generate man files from local project and not from installed scripts

### DIFF
--- a/make_man
+++ b/make_man
@@ -31,6 +31,10 @@ if [ ! -d $OUTPUT_DIR ]
 python setup.py build
 version=$(./bootstrap.py ./version.py |tail -n 1)
 echo $version
+
+export PATH=./build/scripts-2.7:$PATH
+export PYTHONPATH=./build/lib.linux-x86_64-2.7
+
 for i in scripts/*;
     do
     script_name=$(basename $i)


### PR DESCRIPTION
- The inconvenient is it uses hard coded path
- But this script is not often used

Well. I think it is convenient. Cause i would like, at the end to remove all auto-generated content.
But i understand it is not merged, cause it is not portable.
