### PR TITLE
Fix matplotlib import on Python2

### DIFF
--- a/pyFAI/gui/jupyter.py
+++ b/pyFAI/gui/jupyter.py
@@ -29,7 +29,7 @@
 """Jupyter helper functions
 """
 
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 
 __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"


### PR DESCRIPTION
This PR fix the `matplotlib` import on Python2.
On the same package an own `matplotlib.py` exists.

Feed back from Pierre-Olivier Autran from ID22

```
ImportErrorTraceback (most recent call last)
<ipython-input-4-778183f83bd1> in <module>()
      1 import pyFAI
----> 2 from pyFAI.gui import jupyter
      3 from pyFAI.calibrant import get_calibrant

/usr/lib/python2.7/dist-packages/pyFAI/gui/jupyter.py in <module>()
     42 import numpy
     43 from pylab import subplots, legend
---> 44 from matplotlib import lines
     45 
     46 

ImportError: cannot import name lines
```