### PR TITLE
Clean up debug code

### DIFF
--- a/pyFAI/gui/calibration/ExperimentTask.py
+++ b/pyFAI/gui/calibration/ExperimentTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "06/06/2017"
+__date__ = "24/08/2017"
 
 import os
 import fabio
@@ -165,14 +165,8 @@ class ExperimentTask(AbstractCalibrationTask):
         self.__dialogState = dialog.saveState()
         filename = dialog.selectedFiles()[0]
         try:
-            print("before opening image")
             with fabio.open(filename) as image:
-                print("image is loaded")
-
-                f = fabio.edfimage.EdfImage(data=numpy.random.random((10, 10)), header={})
-                f.filename = "/tmp/toto.edf"
-                yield f
-                # yield image
+                yield image
         except Exception as e:
             _logger.error(e.args[0])
             _logger.debug("Backtrace", exc_info=True)
@@ -202,9 +196,7 @@ class ExperimentTask(AbstractCalibrationTask):
     def loadImage(self):
         with self.getImageFromDialog("Load calibration image") as image:
             if image is not None:
-                print("in loadImage")
                 settings = self.model().experimentSettingsModel()
-                print(settings)
                 settings.imageFile().setValue(str(image.filename))
                 settings.image().setValue(image.data.copy())
 


### PR DESCRIPTION
This code was introduced while we was doing the release, to debug an issue on Windows. Unfortunately it was merged. See https://github.com/silx-kit/pyFAI/commit/c15cdf6680a55e0d8d4c300cc3e72cf48dad1b0e

It avoid to load any image from the GUI and replace the result by a random array of 10x10 pixels.

