### PR TITLE
Fix absolute_import on Python 2

### DIFF
--- a/pyFAI/gui/jupyter.py
+++ b/pyFAI/gui/jupyter.py
@@ -26,16 +26,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from __future__ import division, print_function, absolute_import
+
 """Jupyter helper functions
 """
-
-from __future__ import division, print_function, absolute_import
 
 __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/10/2017"
+__date__ = "18/12/2017"
 __status__ = "Production"
 __docformat__ = 'restructuredtext'
 


### PR DESCRIPTION
It have to be defined before the module docstring.

Tested using the inplainting notebook on Python2