### PR TITLE
Backport from 0.14-dev to 0.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ addons:
       - libqtcore4
 #For OpenCL:
       - libboost1.48-dev
-      - libboost-python-dev
       - libboost-python1.48
       - opencl-headers
       - python-pyopencl

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,14 @@
 ChangeLog of Versions
 =====================
 
+0.13.1: 30/01/2017
+------------------
+
+* Backport critical bug fix from 0.14-dev
+    - Convert matplotlib mouse input into pixel coordinates (fix issue with numpy 0.12)
+    - Fix eiger-mask script if h5py is not installed
+    - Use "/usr/bin/env python" for scripts
+
 0.13.0: 01/12/2016
 ------------------
 * Global improvement of tests, packaging, code quality, documentation and project tools

--- a/pyFAI/massif.py
+++ b/pyFAI/massif.py
@@ -26,7 +26,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "GPLv3+"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "24/11/2016"
+__date__ = "12/12/2016"
 __status__ = "production"
 
 import sys
@@ -113,7 +113,8 @@ class Massif(object):
         """
         All in one function that finds a maximum from the given seed (x)
         then calculates the region extension and extract position of the neighboring peaks.
-        :param x: seed for the calculation, input coordinates
+        :param x: coordinates of the peak, seed for the calculation
+        :type x: tuple of integer
         :param nmax: maximum number of peak per region
         :param annotate: call back method taking number of points + coordinate as input.
         :param massif_contour: callback to show the contour of a massif with the given index.

--- a/scripts/eiger-mask
+++ b/scripts/eiger-mask
@@ -35,19 +35,27 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "GPLv3+"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "28/11/2016"
+__date__ = "05/12/2016"
 __satus__ = "development"
 
 
 import os
 import sys
-import h5py
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("eiger-mask")
 import numpy
 import fabio
+
 try:
     from argparse import ArgumentParser
 except ImportError:
     from pyFAI.third_party.argparse import ArgumentParser
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
 
 
 def extract_mask(infile):
@@ -65,10 +73,17 @@ def extract_mask(infile):
 
 if __name__ == "__main__":
     description = "A tool to extract the mask from an Eiger detector file."
-    parser = ArgumentParser(description=description)
+    epilog = None
+    if h5py is None:
+        epilog = "Python h5py module is missing. It have to be installed to use this application"
+    parser = ArgumentParser(description=description, epilog=epilog)
     parser.add_argument('input_file', help='Input file. Must be an HDF5 file.')
     parser.add_argument('output_file', nargs="?", help='Output file. It can be an msk, tif, or an edf file.')
     options = parser.parse_args()
+
+    if h5py is None:
+        logger.error("Python h5py module is expected to use this script")
+        sys.exit(1)
 
     infile = os.path.abspath(options.input_file)
     if options.output_file is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@
 #For Windows with Cuda 64 bits:
 #include-dirs: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v3.2\include
 #library-dirs: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v3.2\lib\x64
+[build]
+executable = /usr/bin/env python

--- a/version.py
+++ b/version.py
@@ -53,7 +53,7 @@ from __future__ import absolute_import, print_function, division
 __authors__ = ["Jérôme Kieffer"]
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "02/12/2016"
+__date__ = "30/01/2017"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 __all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion", "calc_hexversion"]
@@ -67,7 +67,7 @@ RELEASE_LEVEL_VALUE = {"dev": 0,
 
 MAJOR = 0
 MINOR = 13
-MICRO = 0
+MICRO = 1
 RELEV = "final"  # <16
 SERIAL = 0  # <16
 


### PR DESCRIPTION
Backport critical bug fix from 0.14-dev
- Convert matplotlib mouse input into pixel coordinates (fix issue with numpy 0.12)
- Fix eiger-mask script if h5py is not installed
- Use "/usr/bin/env python" for scripts