### PR TITLE
fix read the docs

### DIFF
--- a/ci/requirements_rtd.txt
+++ b/ci/requirements_rtd.txt
@@ -2,6 +2,8 @@ numpy
 h5py
 fabio
 sphinx
+scipy
+cython
 sphinxcontrib-programoutput
 silx
 nbsphinx


### PR DESCRIPTION
This is WIP but need to be merged to trigger build from RTD.
RTD is moving to python 3.5 as environment for building the doc