### PR TITLE
Provide the rotation matrix as example in geometry

### DIFF
--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -1784,7 +1784,7 @@ class Geometry(object):
         axis3 (==axis0) is along the beam
         see:
         http://pyfai.readthedocs.io/en/latest/geometry.html#detector-position
-        or ../doc/source/img/PONI.pdf
+        or ../doc/source/img/PONI.png
 
         :param param: list of geometry parameters, defaults to self.param
                       uses elements [3],[4],[5]
@@ -1807,17 +1807,6 @@ class Geometry(object):
                                         cosRot1 * cosRot3 + sinRot1 * sinRot2 * sinRot3,
                                         cosRot3 * sinRot1 - cosRot1 * sinRot2 * sinRot3],
                                        [sinRot2, -cosRot2 * sinRot1, +cosRot1 * cosRot2]])
-#
-#         rot1 = [[ cosRot1, 0.0, -sinRot1 ],
-#                 [     0.0, 1.0, 0.0 ],
-#                 [ sinRot1, 0.0, cosRot1 ]]  # Rotation about axis 1
-#         rot2 = [[ cosRot2, sinRot2, 0.0 ],
-#                 [-sinRot2, cosRot2, 0.0 ],
-#                 [     0.0, 0.0, 1.0 ]]  # Rotation about axis 2
-#         rot3 = [[ 1.0, 0.0, 0.0 ],
-#                 [ 0.0, cosRot3, -sinRot3 ],
-#                 [ 0.0, sinRot3, cosRot3 ] ]  # Rotation about axis 0 (3 via a mod 3?)
-#          = numpy.dot(numpy.dot(rot3, rot2), rot1)  # 3x3 matrix
         return rotation_matrix
 
 # ############################################

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -525,21 +525,21 @@ class Geometry(object):
                                      pos1=p1, pos2=p2, pos3=p3)
             tmp.shape = d1.shape
         else:
-            cosRot1 = cos(self._rot1)
-            cosRot2 = cos(self._rot2)
-            cosRot3 = cos(self._rot3)
-            sinRot1 = sin(self._rot1)
-            sinRot2 = sin(self._rot2)
-            sinRot3 = sin(self._rot3)
+            cos_rot1 = cos(self._rot1)
+            cos_rot2 = cos(self._rot2)
+            cos_rot3 = cos(self._rot3)
+            sin_rot1 = sin(self._rot1)
+            sin_rot2 = sin(self._rot2)
+            sin_rot3 = sin(self._rot3)
             L = self._dist
             if p3 is not None:
                 L = L + p3
-            num = p1 * cosRot2 * cosRot3 \
-                + p2 * (cosRot3 * sinRot1 * sinRot2 - cosRot1 * sinRot3) \
-                - L * (cosRot1 * cosRot3 * sinRot2 + sinRot1 * sinRot3)
-            den = p1 * cosRot2 * sinRot3 \
-                - L * (-(cosRot3 * sinRot1) + cosRot1 * sinRot2 * sinRot3) \
-                + p2 * (cosRot1 * cosRot3 + sinRot1 * sinRot2 * sinRot3)
+            num = p1 * cos_rot2 * cos_rot3 \
+                + p2 * (cos_rot3 * sin_rot1 * sin_rot2 - cos_rot1 * sin_rot3) \
+                - L * (cos_rot1 * cos_rot3 * sin_rot2 + sin_rot1 * sin_rot3)
+            den = p1 * cos_rot2 * sin_rot3 \
+                - L * (-(cos_rot3 * sin_rot1) + cos_rot1 * sin_rot2 * sin_rot3) \
+                + p2 * (cos_rot1 * cos_rot3 + sin_rot1 * sin_rot2 * sin_rot3)
             tmp = numpy.arctan2(num, den)
         return tmp
 
@@ -1794,19 +1794,19 @@ class Geometry(object):
         """
         if param is None:
             param = self.param
-        cosRot1 = cos(param[3])
-        cosRot2 = cos(param[4])
-        cosRot3 = cos(param[5])
-        sinRot1 = sin(param[3])
-        sinRot2 = sin(param[4])
-        sinRot3 = sin(param[5])
-        rotation_matrix = numpy.array([[cosRot2 * cosRot3,
-                                        cosRot3 * sinRot1 * sinRot2 - cosRot1 * sinRot3,
-                                        - (cosRot1 * cosRot3 * sinRot2 + sinRot1 * sinRot3)],
-                                       [cosRot2 * sinRot3,
-                                        cosRot1 * cosRot3 + sinRot1 * sinRot2 * sinRot3,
-                                        cosRot3 * sinRot1 - cosRot1 * sinRot2 * sinRot3],
-                                       [sinRot2, -cosRot2 * sinRot1, +cosRot1 * cosRot2]])
+        cos_rot1 = cos(param[3])
+        cos_rot2 = cos(param[4])
+        cos_rot3 = cos(param[5])
+        sin_rot1 = sin(param[3])
+        sin_rot2 = sin(param[4])
+        sin_rot3 = sin(param[5])
+        rotation_matrix = numpy.array([[cos_rot2 * cos_rot3,
+                                        cos_rot3 * sin_rot1 * sin_rot2 - cos_rot1 * sin_rot3,
+                                        - (cos_rot1 * cos_rot3 * sin_rot2 + sin_rot1 * sin_rot3)],
+                                       [cos_rot2 * sin_rot3,
+                                        cos_rot1 * cos_rot3 + sin_rot1 * sin_rot2 * sin_rot3,
+                                        cos_rot3 * sin_rot1 - cos_rot1 * sin_rot2 * sin_rot3],
+                                       [sin_rot2, -cos_rot2 * sin_rot1, +cos_rot1 * cos_rot2]])
         return rotation_matrix
 
 # ############################################

--- a/pyFAI/test/test_bug_regression.py
+++ b/pyFAI/test/test_bug_regression.py
@@ -39,7 +39,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "25/08/2017"
+__date__ = "31/08/2017"
 
 import sys
 import os
@@ -131,14 +131,16 @@ class TestBug211(unittest.TestCase):
             logger.error("Error with executable: %s, not found. Skipping test", self.exe)
             return
 
-        p = subprocess.Popen([sys.executable, self.exe, "--quiet", "-q", "0.2-0.8", "-o", self.outfile] + self.image_files,
-                            shell=False, env=self.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        command_line = [sys.executable, self.exe, "--quiet", "-q", "0.2-0.8", "-o", self.outfile] + self.image_files
+
+        p = subprocess.Popen(command_line,
+                             shell=False, env=self.env,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         rc = p.wait()
         if rc:
             logger.info(p.stdout.read())
             logger.error(p.stderr.read())
-            l = [sys.executable, self.exe, "--quiet", "-q", "0.2-0.8", "-o", self.outfile] + self.image_files
-            logger.error(os.linesep + (" ".join(l)))
+            logger.error(os.linesep + (" ".join(command_line)))
             env = "Environment:"
             for k, v in self.env.items():
                 env += "%s    %s: %s" % (os.linesep, k, v)

--- a/pyFAI/test/test_geometry.py
+++ b/pyFAI/test/test_geometry.py
@@ -36,7 +36,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "25/08/2017"
+__date__ = "31/08/2017"
 
 
 import unittest
@@ -332,7 +332,8 @@ class ParamTestGeometry(ParameterisedTestCase):
                  ("tth", ("cos", "tan")),
                  ("tth", ("tan", "cython")),
                  ("qFunction", ("numpy", "cython")),
-                 ("rFunction", ("numpy", "cython"))]
+                 ("rFunction", ("numpy", "cython")),
+                 ("chi", ("numpy", "cython"))]
     pixels = {"detector": "Pilatus100k",
               "wavelength": 1e-10}
     geometries = [{'dist': 1, 'rot1': 0, 'rot2': 0, 'rot3': 0},


### PR DESCRIPTION
This provides a way to retrieve the rotation matrix from a geometry at the python level.

@jonwright could you review the patch ?