### PR TITLE
Sparse builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@
 
 #discard generated C-files
 /pyFAI/ext/*.c
+/pyFAI/ext/*.cpp

--- a/pyFAI/ext/_distortion.pyx
+++ b/pyFAI/ext/_distortion.pyx
@@ -28,7 +28,7 @@
 
 __author__ = "Jerome Kieffer"
 __license__ = "MIT"
-__date__ = "23/05/2018"
+__date__ = "12/07/2018"
 __copyright__ = "2011-2018, ESRF"
 __contact__ = "jerome.kieffer@esrf.fr"
 
@@ -837,6 +837,166 @@ def calc_sparse(cnp.float32_t[:, :, :, ::1] pos not None,
             lut[bin_number, i].coef = large_data[idx]
             pixel_count[bin_number] += 1
         res = numpy.asarray(lut)
+    else:
+        raise RuntimeError("Unimplemented sparse matrix format: %s", format)
+    return res
+
+
+include "sparse_builder.pxi"
+
+
+@cython.boundscheck(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+def calc_sparse_v2(cnp.float32_t[:, :, :, ::1] pos not None,
+                   shape,
+                   max_pixel_size=(8, 8),
+                   cnp.int8_t[:, ::1] mask=None,
+                   format="csr",
+                   int bins_per_pixel=8,
+                   builder_config=None):
+    """Calculate the look-up table (or CSR) using OpenMP
+    :param pos: 4D position array
+    :param shape: output shape
+    :param max_pixel_size: (2-tuple of int) size of a buffer covering the largest pixel
+    :param format: can be "CSR" or "LUT"
+    :param bins_per_pixel: average splitting factor (number of pixels per bin) #deprecated
+    :return: look-up table in CSR/LUT format
+    """
+    cdef:
+        int shape_in0, shape_in1, shape_out0, shape_out1, size_in, delta0, delta1, bins, large_size
+    format = format.lower()
+    shape_out0, shape_out1 = shape
+    delta0, delta1 = max_pixel_size
+    bins = shape_out0 * shape_out1
+    large_size = bins * bins_per_pixel
+    shape_in0 = pos.shape[0]
+    shape_in1 = pos.shape[1]
+    size_in = shape_in0 * shape_in1
+    cdef:
+        int i, j, k, ms, ml, ns, nl
+        int i0, i1, lut_size, offset0, offset1, box_size0, box_size1
+        int counter, bin_number
+        int idx, err_cnt = 0
+        float A0, A1, B0, B1, C0, C1, D0, D1, pAB, pBC, pCD, pDA, cAB, cBC, cCD, cDA,
+        float area, value, foffset0, foffset1
+        cnp.int32_t[::1] indptr, indices, idx_bin, idx_pixel
+        cnp.float32_t[::1] data, large_data
+        cnp.float32_t[:, ::1] buffer
+        bint do_mask = mask is not None
+        lut_point[:, :] lut
+    if do_mask:
+        assert shape_in0 == mask.shape[0], "shape_in0 == mask.shape[0]"
+        assert shape_in1 == mask.shape[1], "shape_in1 == mask.shape[1]"
+
+    # Here we create a builder:
+    if builder_config is None:
+        builder = SparseBuilder(bins, block_size=6, heap_size=bins)
+    else:
+        builder = SparseBuilder(bins, **builder_config)
+    buffer = numpy.empty((delta0, delta1), dtype=numpy.float32)
+    counter = -1  # bin index
+    with nogil:
+        # i, j, idx are indices of the raw image uncorrected
+        for idx in range(size_in):
+            i = idx // shape_in1
+            j = idx % shape_in1
+            if do_mask and mask[i, j]:
+                continue
+            idx = i * shape_in1 + j  # pixel index
+            buffer[:, :] = 0.0
+            A0 = pos[i, j, 0, 0]
+            A1 = pos[i, j, 0, 1]
+            B0 = pos[i, j, 1, 0]
+            B1 = pos[i, j, 1, 1]
+            C0 = pos[i, j, 2, 0]
+            C1 = pos[i, j, 2, 1]
+            D0 = pos[i, j, 3, 0]
+            D1 = pos[i, j, 3, 1]
+            foffset0 = _floor_min4(A0, B0, C0, D0)
+            foffset1 = _floor_min4(A1, B1, C1, D1)
+            offset0 = <int> foffset0
+            offset1 = <int> foffset1
+            box_size0 = (<int> _ceil_max4(A0, B0, C0, D0)) - offset0
+            box_size1 = (<int> _ceil_max4(A1, B1, C1, D1)) - offset1
+            if (box_size0 > delta0) or (box_size1 > delta1):
+                # Increase size of the buffer
+                delta0 = offset0 if offset0 > delta0 else delta0
+                delta1 = offset1 if offset1 > delta1 else delta1
+                with gil:
+                    buffer = numpy.zeros((delta0, delta1), dtype=numpy.float32)
+
+            A0 = A0 - foffset0
+            A1 = A1 - foffset1
+            B0 = B0 - foffset0
+            B1 = B1 - foffset1
+            C0 = C0 - foffset0
+            C1 = C1 - foffset1
+            D0 = D0 - foffset0
+            D1 = D1 - foffset1
+            if B0 != A0:
+                pAB = (B1 - A1) / (B0 - A0)
+                cAB = A1 - pAB * A0
+            else:
+                pAB = cAB = 0.0
+            if C0 != B0:
+                pBC = (C1 - B1) / (C0 - B0)
+                cBC = B1 - pBC * B0
+            else:
+                pBC = cBC = 0.0
+            if D0 != C0:
+                pCD = (D1 - C1) / (D0 - C0)
+                cCD = C1 - pCD * C0
+            else:
+                pCD = cCD = 0.0
+            if A0 != D0:
+                pDA = (A1 - D1) / (A0 - D0)
+                cDA = D1 - pDA * D0
+            else:
+                pDA = cDA = 0.0
+
+            integrate(buffer, B0, A0, pAB, cAB)
+            integrate(buffer, A0, D0, pDA, cDA)
+            integrate(buffer, D0, C0, pCD, cCD)
+            integrate(buffer, C0, B0, pBC, cBC)
+            area = 0.5 * ((C0 - A0) * (D1 - B1) - (C1 - A1) * (D0 - B0))
+            for ms in range(box_size0):
+                ml = ms + offset0
+                if ml < 0 or ml >= shape_out0:
+                    continue
+                for ns in range(box_size1):
+                    # ms,ns are indexes of the corrected image in short form, ml & nl are the same
+                    nl = ns + offset1
+                    if nl < 0 or nl >= shape_out1:
+                        continue
+                    value = buffer[ms, ns] / area
+                    if value == 0.0:
+                        continue
+                    if value < 0.0 or value > 1.0001:
+                        # here we print pathological cases for debugging
+                        if err_cnt < 1000:
+                            with gil:
+                                print(i, j, ms, box_size0, ns, box_size1, buffer[ms, ns], area, value, buffer[0, 0], buffer[0, 1], buffer[1, 0], buffer[1, 1])
+                                print(" A0=%s; A1=%s; B0=%s; B1=%s; C0=%s; C1=%s; D0=%s; D1=%s" % (A0, A1, B0, B1, C0, C1, D0, D1))
+                            err_cnt += 1
+                        continue
+
+                    bin_number = ml * shape_out1 + nl
+                    # with gil: #Use the gil to perform an atomic operation
+                    counter += 1
+                    if counter >= large_size:
+                        with gil:
+                            raise RuntimeError("Provided temporary space for storage is not enough. " +
+                                               "Please increase bins_per_pixel=%s. " % bins_per_pixel +
+                                               "The suggested value is %i or greater." % ceil(1.1 * bins_per_pixel * size_in / idx))
+                    builder.cinsert(bin_number, idx, value)
+    logger.info("number of elements: %s, average per bin %.3f allocated max: %s",
+                counter, counter / size_in, bins_per_pixel)
+
+    if format == "csr":
+        res = builder.to_csr()
+    elif format == "lut":
+        raise NotImplementedError("")
     else:
         raise RuntimeError("Unimplemented sparse matrix format: %s", format)
     return res

--- a/pyFAI/ext/setup.py
+++ b/pyFAI/ext/setup.py
@@ -24,7 +24,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "10/07/2018"
+__date__ = "11/07/2018"
 
 from numpy.distutils.misc_util import Configuration
 import platform
@@ -79,7 +79,6 @@ def configuration(parent_package='', top_path=None):
         create_extension_config('splitPixelFullCSR', can_use_openmp=True),
         create_extension_config('relabel'),
         create_extension_config("bilinear", can_use_openmp=True),
-        create_extension_config('_distortion', can_use_openmp=True),
         # create_extension_config('_distortionCSR', can_use_openmp=True),
         create_extension_config('_bispev', can_use_openmp=True),
         create_extension_config('_convolution', can_use_openmp=True),
@@ -99,6 +98,13 @@ def configuration(parent_package='', top_path=None):
 
     for ext_config in ext_modules:
         config.add_extension(**ext_config)
+
+    config.add_extension('_distortion',
+                         sources=['_distortion.pyx'],
+                         include_dirs=[numpy.get_include()],
+                         language='c++',
+                         extra_link_args=['-fopenmp'],
+                         extra_compile_args=['-fopenmp'])
 
     config.add_extension('sparse_builder',
                          sources=['sparse_builder.pyx'],

--- a/pyFAI/ext/setup.py
+++ b/pyFAI/ext/setup.py
@@ -24,7 +24,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "31/08/2017"
+__date__ = "10/07/2018"
 
 from numpy.distutils.misc_util import Configuration
 import platform
@@ -99,6 +99,13 @@ def configuration(parent_package='', top_path=None):
 
     for ext_config in ext_modules:
         config.add_extension(**ext_config)
+
+    config.add_extension('sparse_builder',
+                         sources=['sparse_builder.pyx'],
+                         include_dirs=[numpy.get_include()],
+                         language='c++',
+                         extra_link_args=['-fopenmp'],
+                         extra_compile_args=['-fopenmp'])
 
     return config
 

--- a/pyFAI/ext/sparse_builder.pxi
+++ b/pyFAI/ext/sparse_builder.pxi
@@ -8,13 +8,9 @@ from libc.math cimport fabs
 cimport libc.stdlib
 cimport libc.string
 
-from cython.parallel import prange
 from cython.operator cimport dereference
 from cython.operator cimport preincrement
 cimport cython
-from cython cimport floating
-
-cdef double EPS32 = (1.0 + numpy.finfo(numpy.float32).eps)
 
 
 cdef struct pixel_t:

--- a/pyFAI/ext/sparse_builder.pxi
+++ b/pyFAI/ext/sparse_builder.pxi
@@ -1,0 +1,342 @@
+import numpy
+cimport numpy as cnumpy
+
+from libcpp.vector cimport vector
+from libcpp.list cimport list as clist
+from libcpp cimport bool
+from libc.math cimport fabs
+cimport libc.stdlib
+cimport libc.string
+
+from cython.parallel import prange
+from cython.operator cimport dereference
+from cython.operator cimport preincrement
+cimport cython
+from cython cimport floating
+
+cdef double EPS32 = (1.0 + numpy.finfo(numpy.float32).eps)
+
+
+cdef struct pixel_t:
+    cnumpy.int32_t index
+    cnumpy.float32_t coef
+
+cdef cppclass PixelElementaryBlock:
+    vector[cnumpy.int32_t] _indexes
+    vector[cnumpy.float32_t] _coefs
+    int _size
+    int _max_size
+
+    PixelElementaryBlock(int size) nogil:
+        this._indexes.reserve(size)
+        this._coefs.reserve(size)
+        this._size = 0
+        this._max_size = size
+
+    void push(pixel_t &pixel) nogil:
+        this._indexes.push_back(pixel.index)
+        this._coefs.push_back(pixel.coef)
+        this._size += 1
+
+    int size() nogil:
+        return this._size
+
+    bool is_full() nogil:
+        return this._size == this._max_size
+
+cdef cppclass PixelBlock:
+    clist[PixelElementaryBlock*] _blocks
+    int _block_size
+
+    PixelBlock(int block_size) nogil:
+        this._block_size = block_size
+
+    __dealloc__() nogil:
+        cdef:
+            PixelElementaryBlock* element
+            int i = 0
+            clist[PixelElementaryBlock*].iterator it
+        it = this._blocks.begin()
+        while it != this._blocks.end():
+            element = dereference(it)
+            del element
+            preincrement(it)
+        this._blocks.clear()
+
+    void push(pixel_t &pixel) nogil:
+        cdef:
+            PixelElementaryBlock *block
+        if _blocks.size() == 0 or this._blocks.back().is_full():
+            block = new PixelElementaryBlock(size=this._block_size)
+            this._blocks.push_back(block)
+        block = this._blocks.back()
+        block.push(pixel)
+
+    int size() nogil:
+        cdef:
+            int size = 0
+            clist[PixelElementaryBlock*].iterator it
+        it = this._blocks.begin()
+        while it != this._blocks.end():
+            size += dereference(it).size()
+            preincrement(it)
+        return size
+
+    cnumpy.int32_t[:] index_array():
+        cdef:
+            clist[PixelElementaryBlock*].iterator it
+            PixelElementaryBlock* block
+            int size
+            int begin
+            cnumpy.int32_t[:] data
+            cnumpy.int32_t[:] data2
+
+        size = this.size()
+        data = numpy.empty(size, dtype=numpy.int32)
+
+        begin = 0
+        it = this._blocks.begin()
+        while it != this._blocks.end():
+            block = dereference(it)
+            if block.size() != 0:
+                data2 = numpy.array(block._indexes, dtype=numpy.int32)
+                data[begin:begin + block.size()] = data2
+                begin += block.size()
+            preincrement(it)
+        return data
+
+    cnumpy.float32_t[:] coef_array():
+        cdef:
+            clist[PixelElementaryBlock*].iterator it
+            PixelElementaryBlock* block
+            int size
+            int begin
+            cnumpy.float32_t[:] data
+            cnumpy.float32_t[:] data2
+
+        size = this.size()
+        data = numpy.empty(size, dtype=numpy.float32)
+
+        begin = 0
+        it = this._blocks.begin()
+        while it != this._blocks.end():
+            block = dereference(it)
+            if block.size() != 0:
+                data2 = numpy.array(block._coefs, dtype=numpy.float32)
+                data[begin:begin + block.size()] = data2
+                begin += block.size()
+            preincrement(it)
+        return data
+
+
+cdef cppclass PixelBin:
+    clist[pixel_t] _pixels
+    PixelBlock *_pixels_in_block
+
+    PixelBin(int block_size) nogil:
+        if block_size > 0:
+            this._pixels_in_block = new PixelBlock(block_size)
+        else:
+            this._pixels_in_block = NULL
+
+    __dealloc__() nogil:
+        if this._pixels_in_block != NULL:
+            del this._pixels_in_block
+            this._pixels_in_block = NULL
+        else:
+            this._pixels.clear()
+
+    void push(pixel_t &pixel) nogil:
+        if this._pixels_in_block != NULL:
+            this._pixels_in_block.push(pixel)
+        else:
+            this._pixels.push_back(pixel)
+
+    int size() nogil:
+        if this._pixels_in_block != NULL:
+            return this._pixels_in_block.size()
+        else:
+            return this._pixels.size()
+
+    cnumpy.int32_t[:] index_array():
+        cdef:
+            int i = 0
+            clist[pixel_t].iterator it_points
+
+        if this._pixels_in_block != NULL:
+            return this._pixels_in_block.index_array()
+
+        data = numpy.empty(this.size(), dtype=numpy.int32)
+        it_points = this._pixels.begin()
+        while it_points != this._pixels.end():
+            data[i] = dereference(it_points).index
+            preincrement(it_points)
+            i += 1
+        return data
+
+    cnumpy.float32_t[:] coef_array():
+        cdef:
+            int i = 0
+            clist[pixel_t].iterator it_points
+
+        if this._pixels_in_block != NULL:
+            return this._pixels_in_block.coef_array()
+
+        data = numpy.empty(this.size(), dtype=numpy.float32)
+        it_points = this._pixels.begin()
+        while it_points != this._pixels.end():
+            data[i] = dereference(it_points).coef
+            preincrement(it_points)
+            i += 1
+        return data
+
+
+cdef class SparseBuilder(object):
+
+    cdef PixelBin **_bins
+    cdef int _nbin
+    cdef int _block_size
+
+    def __init__(self, nbin, block_size=512):
+        self._block_size = block_size
+        self._nbin = nbin
+        self._bins = <PixelBin **>libc.stdlib.malloc(self._nbin * sizeof(PixelBin *))
+        libc.string.memset(self._bins, 0, self._nbin * sizeof(PixelBin *))
+
+    def __dealloc__(self):
+        cdef:
+            PixelBin *pixel_bin
+            int i
+        for i in range(self._nbin):
+            pixel_bin = self._bins[i]
+            if pixel_bin != NULL:
+                del pixel_bin
+        libc.stdlib.free(self._bins)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef PixelBin *_create_bin(self) nogil:
+        return new PixelBin(self._block_size)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef void cinsert(self, int bin_id, int index, cnumpy.float32_t coef) nogil:
+        cdef:
+            pixel_t pixel
+            PixelBin *pixel_bin
+        if bin_id < 0 or bin_id >= self._nbin:
+            return
+        pixel.index = index
+        pixel.coef = coef
+
+        pixel_bin = self._bins[bin_id]
+        if pixel_bin == NULL:
+            pixel_bin = self._create_bin()
+            self._bins[bin_id] = pixel_bin
+        self._bins[bin_id].push(pixel)
+
+    def insert(self, bin_id, index, coef):
+        if bin_id < 0 or bin_id >= self._nbin:
+            raise ValueError("bin_id out of range")
+        self.cinsert(bin_id, index, coef)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    def get_bin_coefs(self, bin_id):
+        cdef:
+            PixelBin *pixel_bin
+        if bin_id < 0 or bin_id >= self._nbin:
+            raise ValueError("bin_id out of range")
+        pixel_bin = self._bins[bin_id]
+        if pixel_bin == NULL:
+            return numpy.empty(shape=(0, 1), dtype=numpy.float32)
+        return numpy.array(pixel_bin.coef_array())
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    def get_bin_indexes(self, bin_id):
+        cdef:
+            PixelBin *pixel_bin
+        if bin_id < 0 or bin_id >= self._nbin:
+            raise ValueError("bin_id out of range")
+        pixel_bin = self._bins[bin_id]
+        if pixel_bin == NULL:
+            return numpy.empty(shape=(0, 1), dtype=numpy.int32)
+        return numpy.array(pixel_bin.index_array())
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    def get_bin_size(self, bin_id):
+        cdef:
+            PixelBin *pixel_bin
+        if bin_id < 0 or bin_id >= self._nbin:
+            raise ValueError("bin_id out of range")
+        pixel_bin = self._bins[bin_id]
+        if pixel_bin == NULL:
+            return 0
+        return pixel_bin.size()
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    def size(self):
+        cdef:
+            PixelBin *pixel_bin
+            int size
+            int bin_id
+
+        size = 0
+        for bin_id in range(self._nbin):
+            pixel_bin = self._bins[bin_id]
+            if pixel_bin != NULL:
+                size += pixel_bin.size()
+        return size
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    def to_csr(self):
+        cdef:
+            cnumpy.int32_t[:] indexes
+            cnumpy.int32_t[:] indexes2
+            cnumpy.float32_t[:] coefs
+            cnumpy.float32_t[:] coefs2
+            cnumpy.int32_t[:] nbins
+            PixelBin *pixel_bin
+            int size
+            int i
+            int begin, end
+            int bin_id
+            int bin_size
+
+        # indexes of the first and the last+1 elements of each bins
+        size = 0
+        nbins = numpy.empty(self._nbin + 1, dtype=numpy.int32)
+        nbins[0] = size
+        for bin_id in range(self._nbin):
+            pixel_bin = self._bins[bin_id]
+            if pixel_bin != NULL:
+                bin_size = pixel_bin.size()
+            else:
+                bin_size = 0
+            size += bin_size
+            nbins[bin_id + 1] = size
+
+        indexes = numpy.empty(size, dtype=numpy.int32)
+        coefs = numpy.empty(size, dtype=numpy.float32)
+
+        for bin_id in range(self._nbin):
+            pixel_bin = self._bins[bin_id]
+            if pixel_bin == NULL or pixel_bin.size() == 0:
+                continue
+            begin = nbins[bin_id]
+            end = nbins[bin_id + 1]
+            indexes[begin:end] = pixel_bin.index_array()
+            coefs[begin:end] = pixel_bin.coef_array()
+
+        return numpy.array(coefs), numpy.array(indexes), numpy.array(nbins)

--- a/pyFAI/ext/sparse_builder.pxi
+++ b/pyFAI/ext/sparse_builder.pxi
@@ -117,10 +117,12 @@ cdef cppclass PixelBlock:
     clist[PixelElementaryBlock*] _blocks
     int _block_size
     Heap *_heap
+    PixelElementaryBlock* _current_block
 
     PixelBlock(int block_size, Heap *heap) nogil:
         this._block_size = block_size
         this._heap = heap
+        this._current_block = NULL
 
     __dealloc__() nogil:
         cdef:
@@ -137,10 +139,11 @@ cdef cppclass PixelBlock:
     void push(pixel_t &pixel) nogil:
         cdef:
             PixelElementaryBlock *block
-        if _blocks.size() == 0 or this._blocks.back().is_full():
+        if this._current_block == NULL or this._current_block.is_full():
             block = new PixelElementaryBlock(this._block_size, this._heap)
             this._blocks.push_back(block)
-        block = this._blocks.back()
+            this._current_block = block
+        block = this._current_block
         block.push(pixel)
 
     int size() nogil:

--- a/pyFAI/ext/sparse_builder.pxi
+++ b/pyFAI/ext/sparse_builder.pxi
@@ -56,20 +56,24 @@ cdef cppclass Heap:
     cnumpy.int32_t * alloc_indexes(int size) nogil:
         cdef:
             cnumpy.int32_t *data
-        if this._indexes.size() == 0 or this._index_pos + size > this._block_size:
-            data = <cnumpy.int32_t *>libc.stdlib.malloc(size * sizeof(cnumpy.int32_t))
+        if this._indexes.size() == 0 or this._index_pos + size >= this._block_size:
+            data = <cnumpy.int32_t *>libc.stdlib.malloc(this._block_size * sizeof(cnumpy.int32_t))
             this._indexes.push_back(data)
             this._index_pos = 0
+        else:
+            this._index_pos += size
         data = this._indexes.back()
         return data + this._index_pos
 
     cnumpy.float32_t * alloc_coefs(int size) nogil:
         cdef:
             cnumpy.float32_t *data
-        if this._coefs.size() == 0 or this._coef_pos + size > this._block_size:
-            data = <cnumpy.float32_t *>libc.stdlib.malloc(size * sizeof(cnumpy.float32_t))
+        if this._coefs.size() == 0 or this._coef_pos + size >= this._block_size:
+            data = <cnumpy.float32_t *>libc.stdlib.malloc(this._block_size * sizeof(cnumpy.float32_t))
             this._coefs.push_back(data)
             this._coef_pos = 0
+        else:
+            this._coef_pos += size
         data = this._coefs.back()
         return data + this._coef_pos
 

--- a/pyFAI/ext/sparse_builder.pxi
+++ b/pyFAI/ext/sparse_builder.pxi
@@ -99,52 +99,52 @@ cdef cppclass Heap:
     cnumpy.int32_t * alloc_indexes(int size) nogil:
         cdef:
             cnumpy.int32_t *data
-        if this._current_index_block == NULL or this._index_pos + size >= this._block_size:
+        if this._current_index_block == NULL or this._index_pos + size > this._block_size:
             data = <cnumpy.int32_t *>libc.stdlib.malloc(this._block_size * sizeof(cnumpy.int32_t))
             this._current_index_block = data
             this._indexes.push_back(data)
             this._index_pos = 0
-        else:
-            this._index_pos += size
-        return this._current_index_block + this._index_pos
+        data = this._current_index_block + this._index_pos
+        this._index_pos += size
+        return data
 
     cnumpy.float32_t * alloc_coefs(int size) nogil:
         cdef:
             cnumpy.float32_t *data
-        if this._current_coef_block == NULL or this._coef_pos + size >= this._block_size:
+        if this._current_coef_block == NULL or this._coef_pos + size > this._block_size:
             data = <cnumpy.float32_t *>libc.stdlib.malloc(this._block_size * sizeof(cnumpy.float32_t))
             this._current_coef_block = data
             this._coefs.push_back(data)
             this._coef_pos = 0
-        else:
-            this._coef_pos += size
-        return this._current_coef_block + this._coef_pos
+        data = this._current_coef_block + this._coef_pos
+        this._coef_pos += size
+        return data
 
     chained_pixel_t* alloc_pixel() nogil:
         cdef:
             chained_pixel_t *data
             int foo
-        if this._current_pixel_block == NULL or this._pixel_pos + 1 >= this._block_size:
+        if this._current_pixel_block == NULL or this._pixel_pos + 1 > this._block_size:
             data = <chained_pixel_t *>libc.stdlib.malloc(this._block_size * sizeof(chained_pixel_t))
             this._current_pixel_block = data
             this._pixels.push_back(data)
             this._pixel_pos = 0
-        else:
-            this._pixel_pos += 1
-        return this._current_pixel_block + this._pixel_pos
+        data = this._current_pixel_block + this._pixel_pos
+        this._pixel_pos += 1
+        return data
 
     packed_data_t* alloc_packed_data() nogil:
         cdef:
             packed_data_t *data
             int foo
-        if this._current_packed_block == NULL or this._packed_pos + 1 >= this._block_size:
+        if this._current_packed_block == NULL or this._packed_pos + 1 > this._block_size:
             data = <packed_data_t *>libc.stdlib.malloc(this._block_size * sizeof(packed_data_t))
             this._current_packed_block = data
             this._packed_data.push_back(data)
             this._packed_pos = 0
-        else:
-            this._packed_pos += 1
-        return this._current_packed_block + this._packed_pos
+        data = this._current_packed_block + this._packed_pos
+        this._packed_pos += 1
+        return data
 
 
 cdef cppclass PixelElementaryBlock:
@@ -180,7 +180,7 @@ cdef cppclass PixelElementaryBlock:
         return this._size
 
     bool is_full() nogil:
-        return this._size == this._max_size
+        return this._size >= this._max_size
 
     bool has_space(int size) nogil:
         return this._size + size <= this._max_size

--- a/pyFAI/ext/sparse_builder.pxi
+++ b/pyFAI/ext/sparse_builder.pxi
@@ -21,6 +21,7 @@ cdef struct pixel_t:
     cnumpy.int32_t index
     cnumpy.float32_t coef
 
+
 cdef cppclass PixelElementaryBlock:
     cnumpy.int32_t *_indexes
     cnumpy.float32_t *_coefs
@@ -47,6 +48,7 @@ cdef cppclass PixelElementaryBlock:
 
     bool is_full() nogil:
         return this._size == this._max_size
+
 
 cdef cppclass PixelBlock:
     clist[PixelElementaryBlock*] _blocks

--- a/pyFAI/ext/sparse_builder.pxi
+++ b/pyFAI/ext/sparse_builder.pxi
@@ -1,3 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Fast Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2018 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#  .
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#  .
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+__author__ = "Valentin Valls"
+__license__ = "MIT"
+__date__ = "13/07/2018"
+__copyright__ = "2018, ESRF"
+
 import numpy
 cimport numpy as cnumpy
 

--- a/pyFAI/ext/sparse_builder.pyx
+++ b/pyFAI/ext/sparse_builder.pyx
@@ -1,0 +1,65 @@
+import numpy
+cimport numpy as cnumpy
+
+from libcpp.vector cimport vector
+from libcpp.list cimport list as clist
+from libcpp cimport bool
+from libc.math cimport fabs
+cimport libc.stdlib
+cimport libc.string
+
+from cython.parallel import prange
+from cython.operator cimport dereference
+from cython.operator cimport preincrement
+cimport cython
+from cython cimport floating
+
+include "sparse_builder.pxi"
+
+
+@cython.cdivision(True)
+cdef inline floating calc_upper_bound(floating maximum_value) nogil:
+    if maximum_value > 0:
+        return maximum_value * EPS32
+    else:
+        return maximum_value / EPS32
+
+
+@cython.cdivision(True)
+cdef inline floating  get_bin_number(floating x0, floating pos0_min, floating delta) nogil:
+    return (x0 - pos0_min) / delta
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def feed_histogram(SparseBuilder builder not None,
+                   cnumpy.ndarray pos not None,
+                   cnumpy.ndarray weights not None,
+                   int bins=100,
+                   double empty=0.0,
+                   double normalization_factor=1.0):
+    assert pos.size == weights.size
+    assert bins > 1
+    cdef:
+        int  size = pos.size
+        cnumpy.float32_t[::1] cpos = numpy.ascontiguousarray(pos.ravel(), dtype=numpy.float32)
+        cnumpy.float32_t delta, min0, max0, maxin0
+        cnumpy.float32_t a = 0.0
+        cnumpy.float32_t d = 0.0
+        cnumpy.float32_t fbin = 0.0
+        cnumpy.float32_t tmp_count, tmp_data = 0.0
+        cnumpy.float32_t epsilon = 1e-10
+        int bin = 0, i, idx
+
+    min0 = pos.min()
+    maxin0 = pos.max()
+    max0 = calc_upper_bound(maxin0)
+    delta = (max0 - min0) / float(bins)
+
+    with nogil:
+        for i in range(size):
+            a = cpos[i]
+            fbin = get_bin_number(a, min0, delta)
+            bin = < int > fbin
+            builder.cinsert(bin, i, 1.0)

--- a/pyFAI/ext/sparse_builder.pyx
+++ b/pyFAI/ext/sparse_builder.pyx
@@ -16,6 +16,7 @@ from cython cimport floating
 
 include "sparse_builder.pxi"
 
+cdef double EPS32 = (1.0 + numpy.finfo(numpy.float32).eps)
 
 @cython.cdivision(True)
 cdef inline floating calc_upper_bound(floating maximum_value) nogil:

--- a/pyFAI/ext/sparse_builder.pyx
+++ b/pyFAI/ext/sparse_builder.pyx
@@ -1,3 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Fast Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2018 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#  .
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#  .
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+__author__ = "Valentin Valls"
+__license__ = "MIT"
+__date__ = "13/07/2018"
+__copyright__ = "2018, ESRF"
+
 import numpy
 cimport numpy as cnumpy
 

--- a/pyFAI/test/test_all.py
+++ b/pyFAI/test/test_all.py
@@ -33,7 +33,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "15/03/2018"
+__date__ = "10/07/2018"
 
 import sys
 import unittest
@@ -81,6 +81,7 @@ from . import test_preproc
 from . import test_bayes
 from . import test_scripts
 from . import test_spline
+from . import test_sparse_builder
 from . import test_goniometer
 from . import test_integrate_app
 from . import test_pyfai_api
@@ -131,6 +132,7 @@ def suite():
     testsuite.addTest(test_bayes.suite())
     testsuite.addTest(test_scripts.suite())
     testsuite.addTest(test_spline.suite())
+    testsuite.addTest(test_sparse_builder.suite())
     testsuite.addTest(test_goniometer.suite())
     testsuite.addTest(test_opencl.suite())
     testsuite.addTest(test_pyfai_api.suite())

--- a/pyFAI/test/test_sparse_builder.py
+++ b/pyFAI/test/test_sparse_builder.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015-2018 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Test suites for sparse builder module"""
+
+from __future__ import absolute_import, division, print_function
+
+__author__ = "Valentin Valls"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "10/07/2018"
+
+
+import unittest
+import numpy
+import logging
+logger = logging.getLogger(__name__)
+from ..ext import sparse_builder
+
+
+class TestSparseBuilder(unittest.TestCase):
+    """Test for sparse builder
+    """
+
+    def test_insert(self):
+        builder = sparse_builder.SparseBuilder(10, block_size=512)
+        builder.insert(0, 0, 1.0)
+        builder.insert(0, 1, 0.6)
+        builder.insert(1, 1, 0.4)
+        self.assertEqual(builder.size(), 3)
+
+    def test_bin_size(self):
+        builder = sparse_builder.SparseBuilder(10, block_size=512)
+        builder.insert(0, 0, 1.0)
+        builder.insert(0, 1, 0.6)
+        builder.insert(1, 1, 0.4)
+        self.assertEqual(builder.get_bin_size(0), 2)
+        self.assertEqual(builder.get_bin_size(1), 1)
+        self.assertEqual(builder.get_bin_size(2), 0)
+
+    def test_bin_coefs(self):
+        builder = sparse_builder.SparseBuilder(10, block_size=512)
+        builder.insert(0, 0, 1.0)
+        builder.insert(0, 1, 0.6)
+        builder.insert(1, 1, 0.4)
+        builder.insert(0, 2, 1.0)
+        self.assertTrue(numpy.allclose(builder.get_bin_coefs(0), numpy.array([1.0, 0.6, 1.0])))
+        self.assertTrue(numpy.allclose(builder.get_bin_coefs(1), numpy.array([0.4])))
+        self.assertTrue(numpy.allclose(builder.get_bin_coefs(2), numpy.array([])))
+
+    def test_bin_indexes(self):
+        builder = sparse_builder.SparseBuilder(10, block_size=512)
+        builder.insert(0, 0, 1.0)
+        builder.insert(0, 1, 0.6)
+        builder.insert(1, 1, 0.4)
+        builder.insert(0, 2, 1.0)
+        self.assertTrue(numpy.allclose(builder.get_bin_indexes(0), numpy.array([0, 1, 2])))
+        self.assertTrue(numpy.allclose(builder.get_bin_indexes(1), numpy.array([1])))
+        self.assertTrue(numpy.allclose(builder.get_bin_indexes(2), numpy.array([])))
+
+    def test_csr(self):
+        builder = sparse_builder.SparseBuilder(10, block_size=512)
+        builder.insert(0, 0, 1.0)
+        builder.insert(0, 1, 0.6)
+        builder.insert(1, 1, 0.4)
+        a, b, c = builder.to_csr()
+        self.assertTrue(numpy.allclose(a, numpy.array([1.0, 0.6, 0.4])))
+        self.assertTrue(numpy.allclose(b, numpy.array([0, 1, 1])))
+        self.assertTrue(numpy.allclose(c, numpy.array([0, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3])))
+
+    def test_small_tth(self):
+        shape = (512, 512)
+        npt = 200
+        y, x = numpy.ogrid[:shape[0], :shape[1]]
+        tth = numpy.sqrt(x * x + y * y)
+        maxI = 1000
+        mod = 0.5 + 0.5 * numpy.cos(tth / 12) + 0.25 * numpy.cos(tth / 6) + 0.1 * numpy.cos(tth / 4)
+        data = (numpy.ones(shape) * maxI * mod).astype("uint16")
+
+        builder = sparse_builder.SparseBuilder(npt, block_size=512)
+        sparse_builder.feed_histogram(builder, tth, data, npt)
+        self.assertEqual(builder.size(), shape[0] * shape[1])
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loader(TestSparseBuilder))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/pyFAI/test/test_sparse_builder.py
+++ b/pyFAI/test/test_sparse_builder.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import, division, print_function
 __author__ = "Valentin Valls"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "11/07/2018"
+__date__ = "13/07/2018"
 
 
 import unittest
@@ -41,79 +41,130 @@ import numpy
 import logging
 logger = logging.getLogger(__name__)
 from ..ext import sparse_builder
+from . import utilstest
+import collections
 
 
-class TestSparseBuilder(unittest.TestCase):
+class TestSparseBuilder(utilstest.ParametricTestCase):
     """Test for sparse builder
     """
 
+    def each_builders(self, nbin):
+        builders = collections.OrderedDict()
+
+        builders["block"] = sparse_builder.SparseBuilder(nbin, mode="block", block_size=512)
+        builders["block_small"] = sparse_builder.SparseBuilder(nbin, mode="block", block_size=2)
+        builders["block_heap"] = sparse_builder.SparseBuilder(nbin, mode="block", block_size=2, heap_size=128)
+        builders["block_small_heap"] = sparse_builder.SparseBuilder(nbin, mode="block", block_size=1, heap_size=3)
+        builders["heaplist"] = sparse_builder.SparseBuilder(nbin, mode="heaplist", heap_size=512)
+        builders["heaplist_small_heap"] = sparse_builder.SparseBuilder(nbin, mode="heaplist", heap_size=3)
+        builders["stdlist"] = sparse_builder.SparseBuilder(nbin, mode="stdlist")
+        builders["pack"] = sparse_builder.SparseBuilder(nbin, mode="pack", heap_size=512)
+        builders["pack_small_heap"] = sparse_builder.SparseBuilder(nbin, mode="pack", heap_size=3)
+
+        for builder_name, builder in builders.items():
+            yield builder_name, builder
+
+    def subtest_each_builders(self, nbin):
+        for builder_name, builder in self.each_builders(nbin):
+            with self.subTest(builder=builder_name):
+                yield builder
+
     def test_insert(self):
-        builder = sparse_builder.SparseBuilder(10, block_size=512)
-        builder.insert(0, 0, 1.0)
-        builder.insert(0, 1, 0.6)
-        builder.insert(1, 1, 0.4)
-        self.assertEqual(builder.size(), 3)
+        for builder in self.subtest_each_builders(10):
+            builder.insert(0, 0, 1.0)
+            builder.insert(0, 1, 0.6)
+            builder.insert(1, 1, 0.4)
+            self.assertEqual(builder.size(), 3)
+
+    def test_bin_sizes(self):
+        for builder in self.subtest_each_builders(5):
+            builder.insert(0, 0, 1.0)
+            builder.insert(0, 1, 0.6)
+            builder.insert(1, 1, 0.4)
+            builder.insert(4, 2, 1.0)
+            builder.insert(4, 3, 1.0)
+            builder.insert(4, 4, 1.0)
+            builder.insert(4, 5, 1.0)
+            builder.insert(4, 6, 1.0)
+            self.assertTrue(numpy.allclose(builder.get_bin_sizes(), numpy.array([2, 1, 0, 0, 5])))
 
     def test_bin_size(self):
-        builder = sparse_builder.SparseBuilder(10, block_size=512)
-        builder.insert(0, 0, 1.0)
-        builder.insert(0, 1, 0.6)
-        builder.insert(1, 1, 0.4)
-        self.assertEqual(builder.get_bin_size(0), 2)
-        self.assertEqual(builder.get_bin_size(1), 1)
-        self.assertEqual(builder.get_bin_size(2), 0)
+        for builder in self.subtest_each_builders(10):
+            builder.insert(0, 0, 1.0)
+            builder.insert(0, 1, 0.6)
+            builder.insert(1, 1, 0.4)
+            self.assertEqual(builder.get_bin_size(0), 2)
+            self.assertEqual(builder.get_bin_size(1), 1)
+            self.assertEqual(builder.get_bin_size(2), 0)
 
     def test_bin_coefs(self):
-        builder = sparse_builder.SparseBuilder(10, block_size=512)
-        builder.insert(0, 0, 1.0)
-        builder.insert(0, 1, 0.6)
-        builder.insert(1, 1, 0.4)
-        builder.insert(0, 2, 1.0)
-        self.assertTrue(numpy.allclose(builder.get_bin_coefs(0), numpy.array([1.0, 0.6, 1.0])))
-        self.assertTrue(numpy.allclose(builder.get_bin_coefs(1), numpy.array([0.4])))
-        self.assertTrue(numpy.allclose(builder.get_bin_coefs(2), numpy.array([])))
+        for builder in self.subtest_each_builders(10):
+            if builder.mode() == "pack":
+                continue
+            builder.insert(0, 0, 1.0)
+            builder.insert(0, 1, 0.6)
+            builder.insert(1, 1, 0.4)
+            builder.insert(0, 2, 1.0)
+            self.assertTrue(numpy.allclose(builder.get_bin_coefs(0), numpy.array([1.0, 0.6, 1.0])))
+            self.assertTrue(numpy.allclose(builder.get_bin_coefs(1), numpy.array([0.4])))
+            self.assertTrue(numpy.allclose(builder.get_bin_coefs(2), numpy.array([])))
 
     def test_bin_indexes(self):
-        builder = sparse_builder.SparseBuilder(10, block_size=512)
-        builder.insert(0, 0, 1.0)
-        builder.insert(0, 1, 0.6)
-        builder.insert(1, 1, 0.4)
-        builder.insert(0, 2, 1.0)
-        self.assertTrue(numpy.allclose(builder.get_bin_indexes(0), numpy.array([0, 1, 2])))
-        self.assertTrue(numpy.allclose(builder.get_bin_indexes(1), numpy.array([1])))
-        self.assertTrue(numpy.allclose(builder.get_bin_indexes(2), numpy.array([])))
+        for builder in self.subtest_each_builders(10):
+            if builder.mode() == "pack":
+                continue
+            builder.insert(0, 0, 1.0)
+            builder.insert(0, 1, 0.6)
+            builder.insert(1, 1, 0.4)
+            builder.insert(0, 2, 1.0)
+            self.assertTrue(numpy.allclose(builder.get_bin_indexes(0), numpy.array([0, 1, 2])))
+            self.assertTrue(numpy.allclose(builder.get_bin_indexes(1), numpy.array([1])))
+            self.assertTrue(numpy.allclose(builder.get_bin_indexes(2), numpy.array([])))
 
-    def test_block_overflow(self):
-        builder = sparse_builder.SparseBuilder(10, block_size=16)
-        for i in range(50):
-            builder.insert(0, i, i * 0.1)
-        self.assertEqual(builder.get_bin_size(0), 50)
-        x = numpy.array(range(50))
-        self.assertTrue(numpy.allclose(builder.get_bin_indexes(0), x))
-        self.assertTrue(numpy.allclose(builder.get_bin_coefs(2), x * 0.1))
+    def test_insert_overflow(self):
+        for builder in self.subtest_each_builders(10):
+            for i in range(50):
+                builder.insert(0, i, i * 0.1)
+            self.assertEqual(builder.get_bin_size(0), 50)
+            x = numpy.array(range(50))
+            coefs, indexes, _bin_indexes = builder.to_csr()
+            self.assertTrue(numpy.allclose(indexes, x))
+            self.assertTrue(numpy.allclose(coefs, x * 0.1))
 
     def test_csr(self):
-        builder = sparse_builder.SparseBuilder(10, block_size=512)
-        builder.insert(0, 0, 1.0)
-        builder.insert(0, 1, 0.6)
-        builder.insert(1, 1, 0.4)
-        a, b, c = builder.to_csr()
-        self.assertTrue(numpy.allclose(a, numpy.array([1.0, 0.6, 0.4])))
-        self.assertTrue(numpy.allclose(b, numpy.array([0, 1, 1])))
-        self.assertTrue(numpy.allclose(c, numpy.array([0, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3])))
+        for builder in self.subtest_each_builders(10):
+            builder.insert(0, 0, 1.0)
+            builder.insert(0, 1, 0.6)
+            builder.insert(1, 1, 0.4)
+            a, b, c = builder.to_csr()
+            self.assertTrue(numpy.allclose(a, numpy.array([1.0, 0.6, 0.4])))
+            self.assertTrue(numpy.allclose(b, numpy.array([0, 1, 1])))
+            self.assertTrue(numpy.allclose(c, numpy.array([0, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3])))
 
     def test_small_tth(self):
-        shape = (512, 512)
+        shape = (256, 256)
         npt = 200
         y, x = numpy.ogrid[:shape[0], :shape[1]]
         tth = numpy.sqrt(x * x + y * y)
         maxI = 1000
         mod = 0.5 + 0.5 * numpy.cos(tth / 12) + 0.25 * numpy.cos(tth / 6) + 0.1 * numpy.cos(tth / 4)
         data = (numpy.ones(shape) * maxI * mod).astype("uint16")
+        previous_coefs, previous_indexes, previous_bin_indexes = None, None, None
 
-        builder = sparse_builder.SparseBuilder(npt, block_size=512)
-        sparse_builder.feed_histogram(builder, tth, data, npt)
-        self.assertEqual(builder.size(), shape[0] * shape[1])
+        for builder in self.subtest_each_builders(npt):
+            sparse_builder.feed_histogram(builder, tth, data, npt)
+            self.assertEqual(builder.size(), shape[0] * shape[1])
+
+            # Check consistancy of the results
+            coefs, indexes, bin_indexes = builder.to_csr()
+            if previous_coefs is not None:
+                self.assertTrue(numpy.allclose(coefs, previous_coefs))
+            if previous_indexes is not None:
+                self.assertTrue(numpy.allclose(indexes, previous_indexes))
+            if previous_bin_indexes is not None:
+                self.assertTrue(numpy.allclose(bin_indexes, previous_bin_indexes))
+            previous_coefs, previous_indexes, previous_bin_indexes = coefs, indexes, bin_indexes
 
 
 def suite():

--- a/pyFAI/test/test_sparse_builder.py
+++ b/pyFAI/test/test_sparse_builder.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import, division, print_function
 __author__ = "Valentin Valls"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/07/2018"
+__date__ = "11/07/2018"
 
 
 import unittest
@@ -82,6 +82,15 @@ class TestSparseBuilder(unittest.TestCase):
         self.assertTrue(numpy.allclose(builder.get_bin_indexes(0), numpy.array([0, 1, 2])))
         self.assertTrue(numpy.allclose(builder.get_bin_indexes(1), numpy.array([1])))
         self.assertTrue(numpy.allclose(builder.get_bin_indexes(2), numpy.array([])))
+
+    def test_block_overflow(self):
+        builder = sparse_builder.SparseBuilder(10, block_size=16)
+        for i in range(50):
+            builder.insert(0, i, i * 0.1)
+        self.assertEqual(builder.get_bin_size(0), 50)
+        x = numpy.array(range(50))
+        self.assertTrue(numpy.allclose(builder.get_bin_indexes(0), x))
+        self.assertTrue(numpy.allclose(builder.get_bin_coefs(2), x * 0.1))
 
     def test_csr(self):
         builder = sparse_builder.SparseBuilder(10, block_size=512)


### PR DESCRIPTION
This PR introduce a `SparceBuilder` to simplify part of the cython code.
This could speed up CSR and LUT matrix by generating them in a single pass.

A default image 4096x4096 is stored in 377ms and exported as CSR in 1.63s. But there is still way to improve the current code.

## Default histogram
```
In [27]: class Test(object):
    ...: 
    ...:     def __init__(self):
    ...:         import numpy
    ...:         self.shape = (4096, 4096)
    ...:         self.npt = 500
    ...:         y, x = numpy.ogrid[:self.shape[0], :self.shape[1]]
    ...:         self.tth = numpy.sqrt(x * x + y * y)
    ...:         self.maxI = 1000
    ...:         self.mod = 0.5 + 0.5 * numpy.cos(self.tth / 12) + 0.25 * numpy.cos(self.tth / 6) + 0.1 * numpy.cos(self.tth / 4)
    ...:         self.data = (numpy.ones(self.shape) * self.maxI * self.mod).astype("uint16")
    ...: 
    ...:     def time_histo(self, **kwargs):
    ...:         from pyFAI.ext import sparse_builder
    ...:         %timeit builder = sparse_builder.SparseBuilder(self.npt, **kwargs); sparse_builder.feed_histogram(builder, self.tth, self.data, self.npt)
    ...:         builder = sparse_builder.SparseBuilder(self.npt, **kwargs)
    ...:         sparse_builder.feed_histogram(builder, self.tth, self.data, self.npt)
    ...:         %timeit builder.to_csr()
    ...:         

In [28]: test = Test()

In [29]: test.time_histo(mode="stdlist")
1.34 s ± 188 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
506 ms ± 5.63 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [30]: test.time_histo(mode="block", block_size=1024 * 16)
300 ms ± 13.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
42.4 ms ± 146 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [31]: test.time_histo(mode="block", block_size=1024 * 16, heap_size=1024 * 1024)
260 ms ± 12.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
30 ms ± 201 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [32]: test.time_histo(mode="heaplist", heap_size=1024 * 1024)
220 ms ± 10.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
197 ms ± 296 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [33]: test.time_histo(mode="pack", heap_size=1024 * 1024)
206 ms ± 9.78 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
66.4 ms ± 2.49 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```


## Distortion correction

```
from pyFAI import detectors,distortion, detector_factory
spline = "/tmp/pyFAI_testdata_valls/frelon.spline"
frelon = detectors.FReLoN(spline)
dis = distortion.Distortion(frelon)
from pyFAI.ext import _distortion

# Reference implementation
# -------------------------------
%timeit dis.bin_size = None; dis.calc_size(); _distortion.calc_sparse(dis.pos, dis._shape_out, max_pixel_size=(dis.delta1, dis.delta2), format="csr")
# 651 ms ± 1.62 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Standard c++ linked list
# -------------------------------
builder_config = {"mode": "stdlist"}
%timeit dis.bin_size = None; _distortion.calc_sparse_v2(dis.pos, dis._shape_out, max_pixel_size=(dis.delta1, dis.delta2), format="csr", builder_config=builder_config)
# 1.45 s ± 6.51 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Tuple value/indices per bins
# -------------------------------
builder_config = {"mode": "block", "block_size": 4}
%timeit dis.bin_size = None; _distortion.calc_sparse_v2(dis.pos, dis._shape_out, max_pixel_size=(dis.delta1, dis.delta2), format="csr", builder_config=builder_config)
# 2.22 s ± 8.12 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Tuple value/indices per bins in shared heap block
# ------------------------------------------------
builder_config = {"mode": "block", "block_size": 8, "heap_size": 1024 * 1024}
In [13]: %timeit dis.bin_size = None; _distortion.calc_sparse_v2(dis.pos, dis._shape_out, max_pixel_size=(dis.delta1, dis.delta2), format="csr", builder_config=builder_config)
# 1.79 s ± 17.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Linked list of value/indices in shared heap block
# ------------------------------------------------
builder_config = {"mode": "heaplist", "heap_size": 1024 * 1024}
%timeit dis.bin_size = None; _distortion.calc_sparse_v2(dis.pos, dis._shape_out, max_pixel_size=(dis.delta1, dis.delta2), format="csr", builder_config=builder_config)
# 772 ms ± 4.62 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Tuple of bin/value/indices in shared heap block
# ------------------------------------------------
builder_config = {"mode": "pack", "heap_size": 1024 * 1024}
%timeit dis.bin_size = None; _distortion.calc_sparse_v2(dis.pos, dis._shape_out, max_pixel_size=(dis.delta1, dis.delta2), format="csr", builder_config=builder_config)
# 650 ms ± 8.54 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```