### PR TITLE
pyFAI-Integrate with monitor

### DIFF
--- a/pyFAI/app/integrate.py
+++ b/pyFAI/app/integrate.py
@@ -40,7 +40,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "15/06/2017"
+__date__ = "18/07/2017"
 __satus__ = "production"
 import sys
 import logging
@@ -54,6 +54,8 @@ import pyFAI.worker
 from pyFAI.io import DefaultAiWriter
 from pyFAI.io import HDF5Writer
 from pyFAI.utils.shell import ProgressBar
+from pyFAI import average
+
 
 try:
     from argparse import ArgumentParser
@@ -87,6 +89,27 @@ def integrate_gui(options, args):
     window.set_input_data(args)
     window.show()
     return app.exec_()
+
+
+def get_monitor_value(image, monitor_key):
+    """Return the monitor value from an image using an header key.
+
+    :param fabio.fabioimage.FabioImage image: Image containing the header
+    :param str monitor_key: Key containing the monitor
+    :return: returns the monitor else returns 1.0
+    :rtype: float
+    """
+    if monitor_key is None or monitor_key == "":
+        return 1.0
+    try:
+        monitor = average.get_monitor_value(image, monitor_key)
+        return monitor
+    except average.MonitorNotFound:
+        logger.warning("Monitor %s not found. No normalization applied." % monitor_key)
+        return 1.0
+    except Exception as e:
+        logger.warning("Fail to load monitor. No normalization applied. %s" % str(e))
+        return 1.0
 
 
 def integrate_shell(options, args):
@@ -148,18 +171,22 @@ def integrate_shell(options, args):
 
             for i in range(img.nframes):
                 fimg = img.getframe(i)
-                data = fimg.data
-                if worker.do_2D():
-                    res = worker.process(data, metadata=fimg.header)
-                else:
-                    res = worker.process(data, metadata=fimg.header)
+                normalization_factor = get_monitor_value(fimg, options.monitor_key)
+                data = img.data
+                res = worker.process(data=data,
+                                     metadata=fimg.header,
+                                     normalization_factor=normalization_factor)
+                if not worker.do_2D():
                     res = res.T[1]
                 writer.write(res, index=i)
             writer.close()
         else:
+            normalization_factor = get_monitor_value(img, options.monitor_key)
             data = img.data
             writer = DefaultAiWriter(outpath, worker.ai)
-            worker.process(data, writer=writer)
+            worker.process(data,
+                           normalization_factor=normalization_factor,
+                           writer=writer)
             writer.close()
 
     progress_bar.clear()
@@ -204,6 +231,15 @@ http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=697348"""
                         help="Configuration file containing the processing to be done")
     parser.add_argument("args", metavar='FILE', type=str, nargs='*',
                         help="Files to be integrated")
+    parser.add_argument("--monitor-name", dest="monitor_key", default=None,
+                        help="Name of the monitor in the header of each input \
+                        files. If defined the contribution of each input file \
+                        is divided by the monitor. If the header does not \
+                        contain or contains a wrong value, the contribution \
+                        of the input file is ignored.\
+                        On EDF files, values from 'counter_pos' can accessed \
+                        by using the expected mnemonic. \
+                        For example 'counter/bmon'.")
     options = parser.parse_args()
 
     # Analysis arguments and options

--- a/pyFAI/average.py
+++ b/pyFAI/average.py
@@ -35,7 +35,7 @@ __authors__ = ["Jérôme Kieffer", "Valentin Valls"]
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "08/11/2016"
+__date__ = "18/07/2017"
 __status__ = "production"
 
 import logging
@@ -520,7 +520,7 @@ def _get_monitor_value_from_edf(image, monitor_key):
     return monitor
 
 
-def _get_monitor_value(image, monitor_key):
+def get_monitor_value(image, monitor_key):
     """Return the monitor value from an image using an header key.
 
     :param fabio.fabioimage.FabioImage image: Image containing the header
@@ -873,7 +873,7 @@ class Average(object):
             corrected_image /= self._flat
         if self._monitor_key is not None:
             try:
-                monitor = _get_monitor_value(fabio_image, self._monitor_key)
+                monitor = get_monitor_value(fabio_image, self._monitor_key)
                 corrected_image /= monitor
             except MonitorNotFound as e:
                 logger.warning("Monitor not found in filename '%s', data skipped. Cause: %s", fabio_image.filename, str(e))

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -39,7 +39,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "06/07/2017"
+__date__ = "18/07/2017"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -1456,9 +1456,9 @@ class Geometry(object):
 
     def make_headers(self, type_="list"):
         """Create a configuration for the
-        
+
         :param type: can be "list" or "dict"
-        :return: the header with the proper format  
+        :return: the header with the proper format
         """
         res = None
         if type_ == "dict":

--- a/pyFAI/io.py
+++ b/pyFAI/io.py
@@ -45,7 +45,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/06/2017"
+__date__ = "18/07/2017"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -433,9 +433,9 @@ class DefaultAiWriter(Writer):
 
     def __init__(self, filename, engine=None):
         """Constructor of the historical writer of azimuthalIntegrator.
-        
+
         :param filename: name of the output file
-        :param ai: integrator, should provide make_headers method. 
+        :param ai: integrator, should provide make_headers method.
         """
         self._filename = filename
         self._engine = engine
@@ -486,7 +486,7 @@ class DefaultAiWriter(Writer):
                has_mask=None, has_dark=False, has_flat=False,
                polarization_factor=None, normalization_factor=None, metadata=None):
         """This method save the result of a 1D integration as ASCII file.
-        
+
         :param filename: the filename used to save the 1D integration
         :type filename: str
         :param dim1: the x coordinates of the integrated curve
@@ -533,7 +533,7 @@ class DefaultAiWriter(Writer):
                polarization_factor=None, normalization_factor=None,
                metadata=None):
         """This method save the result of a 2D integration.
-        
+
         :param filename: the filename used to save the 2D histogram
         :type filename: str
         :param dim1: the 1st coordinates of the histogram
@@ -555,8 +555,6 @@ class DefaultAiWriter(Writer):
         :param normalization_factor: the monitor value
         :type normalization_factor: float, None
         :param metadata: JSON serializable dictionary containing the metadata
-        
-        
         """
         if fabio is None:
             raise RuntimeError("FabIO module is needed to save EDF images")

--- a/pyFAI/io.py
+++ b/pyFAI/io.py
@@ -561,7 +561,9 @@ class DefaultAiWriter(Writer):
         dim1_unit = units.to_unit(dim1_unit)
 
         # Remove \n and \t)
-        header = OrderedDict((("Engine", " ".join(str(self._engine).split()))))
+        engine_info = " ".join(str(self._engine).split())
+        header = OrderedDict()
+        header["Engine"] = engine_info
 
         if "make_headers" in dir(self._engine):
             header.update(self._engine.make_headers("dict"))

--- a/pyFAI/test/test_all.py
+++ b/pyFAI/test/test_all.py
@@ -32,7 +32,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "09/03/2017"
+__date__ = "18/07/2017"
 
 import sys
 import unittest
@@ -80,6 +80,7 @@ from . import test_preproc
 from . import test_bayes
 from . import test_scripts
 from . import test_goniometer
+from . import test_integrate_app
 from ..opencl import test as test_opencl
 
 
@@ -97,6 +98,7 @@ def suite():
     testsuite.addTest(test_export.suite())
     testsuite.addTest(test_saxs.suite())
     testsuite.addTest(test_integrate.suite())
+    testsuite.addTest(test_integrate_app.suite())
     testsuite.addTest(test_bilinear.suite())
     testsuite.addTest(test_distortion.suite())
     testsuite.addTest(test_flat.suite())

--- a/pyFAI/test/test_integrate_app.py
+++ b/pyFAI/test/test_integrate_app.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+import json
+import os
+import fabio
+import contextlib
+import unittest
+import pyFAI.app.integrate
+from fabio.ext.cf_io import tempfile
+from .utilstest import UtilsTest
+import numpy
+
+
+class TestIntegrateApp(unittest.TestCase):
+
+    class Options(object):
+
+        def __init__(self):
+            self.version = None
+            self.verbose = False
+            self.output = None
+            self.format = None
+            self.slow = None
+            self.rapid = None
+            self.gui = False
+            self.json = ".azimint.json"
+            self.monitor_key = None
+
+    @contextlib.contextmanager
+    def jsontempfile(self, ponipath, nbpt_azim=1):
+        data = {}
+        data["poni"] = ponipath
+        data["wavelength"] = 1
+        data["nbpt_rad"] = 3
+        data["nbpt_azim"] = nbpt_azim
+        data["do_2D"] = nbpt_azim > 1
+        fd, path = tempfile.mkstemp(prefix="pyfai_", suffix=".json")
+        os.close(fd)
+        with open(path, 'w') as fp:
+            json.dump(data, fp)
+        yield path
+        os.remove(path)
+
+    @contextlib.contextmanager
+    def datatempfile(self, data, header):
+        fd, path = tempfile.mkstemp(prefix="pyfai_", suffix=".edf")
+        os.close(fd)
+        img = fabio.edfimage.edfimage(data, header)
+        img.save(path)
+        img = None
+        yield path
+        os.remove(path)
+
+    @contextlib.contextmanager
+    def resulttempfile(self):
+        fd, path = tempfile.mkstemp(prefix="pyfai_", suffix=".out")
+        os.close(fd)
+        os.remove(path)
+        yield path
+        os.remove(path)
+
+    def test_integrate_default_output_dat(self):
+        ponifile = UtilsTest.getimage("Pilatus1M.poni")
+        options = self.Options()
+        data = numpy.array([[0, 0], [0, 100], [0, 0]])
+        with self.datatempfile(data, {}) as datapath:
+            with self.jsontempfile(ponifile) as jsonpath:
+                options.json = jsonpath
+                pyFAI.app.integrate.integrate_shell(options, [datapath])
+                self.assertTrue(os.path.exists(datapath[:-4] + ".dat"))
+
+    def test_integrate_default_output_azim(self):
+        ponifile = UtilsTest.getimage("Pilatus1M.poni")
+        options = self.Options()
+        data = numpy.array([[0, 0], [0, 100], [0, 0]])
+        with self.datatempfile(data, {}) as datapath:
+            with self.jsontempfile(ponifile, nbpt_azim=2) as jsonpath:
+                options.json = jsonpath
+                pyFAI.app.integrate.integrate_shell(options, [datapath])
+                self.assertTrue(os.path.exists(datapath[:-4] + ".azim"))
+
+    def test_integrate_file_output_dat(self):
+        ponifile = UtilsTest.getimage("Pilatus1M.poni")
+        options = self.Options()
+        data = numpy.array([[0, 0], [0, 100], [0, 0]])
+        with self.datatempfile(data, {}) as datapath:
+            with self.jsontempfile(ponifile) as jsonpath:
+                options.json = jsonpath
+                with self.resulttempfile() as resultpath:
+                    options.output = resultpath
+                    pyFAI.app.integrate.integrate_shell(options, [datapath])
+                    self.assertTrue(os.path.exists(resultpath))
+
+    def test_integrate_no_monitor(self):
+        ponifile = UtilsTest.getimage("Pilatus1M.poni")
+        options = self.Options()
+        data = numpy.array([[0, 0], [0, 100], [0, 0]])
+        expected = numpy.array([[12.7, 0], [38.1, 0], [63.5, 267.6]])
+        with self.datatempfile(data, {}) as datapath:
+            with self.jsontempfile(ponifile) as jsonpath:
+                options.json = jsonpath
+                with self.resulttempfile() as resultpath:
+                    options.output = resultpath
+                    pyFAI.app.integrate.integrate_shell(options, [datapath])
+                    result = numpy.loadtxt(resultpath)
+                    numpy.testing.assert_almost_equal(result, expected, decimal=1)
+
+    def test_integrate_monitor(self):
+        ponifile = UtilsTest.getimage("Pilatus1M.poni")
+        options = self.Options()
+        options.monitor_key = "my_mon"
+        data = numpy.array([[0, 0], [0, 100], [0, 0]])
+        expected = numpy.array([[12.7, 0], [38.1, 0], [63.5, 535.1]])
+        with self.datatempfile(data, {"my_mon": "0.5"}) as datapath:
+            with self.jsontempfile(ponifile) as jsonpath:
+                options.json = jsonpath
+                with self.resulttempfile() as resultpath:
+                    options.output = resultpath
+                    pyFAI.app.integrate.integrate_shell(options, [datapath])
+                    result = numpy.loadtxt(resultpath)
+                    numpy.testing.assert_almost_equal(result, expected, decimal=1)
+
+    def test_integrate_counter_monitor(self):
+        ponifile = UtilsTest.getimage("Pilatus1M.poni")
+        options = self.Options()
+        options.monitor_key = "counter/my_mon"
+        data = numpy.array([[0, 0], [0, 100], [0, 0]])
+        expected = numpy.array([[12.7, 0], [38.1, 0], [63.5, 133.8]])
+        with self.datatempfile(data, {"counter_mne": "my_mon", "counter_pos": "2.0"}) as datapath:
+            with self.jsontempfile(ponifile) as jsonpath:
+                options.json = jsonpath
+                with self.resulttempfile() as resultpath:
+                    options.output = resultpath
+                    pyFAI.app.integrate.integrate_shell(options, [datapath])
+                    result = numpy.loadtxt(resultpath)
+                    numpy.testing.assert_almost_equal(result, expected, decimal=1)
+
+
+def suite():
+    testsuite = unittest.TestSuite()
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite.addTest(loader(TestIntegrateApp))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -85,7 +85,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "02/02/2017"
+__date__ = "18/07/2017"
 __status__ = "development"
 
 import threading
@@ -269,7 +269,7 @@ class Worker(object):
         self.ai.reset()
         self.warmup(sync)
 
-    def process(self, data, normalization_factor=1.0, writer=None):
+    def process(self, data, normalization_factor=1.0, writer=None, metadata=None):
         """
         Process a frame
         #TODO:
@@ -292,6 +292,9 @@ class Worker(object):
                  "correctSolidAngle": self.correct_solid_angle,
                  "safe": self.safe
                  }
+
+        if metadata is not None:
+            kwarg["metadata"] = metadata
 
         if monitor is not None:
             kwarg["normalization_factor"] = monitor


### PR DESCRIPTION
- It added tests for for pyFAI-integrate
    - Therefore there is fix here and there for python, and buggy code
- It uses the monitor to fix the normalization factor: `normalization_factor = monitor`. Maybe it is `1/monitor`? I do it fast
- The normalization was stored on the result
- You can use this kind of param `--monitor-name=counter/mon`
- I do not update the GUI. We can provide a text input. But i presume it will not be a nice solution.

Closes #446