### PR TITLE
[calib2] Fix "wrong size" with Frelon detector

### DIFF
--- a/pyFAI/app/calib2.py
+++ b/pyFAI/app/calib2.py
@@ -34,7 +34,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "06/03/2018"
+__date__ = "19/06/2018"
 __status__ = "production"
 
 import logging
@@ -79,6 +79,11 @@ def configure_parser_arguments(parser):
     parser.add_argument("-v", "--verbose",
                         action="store_true", dest="debug", default=False,
                         help="switch to debug/verbose mode")
+    parser.add_argument('--debug',
+                        dest="debug",
+                        action="store_true",
+                        default=False,
+                        help='Set logging system in debug mode')
 
     # Settings
     parser.add_argument("-c", "--calibrant", dest="spacing", metavar="FILE",
@@ -251,6 +256,9 @@ def setup(model):
     # Analyse aruments and options
     options = parser.parse_args()
     args = options.args
+
+    if options.debug:
+        logging.root.setLevel(logging.DEBUG)
 
     # Settings
     settings = model.experimentSettingsModel()

--- a/pyFAI/detectors/_common.py
+++ b/pyFAI/detectors/_common.py
@@ -648,6 +648,9 @@ class Detector(with_metaclass(DetectorMeta, object)):
             if shape != self.max_shape:
                 logger.warning("guess_binning is not implemented for %s detectors!\
                  and image size %s is wrong, expected %s!" % (self.name, shape, self.shape))
+                return False
+            self._binning = 1, 1
+            return True
         elif self.max_shape:
             bin1 = self.max_shape[0] // shape[0]
             bin2 = self.max_shape[1] // shape[1]

--- a/pyFAI/detectors/_common.py
+++ b/pyFAI/detectors/_common.py
@@ -35,7 +35,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "20/02/2018"
+__date__ = "19/06/2018"
 __status__ = "stable"
 
 
@@ -635,9 +635,9 @@ class Detector(with_metaclass(DetectorMeta, object)):
         :return: True if the data fit the detector
         :rtype: bool
         """
-        if "shape" in dir(data):
+        if hasattr(data, "shape"):
             shape = data.shape
-        elif "__len__" in dir(data):
+        elif hasattr(data, "__len__"):
             shape = tuple(data[:2])
         else:
             logger.warning("No shape available to guess the binning: %s", data)

--- a/pyFAI/detectors/_common.py
+++ b/pyFAI/detectors/_common.py
@@ -647,7 +647,7 @@ class Detector(with_metaclass(DetectorMeta, object)):
         if not self.force_pixel:
             if shape != self.max_shape:
                 logger.warning("guess_binning is not implemented for %s detectors!\
-                 and image size %s! is wrong, expected %s!" % (self.name, shape, self.shape))
+                 and image size %s is wrong, expected %s!" % (self.name, shape, self.shape))
         elif self.max_shape:
             bin1 = self.max_shape[0] // shape[0]
             bin2 = self.max_shape[1] // shape[1]

--- a/pyFAI/resources/gui/calibration-experiment.ui
+++ b/pyFAI/resources/gui/calibration-experiment.ui
@@ -340,7 +340,7 @@
          <item row="3" column="1">
           <widget class="QLabel" name="_error">
            <property name="styleSheet">
-            <string notr="true">color:red</string>
+            <string notr="true">QLabel {color:red}</string>
            </property>
            <property name="text">
             <string>dsdfsddsf</string>


### PR DESCRIPTION
There was a missing case in `guess_binning`.

I can't really manage all the cases as it is not very clear to me why for example we couldn't use a shape smaller than max_size in this case. Maybe it is cause of the splinefile?

Closes #851