### PR TITLE
Fix documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -152,7 +152,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/source/man/MX-calibrate.rst
+++ b/doc/source/man/MX-calibrate.rst
@@ -105,10 +105,3 @@ This tool has been developed for ESRF MX-beamlines where an acceptable
 calibration is usually present is the header of the image. PyFAI reads it and
 does a "recalib" on each of them before exporting a linear regression of all
 parameters versus this distance.
-
-Example:
---------
-
-
-.. command-output:: MX-calibrate --help
-    :nostderr:

--- a/doc/source/man/check_calib.rst
+++ b/doc/source/man/check_calib.rst
@@ -7,7 +7,5 @@ Purpose
 Check_calib is a deprecated tool aiming at validating both the geometric
 calibration and everything else like flat-field correction, distortion
 correction, at a sub-pixel level. Please use the `validate`, `validate2` and
-`chiplot` commands in pyFAI-calib, during the refinement process to obtain the same output with more options.
-
-.. command-output:: check_calib --help
-    :nostderr:
+`chiplot` commands in pyFAI-calib, during the refinement process to obtain the
+same output with more options.

--- a/doc/source/man/detector2nexus.rst
+++ b/doc/source/man/detector2nexus.rst
@@ -31,8 +31,8 @@ Options:
                         pyFAI.detectors
   -s SPLINEFILE, --splinefile SPLINEFILE
                         Geometric distortion file from FIT2D
-  -dx DX, --x-corr DX   Geometric correction for pilatus
-  -dy DY, --y-corr DY   Geometric correction for pilatus
+  --dx DX, --x-corr DX   Geometric correction for pilatus
+  --dy DY, --y-corr DY   Geometric correction for pilatus
   -p PIXEL, --pixel PIXEL
                         pixel size (comma separated): x,y
   -S SHAPE, --shape SHAPE

--- a/doc/source/man/detector2nexus.rst
+++ b/doc/source/man/detector2nexus.rst
@@ -40,6 +40,3 @@ Options:
   -d DARK, --dark DARK  Dark noise to be subtracted
   -f FLAT, --flat FLAT  Flat field correction
   -v, --verbose         switch to verbose/debug mode
-
-.. command-output:: detector2nexus --help
-    :nostderr:

--- a/doc/source/man/diff_map.rst
+++ b/doc/source/man/diff_map.rst
@@ -55,14 +55,15 @@ Usage:
 diff_map [options] imagefiles*
 
 positional arguments:
-  FILE                  List of files to integrate
+  FILE                  List of files to integrate. Mandatory without GUI
 
 optional arguments:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
   -o FILE, --output FILE
-                        HDF5 File where processed map will be saved
-  -v, --verbose         switch to verbose/debug mode, defaut: quiet
+                        HDF5 File where processed map will be saved. Mandatory
+                        without GUI
+  -v, --verbose         switch to verbose/debug mode, default: quiet
   -P FILE, --prefix FILE
                         Prefix or common base for all files
   -e EXTENSION, --extension EXTENSION
@@ -72,10 +73,12 @@ optional arguments:
   -r SLOW, --slow SLOW  number of points for slow motion. Mandatory without
                         GUI
   -c NPT_RAD, --npt NPT_RAD
-                        number of points in diffraction powder pattern,
+                        number of points in diffraction powder pattern.
                         Mandatory without GUI
-  -d FILE, --dark FILE  list of dark images to average and subtract
-  -f FILE, --flat FILE  list of flat images to average and divide
+  -d FILE, --dark FILE  list of dark images to average and subtract (comma
+                        separated list)
+  -f FILE, --flat FILE  list of flat images to average and divide (comma
+                        separated list)
   -m FILE, --mask FILE  file containing the mask, no mask by default
   -p FILE, --poni FILE  file containing the diffraction parameter (poni-file),
                         Mandatory without GUI

--- a/doc/source/man/diff_map.rst
+++ b/doc/source/man/diff_map.rst
@@ -95,7 +95,3 @@ Bugs:
 #. There is a known bug on Debian7 where importing a large
    number of file can take much longer than the integration itself: consider
    passing files in the command line
-
-
-.. command-output:: diff_map --help
-    :nostderr:

--- a/doc/source/man/diff_tomo.rst
+++ b/doc/source/man/diff_tomo.rst
@@ -56,7 +56,3 @@ Options:
 
 
 Most of those options are mandatory to define the structure of the dataset.
-
-
-.. command-output:: diff_tomo --help
-    :nostderr:

--- a/doc/source/man/pyFAI-average.rst
+++ b/doc/source/man/pyFAI-average.rst
@@ -26,8 +26,10 @@ optional arguments:
   -o OUTPUT, --output OUTPUT
                         Output/ destination of average image
   -m METHOD, --method METHOD
-                        Method used for averaging, can be 'mean'(default) or
-                        'min', 'max', 'median', 'sum', 'quantiles'
+                        Method used for averaging, can be 'mean' (default) or
+                        'min', 'max', 'median', 'sum', 'quantiles' , 'cutoff',
+                        'std'. Multiple filters can be defined with ','
+                        separator.
   -c CUTOFF, --cutoff CUTOFF
                         Take the mean of the average +/- cutoff * std_dev.
   -F FORMAT, --format FORMAT
@@ -37,3 +39,16 @@ optional arguments:
   -v, --verbose         switch to verbose/debug mode
   -q QUANTILES, --quantiles QUANTILES
                         average out between two quantiles -q 0.20-0.90
+  --monitor-name MONITOR_KEY
+                        Name of the monitor in the header of each input files.
+                        If defined the contribution of each input file is
+                        divided by the monitor. If the header does not contain
+                        or contains a wrong value, the contribution of the
+                        input file is ignored. On EDF files, values from
+                        'counter_pos' can accessed by using the expected
+                        mnemonic. For example 'counter/bmon'.
+  --quiet               Only error messages are printed out
+
+It can also be used to merge many images from the same sample when using a
+small beam and reduce the spotty-ness of Debye-Sherrer rings. In this case the
+"max-filter" is usually recommended.

--- a/doc/source/man/pyFAI-average.rst
+++ b/doc/source/man/pyFAI-average.rst
@@ -37,8 +37,3 @@ optional arguments:
   -v, --verbose         switch to verbose/debug mode
   -q QUANTILES, --quantiles QUANTILES
                         average out between two quantiles -q 0.20-0.90
-
-
-.. command-output:: pyFAI-average --help
-    :nostderr:
-

--- a/doc/source/man/pyFAI-calib.rst
+++ b/doc/source/man/pyFAI-calib.rst
@@ -10,7 +10,7 @@ You will need to provide a calibrant or a "d-spacing" file containing the spacin
 Angstrom (in decreasing order).
 
 If you are using a standard calibrant, look at
-https://github.com/kif/pyFAI/tree/master/calibration
+https://github.com/silx-kit/pyFAI/tree/master/calibration
 or search in the American Mineralogist database:
 [AMD]_ or in the [COD]_.
 The --calibrant option is mandatory !

--- a/doc/source/man/pyFAI-calib.rst
+++ b/doc/source/man/pyFAI-calib.rst
@@ -149,10 +149,6 @@ entry (time-stamps will help you).
 Example of usage:
 -----------------
 
-
-.. command-output:: pyFAI-calib --help
-    :nostderr:
-
 Pilatus 1M image of Silver Behenate taken at ESRF-BM26:
 .......................................................
 

--- a/doc/source/man/pyFAI-calib.rst
+++ b/doc/source/man/pyFAI-calib.rst
@@ -136,7 +136,6 @@ Options:
   -p PIXEL, --pixel PIXEL
                         size of the pixel in micron
 
-
 Tips & Tricks
 -------------
 

--- a/doc/source/man/pyFAI-drawmask.rst
+++ b/doc/source/man/pyFAI-drawmask.rst
@@ -27,7 +27,9 @@ Usage: pyFAI-drawmask [options] file1.edf file2.edf ...
 Options:
 --------
 
-  --version   show program's version number and exit
-  -h, --help  show help message and exit
+  -h, --help     show this help message and exit
+  -v, --version  show program's version number and exit
 
-Optionally the script will print the number of pixel masked and the intensity masked (as well on other files provided in input)
+The mask image is saved into file1-masked.edf. Optionally the script will
+print the number of pixel masked and the intensity masked (as well on other
+files provided in input)

--- a/doc/source/man/pyFAI-drawmask.rst
+++ b/doc/source/man/pyFAI-drawmask.rst
@@ -31,6 +31,3 @@ Options:
   -h, --help  show help message and exit
 
 Optionally the script will print the number of pixel masked and the intensity masked (as well on other files provided in input)
-
-.. command-output:: pyFAI-drawmask --help
-    :nostderr:

--- a/doc/source/man/pyFAI-integrate.rst
+++ b/doc/source/man/pyFAI-integrate.rst
@@ -36,10 +36,3 @@ the LImA plugin of pyFAI.
 
 Nota: there is bug in debian6 making the GUI crash (to be fixed inside pyqt)
 http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=697348
-
-Example:
---------
-
-
-.. command-output:: pyFAI-integrate --help
-    :nostderr:

--- a/doc/source/man/pyFAI-integrate.rst
+++ b/doc/source/man/pyFAI-integrate.rst
@@ -21,11 +21,31 @@ pyFAI-integrate [options] file1.edf file2.edf ...
 Options:
 --------
 
-  --version             show program's version number and exit
-  -h, --help            show help message and exit
+  -h, --help            show this help message and exit
+  -V, --version         show program's version number and exit
   -v, --verbose         switch to verbose/debug mode
-  -o OUTPUT, --output=OUTPUT
+  -o OUTPUT, --output OUTPUT
                         Directory or file where to store the output data
+  -f FORMAT, --format FORMAT
+                        output data format (can be HDF5)
+  -s SLOW, --slow-motor SLOW
+                        Dimension of the scan on the slow direction (makes
+                        sense only with HDF5)
+  -r RAPID, --fast-motor RAPID
+                        Dimension of the scan on the fast direction (makes
+                        sense only with HDF5)
+  --no-gui              Process the dataset without showing the user
+                        interface.
+  -j JSON, --json JSON  Configuration file containing the processing to be
+                        done
+  --monitor-name MONITOR_KEY
+                        Name of the monitor in the header of each input files.
+                        If defined the contribution of each input file is
+                        divided by the monitor. If the header does not contain
+                        or contains a wrong value, the contribution of the
+                        input file is ignored. On EDF files, values from
+                        'counter_pos' can accessed by using the expected
+                        mnemonic. For example 'counter/bmon'.
 
 Tips & Tricks:
 --------------

--- a/doc/source/man/pyFAI-recalib.rst
+++ b/doc/source/man/pyFAI-recalib.rst
@@ -1,7 +1,5 @@
 Calibration tool: pyFAI-recalib
 ===============================
 
-pyFAI-recalib is now obsolete. All feature provided by it are now available as part of pyFAI-calib.
-
-.. command-output:: pyFAI-recalib --help
-    :nostderr:
+pyFAI-recalib is now obsolete. All feature provided by it are now available as
+part of pyFAI-calib.

--- a/doc/source/man/pyFAI-saxs.rst
+++ b/doc/source/man/pyFAI-saxs.rst
@@ -42,11 +42,3 @@ Options:
                         2th_deg, 2th_rad or r_mm
   --ext EXT             extension of the regrouped filename (.dat)
   --method METHOD       Integration method
-
-
-Example:
---------
-
-
-.. command-output:: pyFAI-saxs --help
-    :nostderr:

--- a/doc/source/man/pyFAI-waxs.rst
+++ b/doc/source/man/pyFAI-waxs.rst
@@ -49,10 +49,3 @@ Options:
 
 pyFAI-waxs is the script of pyFAI that allows data reduction (azimuthal integration) for Wide Angle Scattering
 to produce X-Ray Powder Diffraction Pattern with output axis in 2-theta space.
-
-Example:
---------
-
-
-.. command-output:: pyFAI-waxs --help
-    :nostderr:

--- a/doc/source/man/pyFAI-waxs.rst
+++ b/doc/source/man/pyFAI-waxs.rst
@@ -42,10 +42,12 @@ Options:
   --ext EXT             extension of the regrouped filename (.xy)
   --method METHOD       Integration method
   --multi               Average out all frame in a file before integrating
+                        extracting variance, otherwise treat every single
+                        frame
   --average AVERAGE     Method for averaging out: can be 'mean' (default),
                         'min', 'max' or 'median
   --do-2D               Perform 2D integration in addition to 1D
 
-
-pyFAI-waxs is the script of pyFAI that allows data reduction (azimuthal integration) for Wide Angle Scattering
-to produce X-Ray Powder Diffraction Pattern with output axis in 2-theta space.
+pyFAI-waxs is the script of pyFAI that allows data reduction (azimuthal
+integration) for Wide Angle Scattering to produce X-Ray Powder Diffraction
+Pattern with output axis in 2-theta space.

--- a/doc/source/operations/windows.rst
+++ b/doc/source/operations/windows.rst
@@ -169,7 +169,7 @@ Install pyFAI from sources
 --------------------------
 
 The sources of pyFAI are available at https://github.com/silx-kit/pyFAI/releases
-the development is performed on https://github.com/kif/pyFAI
+the development is performed on https://github.com/silx-kit/pyFAI
 
 In addition to the Python interpreter, you will need *the* C compiler compatible
 with your Python interpreter, for example you can find the one for Python2.7 at:

--- a/doc/source/project.rst
+++ b/doc/source/project.rst
@@ -240,7 +240,7 @@ The builds cannot yet be retrieved with Travis-CI, but manylinux-wheels are on t
 AppVeyor
 ........
 
-`AppVeyor provides continuous integration on Windows <https://ci.appveyor.com/project/kif/pyFAI>`_, 64 bits computer with Python 2.7 and 3.4.
+`AppVeyor provides continuous integration on Windows <https://ci.appveyor.com/project/ESRF/pyfai>`_, 64 bits computer with Python 2.7 and 3.4.
 Successful builds provide installers for pyFAI as *wheels* and *msi*, they are anonymously available as *artifacts*.
 Due to the limitation of AppVeyor's build system, those installers have openMP disabled.
 

--- a/doc/source/usage/tutorial/Geometry/geometry.rst
+++ b/doc/source/usage/tutorial/Geometry/geometry.rst
@@ -500,6 +500,7 @@ following figure:
    :alt: test
 
    PONI figure
+
 It may appear strange to have (x\_1, x\_2, x\_3) indirect indirect but
 this has been made in such a way chi, the azimuthal angle, is 0 along
 x\_2 and 90\_deg along x\_1 (and not vice-versa).

--- a/doc/source/usage/tutorial/Goniometer/index.rst
+++ b/doc/source/usage/tutorial/Goniometer/index.rst
@@ -3,7 +3,7 @@
 :Keywords: Tutorials
 :Target: Advanced users tutorials using jupyter notebooks for Goniometer
 
-.. _tutorials:
+.. _goniometer_tutorials:
 
 Goniometer and translation table calibration
 ============================================

--- a/doc/source/usage/tutorial/Introduction/introduction.ipynb
+++ b/doc/source/usage/tutorial/Introduction/introduction.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "## Introduction to diffraction image analysis using the notebook\n",
     "\n",
-    "All the tutorials in pyFAI are based on the notebook and if you wish to practice the exercises, you can download the notebook files (.ipynb) from [Github](https://github.com/kif/pyFAI/tree/master/doc/source/usage/tutorial)\n",
+    "All the tutorials in pyFAI are based on the notebook and if you wish to practice the exercises, you can download the notebook files (.ipynb) from [Github](https://github.com/silx-kit/pyFAI/tree/master/doc/source/usage/tutorial)\n",
     "\n",
     "### Load and display diffraction images\n",
     "\n",

--- a/doc/source/usage/tutorial/Introduction/introduction.rst
+++ b/doc/source/usage/tutorial/Introduction/introduction.rst
@@ -78,7 +78,7 @@ Introduction to diffraction image analysis using the notebook
 All the tutorials in pyFAI are based on the notebook and if you wish to
 practice the exercises, you can download the notebook files (.ipynb)
 from
-`Github <https://github.com/kif/pyFAI/tree/master/doc/source/usage/tutorial>`__
+`Github <https://github.com/silx-kit/pyFAI/tree/master/doc/source/usage/tutorial>`__
 
 Load and display diffraction images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/usage/tutorial/MakeCalibrant/make_calibrant.ipynb
+++ b/doc/source/usage/tutorial/MakeCalibrant/make_calibrant.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In this tutorial we will see how to generate a file describing a *reference material* used as calibrant to refine the geometry  of the experimental setup, especially the position of the detector.\n",
     "\n",
-    "In pyFAI, calibrant are defined in a bunch of files available from [github](https://github.com/kif/pyFAI/tree/master/calibration). Those files are automatically installed with pyFAI and readily available from the programming interface, as described in the **Calibrant** tutorial.\n",
+    "In pyFAI, calibrant are defined in a bunch of files available from [github](https://github.com/silx-kit/pyFAI/tree/master/calibration). Those files are automatically installed with pyFAI and readily available from the programming interface, as described in the **Calibrant** tutorial.\n",
     "\n",
     "This tutorials focuses on the content of the file and how to generate other calibrant files and how to exended existing ones.\n",
     "\n",

--- a/doc/source/usage/tutorial/MakeCalibrant/make_calibrant.rst
+++ b/doc/source/usage/tutorial/MakeCalibrant/make_calibrant.rst
@@ -7,7 +7,7 @@ In this tutorial we will see how to generate a file describing a
 experimental setup, especially the position of the detector.
 
 In pyFAI, calibrant are defined in a bunch of files available from
-`github <https://github.com/kif/pyFAI/tree/master/calibration>`__. Those
+`github <https://github.com/silx-kit/pyFAI/tree/master/calibration>`__. Those
 files are automatically installed with pyFAI and readily available from
 the programming interface, as described in the **Calibrant** tutorial.
 

--- a/pyFAI/app/calib2.py
+++ b/pyFAI/app/calib2.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 #    Project: Azimuthal integration
-#             https://github.com/kif/pyFAI
+#             https://github.com/silx-kit/pyFAI
 #
 #    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
 #
@@ -34,7 +34,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "19/07/2017"
+__date__ = "08/09/2017"
 __status__ = "production"
 
 import logging

--- a/pyFAI/app/detector2nexus.py
+++ b/pyFAI/app/detector2nexus.py
@@ -35,9 +35,10 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "19/07/2017"
+__date__ = "08/09/2017"
 __status__ = "development"
 
+import sys
 import logging
 import numpy
 import fabio
@@ -80,9 +81,9 @@ def main():
     parser.add_argument("-s", "--splinefile", dest="splinefile", type=str,
                         default=None,
                         help="Geometric distortion file from FIT2D")
-    parser.add_argument("-dx", "--x-corr", dest="dx", type=str, default=None,
+    parser.add_argument("--dx", "--x-corr", dest="dx", type=str, default=None,
                         help="Geometric correction for pilatus")
-    parser.add_argument("-dy", "--y-corr", dest="dy", type=str, default=None,
+    parser.add_argument("--dy", "--y-corr", dest="dy", type=str, default=None,
                         help="Geometric correction for pilatus")
     parser.add_argument("-p", "--pixel", dest="pixel", type=str, default=None,
                         help="pixel size (comma separated): x,y")
@@ -94,10 +95,16 @@ def main():
                         help="Flat field correction")
     parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False,
                         help="switch to verbose/debug mode")
-#     parser.add_argument("args", metavar='FILE', type=str, nargs='+',
-#                         help="Files to be processed")
+    # parser.add_argument("args", metavar='FILE', type=str, nargs='+',
+    #                     help="Files to be processed")
 
-    options = parser.parse_args()
+    argv = sys.argv
+    # hidden backward compatibility for -dx and -dy
+    # A short option only expect a single char
+    argv = ["-" + a if a.startswith("-dx") else a for a in argv]
+    argv = ["-" + a if a.startswith("-dy") else a for a in argv]
+    print(argv)
+    options = parser.parse_args(args=argv[1:])
 
     if options.verbose:
         logger.setLevel(logging.DEBUG)

--- a/pyFAI/app/drawmask.py
+++ b/pyFAI/app/drawmask.py
@@ -38,7 +38,7 @@ __authors__ = ["Jerome Kieffer", "Valentin Valls"]
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "31/08/2017"
+__date__ = "08/09/2017"
 __satus__ = "Production"
 import os
 import numpy
@@ -47,6 +47,9 @@ logging.basicConfig(level=logging.INFO)
 logging.captureWarnings(True)
 import fabio
 
+_logger = logging.getLogger("drawmask")
+
+BACKEND = None
 try:
     import silx
     if silx.version_info < (0, 2):
@@ -55,14 +58,27 @@ try:
     from silx.gui import qt
     BACKEND = "SILX"
 except ImportError:
+    _logger.error("Error while importing silx", exc_info=True)
+
+if BACKEND is None:
     try:
         import PyMca.MaskImageWidget as PyMcaMaskImageWidget
+        from pyFAI.gui import qt
+        BACKEND = "PYMCA"
     except ImportError:
+        _logger.error("Error while importing PyMca", exc_info=True)
+
+if BACKEND is None:
+    try:
         import PyMca5.PyMca.MaskImageWidget as PyMcaMaskImageWidget
-    from pyFAI.gui import qt
+        from pyFAI.gui import qt
+        BACKEND = "PYMCA"
+    except ImportError:
+        _logger.error("Error while importing PyMca", exc_info=True)
     BACKEND = "PYMCA"
-except:
-    BACKEND = None
+
+if BACKEND is None:
+    raise Exception("No supported backend found")
 
 import pyFAI.utils
 
@@ -70,8 +86,6 @@ try:
     from argparse import ArgumentParser
 except ImportError:
     from pyFAI.third_party.argparse import ArgumentParser
-
-_logger = logging.getLogger("drawmask")
 
 
 class AbstractMaskImageWidget(qt.QMainWindow):

--- a/pyFAI/directories.py
+++ b/pyFAI/directories.py
@@ -38,7 +38,7 @@ This file is very short and simple in such a way to be mangled by installers
 It is used by pyFAI.utils._get_data_path
 
 See bug #144 for discussion about implementation
-https://github.com/kif/pyFAI/issues/144
+https://github.com/silx-kit/pyFAI/issues/144
 """
 
 __author__ = "Jerome Kieffer"

--- a/pyFAI/ext/_distortion.pyx
+++ b/pyFAI/ext/_distortion.pyx
@@ -28,7 +28,7 @@
 
 __author__ = "Jerome Kieffer"
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "08/09/2017"
 __copyright__ = "2011-2016, ESRF"
 __contact__ = "jerome.kieffer@esrf.fr"
 
@@ -36,7 +36,7 @@ import cython
 cimport numpy
 import numpy
 from cython cimport view, floating
-from cython.parallel import prange#, threadlocal
+from cython.parallel import prange
 from cpython.ref cimport PyObject, Py_XDECREF
 from libc.string cimport memset, memcpy
 from libc.math cimport floor, ceil, fabs, copysign
@@ -49,15 +49,13 @@ import time
 logger = logging.getLogger(__name__)
 from ..detectors import detector_factory
 from ..utils import expand2d
-from ..decorators import timeit
 try:
     from ..third_party import six
 except ImportError:
     import six
 import fabio
 
-#include "sparse_common.pxi"
-from sparse_utils cimport ArrayBuilder, lut_point 
+from sparse_utils cimport ArrayBuilder, lut_point
 from sparse_utils import ArrayBuilder, dtype_lut
 # cdef struct lut_point:
 #     int idx
@@ -120,7 +118,7 @@ cdef inline void integrate(float[:, ::1] box, float start, float stop, float slo
     cdef:
         int i, h = 0
         float P, dP, segment_area, abs_area, dA
-        #, sign
+        # , sign
     if start < stop:  # positive contribution
         P = ceil(start)
         dP = P - start
@@ -407,9 +405,9 @@ def calc_LUT(float[:, :, :, ::1] pos not None, shape, bin_size, max_pixel_size,
     outMax[:, :] = 0
     buffer = numpy.empty((delta0, delta1), dtype=numpy.float32)
     buffer_nbytes = buffer.nbytes
-    if (size == 0): # fix 271
-        raise RuntimeError("The look-up table has dimension 0 which is a non-sense."
-                           + "Did you mask out all pixel or is your image out of the geometry range ?")
+    if (size == 0):  # fix 271
+        raise RuntimeError("The look-up table has dimension 0 which is a non-sense." +
+                           " Did you mask out all pixel or is your image out of the geometry range?")
     lut = view.array(shape=(shape0, shape1, size), itemsize=sizeof(lut_point), format="if")
     lut_total_size = shape0 * shape1 * size * sizeof(lut_point)
     memset(&lut[0, 0, 0], 0, lut_total_size)
@@ -421,7 +419,7 @@ def calc_LUT(float[:, :, :, ::1] pos not None, shape, bin_size, max_pixel_size,
             for j in range(shape1):
                 if do_mask and mask[i, j]:
                     continue
-                #reset buffer
+                # reset buffer
                 buffer[:, :] = 0.0
 
                 A0 = pos[i, j, 0, 0]
@@ -795,14 +793,14 @@ def calc_openmp(float[:, :, :, ::1] pos not None,
                         continue
 
                     bin_number = ml * shape_out1 + nl
-#                     with gil: #Use the gil to perform an atomic operation
+                    # with gil: #Use the gil to perform an atomic operation
                     counter += 1
                     pixel_count[bin_number] += 1
                     if counter >= large_size:
                         with gil:
                             raise RuntimeError("Provided temporary space for storage is not enough. " +
-                                               "Please increase bins_per_pixel=%s. "%bins_per_pixel +
-                                               "The suggested value is %i or greater."%ceil(1.1*bins_per_pixel*size_in/idx))
+                                               "Please increase bins_per_pixel=%s. " % bins_per_pixel +
+                                               "The suggested value is %i or greater." % ceil(1.1 * bins_per_pixel * size_in / idx))
                     idx_pixel[counter] += idx
                     idx_bin[counter] += bin_number
                     large_data[counter] += value
@@ -1289,10 +1287,10 @@ class Distortion(object):
 
     def demo_ArrayBuilder(self, int n=10):
         "this just ensures the shared C-library works"
-        cdef: 
+        cdef:
             ArrayBuilder ab
             int i
-         
+
         ab = ArrayBuilder(n)
         for i in range(n):
             ab._append(i, i, 1.0)

--- a/pyFAI/ext/_distortion.pyx
+++ b/pyFAI/ext/_distortion.pyx
@@ -1339,7 +1339,6 @@ class Distortion(object):
                 lout[i] += lin[idx] * coef
         return out[:img_shape[0], :img_shape[1]]
 
-    @timeit
     def uncorrect(self, image):
         """
         Take an image which has been corrected and transform it into it's raw (with loss of information)

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -39,7 +39,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "31/08/2017"
+__date__ = "08/09/2017"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -1750,9 +1750,9 @@ class Geometry(object):
 
     def rotation_matrix(self, param=None):
         """Compute and return the detector tilts as a single rotation matrix
-        
-        Corresponds to rotations about axes 1 then 2 then 3(=> 0 later on)
-         For those using spd (PB = Peter Boesecke), tilts relate to
+
+        Corresponds to rotations about axes 1 then 2 then 3 (=> 0 later on)
+        For those using spd (PB = Peter Boesecke), tilts relate to
         this system (JK = Jerome Kieffer) as follows:
         JK1 = PB2 (Y)
         JK2 = PB1 (X)
@@ -1769,8 +1769,8 @@ class Geometry(object):
 
         :param param: list of geometry parameters, defaults to self.param
                       uses elements [3],[4],[5]
-        :type: list of floats
-        :return rotation matrix
+        :type param: list of float
+        :return: rotation matrix
         :rtype: 3x3 float array
         """
         if param is None:

--- a/pyFAI/opencl/azim_hist.py
+++ b/pyFAI/opencl/azim_hist.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 #    Project: Azimuthal integration
-#             https://github.com/kif/pyFAI
+#             https://github.com/silx-kit/pyFAI
 #
 #    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
 #

--- a/pyFAI/opencl/ocl_fullSplit_CSR.pyx
+++ b/pyFAI/opencl/ocl_fullSplit_CSR.pyx
@@ -375,7 +375,7 @@ class OCLFullSplit1d(object):
         cdef numpy.ndarray[numpy.float32_t, ndim = 1] outMerge = numpy.zeros(self.bins, dtype=numpy.float32)
         cdef float[:] cdata, tdata, cflat, cdark, csolidAngle, cpolarization
 
-        #Ugly hack against bug #89: https://github.com/kif/pyFAI/issues/89
+        #Ugly hack against bug #89: https://github.com/silx-kit/pyFAI/issues/89
         cdef int rc_before, rc_after
         rc_before = sys.getrefcount(self._lut)
         cdef lut_point[:,:] lut = self._lut

--- a/pyFAI/test/test_bug_regression.py
+++ b/pyFAI/test/test_bug_regression.py
@@ -29,7 +29,7 @@
 """test suite for non regression on some bugs.
 
 Please refer to their respective bug number
-https://github.com/kif/pyFAI/issues
+https://github.com/silx-kit/pyFAI/issues
 """
 
 

--- a/pyFAI/test/test_geometry.py
+++ b/pyFAI/test/test_geometry.py
@@ -168,7 +168,7 @@ class TestBug88SolidAngle(unittest.TestCase):
     """
     Test case for solid angle where data got modified inplace.
 
-    https://github.com/kif/pyFAI/issues/88
+    https://github.com/silx-kit/pyFAI/issues/88
     """
 
     def testSolidAngle(self):

--- a/pyFAI/test/test_mask.py
+++ b/pyFAI/test/test_mask.py
@@ -243,7 +243,7 @@ class TestMask(unittest.TestCase):
 
 class TestMaskBeamstop(unittest.TestCase):
     """
-    Test for https://github.com/kif/pyFAI/issues/76
+    Test for https://github.com/silx-kit/pyFAI/issues/76
     """
     dataFile = "mock.tif"
 

--- a/sandbox/processor.py
+++ b/sandbox/processor.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 #    Project: Azimuthal integration
-#             https://github.com/kif/pyFAI
+#             https://github.com/silx-kit/pyFAI
 #
 #
 #    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France

--- a/sandbox/refine_wavelength
+++ b/sandbox/refine_wavelength
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 #    Project: Azimuthal integration 
-#             https://github.com/kif/pyFAI
+#             https://github.com/silx-kit/pyFAI
 #
 #    File: "$Id$"
 #

--- a/sandbox/refinment2D.py
+++ b/sandbox/refinment2D.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 #    Project: Azimuthal integration
-#             https://github.com/kif/pyFAI
+#             https://github.com/silx-kit/pyFAI
 #
 #    Copyright (C) European Synchrotron Radiation Facility, Grenoble, France
 #


### PR DESCRIPTION
Try to clean up the documentation
- Remove `.. command-output:: MX-calibrate --help`, that's not very helpful. And since scripts are generated at the installation time, it make it difficult to execute them like that.
- Then i update the scripts rst with updated options
- Avoid `-dx` and `-dy` on options. As result the documentation for `detector2nexus` looks fine. `-dx` are still supported but are not displayed anymore on the man help. It is now `--dx`
- Remove `@timeit` from an extension. It looks to break the parsing of other functions from the class.
- Fix other documentation warnings
- Improve import log for backward compatibility with PyMca on `drawmask`
- Fix github URL

Closes #342
Closes #644