### PR TITLE
Deprecate legacy way of computing the mask

### DIFF
--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -291,8 +291,6 @@ class AzimuthalIntegrator(Geometry):
             mask = self.mask
         if mask is None:
             mask = numpy.zeros(shape, dtype=bool)
-        elif mask.min() < 0 and mask.max() == 0:  # 0 is valid, <0 is invalid
-            mask = (mask < 0)
         else:
             mask = mask.astype(bool)
         if self.USE_LEGACY_MASK_NORMALIZATION:

--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -49,7 +49,7 @@ from numpy import rad2deg
 from .geometry import Geometry
 from . import units
 from .utils import EPS32, deg2rad, crc32
-from .utils.decorators import deprecated
+from .utils.decorators import deprecated, deprecated_warning
 from .containers import Integrate1dResult, Integrate2dResult
 from .io import DefaultAiWriter
 error = None
@@ -297,8 +297,10 @@ class AzimuthalIntegrator(Geometry):
             mask = mask.astype(bool)
         if self.USE_LEGACY_MASK_NORMALIZATION:
             if mask.sum(dtype=int) > mask.size // 2:
-                logger.warning("Mask likely to be inverted as more"
-                               " than half pixel are masked !!!")
+                reason = "The provided mask is not complient with other engines. "\
+                    "The feature which automatically invert it will be removed soon. "\
+                    "For more information see https://github.com/silx-kit/pyFAI/pull/868"
+                deprecated_warning(__name__, name="provided mask content", reason=reason)
                 numpy.logical_not(mask, mask)
         if (mask.shape != shape):
             try:

--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/06/2018"
+__date__ = "17/07/2018"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -173,6 +173,18 @@ class AzimuthalIntegrator(Geometry):
     """
     DEFAULT_METHOD = "splitbbox"
 
+    USE_LEGACY_MASK_NORMALIZATION = True
+    """If true, the Python engine integrator will normalize the mask to use the
+    most frequent value of the mask as the non-masking value.
+
+    This behaviour is not consistant with other engines and is now deprecated.
+    This flag will be turned off in the comming releases.
+
+    Turning off this flag force the user to provide a mask with 0 as non-masking
+    value. And any non-zero as masking value (negative or positive value). A
+    boolean mask is also accepted (`True` is the masking value).
+    """
+
     def __init__(self, dist=1, poni1=0, poni2=0,
                  rot1=0, rot2=0, rot3=0,
                  pixel1=None, pixel2=None,
@@ -283,10 +295,11 @@ class AzimuthalIntegrator(Geometry):
             mask = (mask < 0)
         else:
             mask = mask.astype(bool)
-        if mask.sum(dtype=int) > mask.size // 2:
-            logger.warning("Mask likely to be inverted as more"
-                           " than half pixel are masked !!!")
-            numpy.logical_not(mask, mask)
+        if self.USE_LEGACY_MASK_NORMALIZATION:
+            if mask.sum(dtype=int) > mask.size // 2:
+                logger.warning("Mask likely to be inverted as more"
+                               " than half pixel are masked !!!")
+                numpy.logical_not(mask, mask)
         if (mask.shape != shape):
             try:
                 mask = mask[:shape[0], :shape[1]]

--- a/pyFAI/test/test_azimuthal_integrator.py
+++ b/pyFAI/test/test_azimuthal_integrator.py
@@ -393,25 +393,25 @@ class TestSaxs(unittest.TestCase):
 
     def test_positive_mask(self):
         ai = AzimuthalIntegrator()
-        data = numpy.array([[0, 1, 2, 3]])
-        mask = numpy.array([[0, 1, 1, 1]])
-        result = ai.create_mask(data, mask, mode="numpy")
-        self.assertEqual(list(result[0]), [False, True, True, True])
+        data = numpy.array([[0, 1, 2, 3, 4]])
+        mask = numpy.array([[0, 0, 0, 1, 2]])
+        result = ai.create_mask(data, mask)
+        self.assertEqual(list(result[0]), [False, False, False, True, True])
 
     def test_negative_mask(self):
         ai = AzimuthalIntegrator()
-        data = numpy.array([[0, 1, 2, 3]])
-        mask = numpy.array([[0, -1, -1, -2]])
-        result = ai.create_mask(data, mask, mode="numpy")
-        self.assertEqual(list(result[0]), [False, True, True, True])
+        data = numpy.array([[0, 1, 2, 3, 4]])
+        mask = numpy.array([[0, 0, 0, -2, -1]])
+        result = ai.create_mask(data, mask)
+        self.assertEqual(list(result[0]), [False, False, False, True, True])
 
     def test_bool_mask(self):
         ai = AzimuthalIntegrator()
         ai.USE_LEGACY_MASK_NORMALIZATION = True
-        data = numpy.array([[0, 1, 2, 3]])
-        mask = numpy.array([[False, True, True, True]])
-        result = ai.create_mask(data, mask, mode="numpy")
-        self.assertEqual(list(result[0]), [False, True, True, True])
+        data = numpy.array([[0, 1, 2, 3, 4]])
+        mask = numpy.array([[False, False, False, True, True]])
+        result = ai.create_mask(data, mask)
+        self.assertEqual(list(result[0]), [False, False, False, True, True])
 
     def test_legacy_mask(self):
         ai = AzimuthalIntegrator()

--- a/pyFAI/test/test_azimuthal_integrator.py
+++ b/pyFAI/test/test_azimuthal_integrator.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "20/02/2018"
+__date__ = "17/07/2018"
 
 import unittest
 import os
@@ -389,7 +389,29 @@ class TestSaxs(unittest.TestCase):
         data = fabio.open(self.edfPilatus).data
         mask = fabio.open(self.maskFile).data
         self.assertTrue(abs(ai.create_mask(data, mask=mask).astype(int) - fabio.open(self.maskRef).data).max() == 0, "test without dummy")
-#         self.assertTrue(abs(self.ai.create_mask(data, mask=mask, dummy=-48912, delta_dummy=40000).astype(int) - fabio.open(self.maskDummy).data).max() == 0, "test_dummy")
+        # self.assertTrue(abs(self.ai.create_mask(data, mask=mask, dummy=-48912, delta_dummy=40000).astype(int) - fabio.open(self.maskDummy).data).max() == 0, "test_dummy")
+
+    def test_positive_mask(self):
+        ai = AzimuthalIntegrator()
+        data = numpy.array([[0, 1, 2, 3]])
+        mask = numpy.array([[0, 1, 1, 1]])
+        result = ai.create_mask(data, mask, mode="numpy")
+        self.assertEqual(list(result[0]), [False, True, True, True])
+
+    def test_negative_mask(self):
+        ai = AzimuthalIntegrator()
+        data = numpy.array([[0, 1, 2, 3]])
+        mask = numpy.array([[0, -1, -1, -2]])
+        result = ai.create_mask(data, mask, mode="numpy")
+        self.assertEqual(list(result[0]), [False, True, True, True])
+
+    def test_bool_mask(self):
+        ai = AzimuthalIntegrator()
+        ai.USE_LEGACY_MASK_NORMALIZATION = True
+        data = numpy.array([[0, 1, 2, 3]])
+        mask = numpy.array([[False, True, True, True]])
+        result = ai.create_mask(data, mask, mode="numpy")
+        self.assertEqual(list(result[0]), [False, True, True, True])
 
     def test_normalization_factor(self):
 

--- a/pyFAI/test/test_azimuthal_integrator.py
+++ b/pyFAI/test/test_azimuthal_integrator.py
@@ -413,6 +413,30 @@ class TestSaxs(unittest.TestCase):
         result = ai.create_mask(data, mask, mode="numpy")
         self.assertEqual(list(result[0]), [False, True, True, True])
 
+    def test_legacy_mask(self):
+        ai = AzimuthalIntegrator()
+        ai.USE_LEGACY_MASK_NORMALIZATION = True
+        data = numpy.array([[0, 1, 2, 3]])
+        mask = numpy.array([[0, 1, 1, 1]])
+        result = ai.create_mask(data, mask, mode="numpy")
+        self.assertEqual(list(result[0]), [False, True, True, True])
+        data = numpy.array([[0, 1, 2, 3]])
+        mask = numpy.array([[1, 0, 0, 0]])
+        result = ai.create_mask(data, mask, mode="numpy")
+        self.assertEqual(list(result[0]), [False, True, True, True])
+
+    def test_no_legacy_mask(self):
+        ai = AzimuthalIntegrator()
+        ai.USE_LEGACY_MASK_NORMALIZATION = False
+        data = numpy.array([[0, 1, 2, 3]])
+        mask = numpy.array([[0, 1, 1, 1]])
+        result = ai.create_mask(data, mask, mode="numpy")
+        self.assertEqual(list(result[0]), [True, False, False, False])
+        data = numpy.array([[0, 1, 2, 3]])
+        mask = numpy.array([[1, 0, 0, 0]])
+        result = ai.create_mask(data, mask, mode="numpy")
+        self.assertEqual(list(result[0]), [False, True, True, True])
+
     def test_normalization_factor(self):
 
         ai = AzimuthalIntegrator(detector="Pilatus100k")


### PR DESCRIPTION
A legacy code on the Python azimuthal integrator engine was able to deal automatically with masking value `=1` or `=0`. This feature was based on data of the mask, considering it should contain less masked pixels than non-masking pixels and inverting the data if it was not the case.

Here is the code
```
# mask is a bool array here
if mask.sum(dtype=int) > mask.size // 2:
    numpy.logical_not(mask, mask)
```

It is a legacy code, but:

- This feature is only active for the Python engine
- Then it is not consistent with other engine (and could introduce inconsistencies if we switch from one to another)
- On some rare cases the user expect to mask more pixels than available pixels
- It is kind of magic

We decide to remove this feature and make it simpler.

This PR introduce:
- A deprecation warning in case the feature is used, asking people to fix the mask.
- Introduce a boolean class attribute `USE_LEGACY_MASK_NORMALIZATION` to `AzimuthalIntegrator` classes. Right now it is set to `True`. This allow people to turn it off if the feature was doing the reverse as expected.
- Introduce some regression tests

It will allow to set `USE_LEGACY_MASK_NORMALIZATION` to false soon.

Close #404