### PR TITLE
Ignore some paths with landslides

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,6 @@
+ignore-paths:
+  - ci/
+  - doc/
+  - package/
+  - plugins/
+  - sandbox/


### PR DESCRIPTION
It ignores some paths with landscape, then the metric should be more interesting.
I mostly skip sandbox files and plugins files. We can talk about that.