### PR TITLE
close #903

### DIFF
--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -39,7 +39,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/07/2018"
+__date__ = "29/08/2018"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -1165,11 +1165,15 @@ class Geometry(object):
         if "detector" in data:
             self.detector = detectors.detector_factory(data["detector"],
                                                        data.get("detector_config"))
+            if isinstance(self.detector, detectors.NexusDetector):
+                # increment the poni_version for Nexus detector as no further config is needed!
+                version += 1
         else:
             self.detector = detectors.Detector()
         if version == 1:
             # Handle former version of PONI-file
-            if self.detector.force_pixel and ("pixelsize1" in data) and ("pixelsize2" in data):
+            if self.detector.force_pixel and \
+                    ("pixelsize1" in data) and ("pixelsize2" in data):
                 pixel1 = float(data["pixelsize1"])
                 pixel2 = float(data["pixelsize2"])
                 self.detector = self.detector.__class__(pixel1=pixel1, pixel2=pixel2)

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -1167,7 +1167,7 @@ class Geometry(object):
                                                        data.get("detector_config"))
             if isinstance(self.detector, detectors.NexusDetector):
                 # increment the poni_version for Nexus detector as no further config is needed!
-                version += 1
+                version = max(2, version)
         else:
             self.detector = detectors.Detector()
         if version == 1:


### PR DESCRIPTION
The error was:
```
In [7]: ai=pyFAI.load('18Aug29D5_0066.poni')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-7-3da680aacbdd> in <module>()
----> 1 ai=pyFAI.load('18Aug29D5_0066.poni')

/usr/lib/python2.7/dist-packages/pyFAI/__init__.pyc in load(filename)
     82     """
     83     from .azimuthalIntegrator import AzimuthalIntegrator
---> 84     return AzimuthalIntegrator.sload(filename)
     85 
     86 

/usr/lib/python2.7/dist-packages/pyFAI/geometry.pyc in sload(cls, filename)
   1138         """
   1139         inst = cls()
-> 1140         inst.load(filename)
   1141         return inst
   1142 

/usr/lib/python2.7/dist-packages/pyFAI/geometry.pyc in load(self, filename)
   1173                 pixel1 = float(data["pixelsize1"])
   1174                 pixel2 = float(data["pixelsize2"])
-> 1175                 self.detector = self.detector.__class__(pixel1=pixel1, pixel2=pixel2)
   1176             else:
   1177                 if "pixelsize1" in data:

TypeError: __init__() got an unexpected keyword argument 'pixel2'

```
because the nexus detector does not take "pixel1/pixel2" as parameter. So just pretend they are newer !