### PR TITLE
Fix residual in case of free wavelength

### DIFF
--- a/pyFAI/calibration.py
+++ b/pyFAI/calibration.py
@@ -734,7 +734,7 @@ class AbstractCalibration(object):
                     if (count == 0):
                         previous = six.MAXSIZE
                     else:
-                        previous = self.geoRef.chi2()
+                        previous = self.geoRef.chi2_wavelength()
                     self.geoRef.refine2_wavelength(1000000, fix=self.fixed)
                     print(self.geoRef)
                     count += 1


### PR DESCRIPTION
`previous` variable was previously tested against `chi2_wavelength()`. It makes sense to initialize it with the same function.