### PR TITLE
'CheckCalib.__init__' not setting the 'img' attribute correctly

### DIFF
--- a/pyFAI/gui/cli_calibration.py
+++ b/pyFAI/gui/cli_calibration.py
@@ -2170,7 +2170,7 @@ class CheckCalib(object):
         else:
             self.ai = None
         if img:
-            self.img = fabio.open(img)
+            self.img = fabio.open(img).data
         else:
             self.img = None
         self.mask = None


### PR DESCRIPTION
CheckCalib.img should be a Numpy array, not a fabio.edfimage.EdfImage instance