### PR TITLE
Fixes few usability problems

### DIFF
--- a/pyFAI/gui/calibration/DetectorSelectorDrop.py
+++ b/pyFAI/gui/calibration/DetectorSelectorDrop.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/10/2018"
+__date__ = "21/11/2018"
 
 import os
 import logging
@@ -64,6 +64,8 @@ class DetectorSelectorDrop(qt.QWidget):
         self._manufacturerList.setModel(model)
         selection = self._manufacturerList.selectionModel()
         selection.selectionChanged.connect(self.__manufacturerChanged)
+        manufacturerModel = model
+        manufacturerSelection = selection
 
         model = AllDetectorModel(self)
         modelFilter = DetectorFilter(self)
@@ -120,6 +122,10 @@ class DetectorSelectorDrop(qt.QWidget):
         self.__pixelWidth.changed.connect(self.__customDetectorChanged)
         self.__pixelHeight.changed.connect(self.__customDetectorChanged)
         self.__customDetector = None
+
+        # By default select all the manufacturers
+        allIndex = manufacturerModel.index(0, 0)
+        manufacturerSelection.select(allIndex, qt.QItemSelectionModel.ClearAndSelect)
 
     def __splineFileChanged(self):
         splineFile = self.__splineFile.value()

--- a/pyFAI/gui/calibration/ExperimentTask.py
+++ b/pyFAI/gui/calibration/ExperimentTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/10/2018"
+__date__ = "21/11/2018"
 
 import fabio
 import numpy
@@ -66,6 +66,7 @@ class ExperimentTask(AbstractCalibrationTask):
         self._customDetector.clicked.connect(self.__customDetector)
 
         self.__plot = self.__createPlot(parent=self._imageHolder)
+        self.__plot.setObjectName("plot-experiment")
         layout = qt.QVBoxLayout(self._imageHolder)
         layout.addWidget(self.__plot)
         layout.setContentsMargins(1, 1, 1, 1)

--- a/pyFAI/gui/calibration/GeometryTask.py
+++ b/pyFAI/gui/calibration/GeometryTask.py
@@ -80,6 +80,8 @@ class ConstraintsPopup(qt.QFrame):
         else:
             value = range_[0]
         self.__min.setValue(value)
+        if value > self.__max.value():
+            self.__max.setValue(value)
         self.__useDefaultMin = True
         self.__updateData()
 
@@ -90,6 +92,8 @@ class ConstraintsPopup(qt.QFrame):
         else:
             value = range_[1]
         self.__max.setValue(value)
+        if self.__min.value() > value:
+            self.__min.setValue(value)
         self.__useDefaultMax = True
         self.__updateData()
 
@@ -113,10 +117,14 @@ class ConstraintsPopup(qt.QFrame):
 
     def __validateMinConstraint(self):
         self.__useDefaultMin = False
+        if self.__min.value() > self.__max.value():
+            self.__min.setValue(self.__max.value())
         self.__updateData()
 
     def __validateMaxConstraint(self):
         self.__useDefaultMax = False
+        if self.__min.value() > self.__max.value():
+            self.__max.setValue(self.__min.value())
         self.__updateData()
 
     def labelCenter(self):

--- a/pyFAI/gui/calibration/GeometryTask.py
+++ b/pyFAI/gui/calibration/GeometryTask.py
@@ -904,7 +904,12 @@ class GeometryTask(AbstractCalibrationTask):
             calibration = self.__getCalibration()
             if calibration is None:
                 return
-            calibration.init(peaks, "massif")
+
+            # Constraints defined by the GUI
+            constraints = self.model().geometryConstraintsModel().copy(self)
+            constraints.fillDefault(calibration.defaultGeometryConstraintsModel())
+
+            calibration.init(peaks, "massif", constraints)
             calibration.toGeometryModel(self.model().peakGeometry())
             self.__defaultConstraints.set(calibration.defaultGeometryConstraintsModel())
             self.__peaksInvalidated = False

--- a/pyFAI/gui/calibration/GeometryTask.py
+++ b/pyFAI/gui/calibration/GeometryTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/11/2018"
+__date__ = "21/11/2018"
 
 import logging
 import numpy
@@ -661,6 +661,7 @@ class GeometryTask(AbstractCalibrationTask):
         self.widgetShow.connect(self.__widgetShow)
 
         self.__plot = self.__createPlot()
+        self.__plot.setObjectName("plot-fit")
         self.__plot.sigMouseMove.connect(self.__mouseMoved)
         self.__plot.sigMouseLeave.connect(self.__mouseLeft)
 

--- a/pyFAI/gui/calibration/GeometryTask.py
+++ b/pyFAI/gui/calibration/GeometryTask.py
@@ -860,7 +860,8 @@ class GeometryTask(AbstractCalibrationTask):
                                       wavelength,
                                       peaks=peaks,
                                       method="massif")
-        calibration.toGeometryConstraintsModel(self.__defaultConstraints)
+        # Copy the default values
+        self.__defaultConstraints.set(calibration.defaultGeometryConstraintsModel())
         return calibration
 
     def __invalidateWavelength(self):
@@ -905,7 +906,7 @@ class GeometryTask(AbstractCalibrationTask):
                 return
             calibration.init(peaks, "massif")
             calibration.toGeometryModel(self.model().peakGeometry())
-            calibration.toGeometryConstraintsModel(self.__defaultConstraints)
+            self.__defaultConstraints.set(calibration.defaultGeometryConstraintsModel())
             self.__peaksInvalidated = False
 
         self.model().fittedGeometry().setFrom(self.model().peakGeometry())

--- a/pyFAI/gui/calibration/GeometryTask.py
+++ b/pyFAI/gui/calibration/GeometryTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "21/11/2018"
+__date__ = "22/11/2018"
 
 import logging
 import numpy
@@ -860,7 +860,7 @@ class GeometryTask(AbstractCalibrationTask):
                                       wavelength,
                                       peaks=peaks,
                                       method="massif")
-        calibration.toGeometryConstriansModel(self.__defaultConstraints)
+        calibration.toGeometryConstraintsModel(self.__defaultConstraints)
         return calibration
 
     def __invalidateWavelength(self):
@@ -905,7 +905,7 @@ class GeometryTask(AbstractCalibrationTask):
                 return
             calibration.init(peaks, "massif")
             calibration.toGeometryModel(self.model().peakGeometry())
-            calibration.toGeometryConstriansModel(self.__defaultConstraints)
+            calibration.toGeometryConstraintsModel(self.__defaultConstraints)
             self.__peaksInvalidated = False
 
         self.model().fittedGeometry().setFrom(self.model().peakGeometry())
@@ -968,7 +968,7 @@ class GeometryTask(AbstractCalibrationTask):
 
         constraints = self.model().geometryConstraintsModel().copy(self)
         constraints.fillDefault(self.__defaultConstraints)
-        calibration.fromGeometryConstriansModel(constraints)
+        calibration.fromGeometryConstraintsModel(constraints)
 
         calibration.refine()
         # write result to the fitted model

--- a/pyFAI/gui/calibration/MaskTask.py
+++ b/pyFAI/gui/calibration/MaskTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "15/10/2018"
+__date__ = "21/11/2018"
 
 import logging
 import os.path
@@ -115,6 +115,7 @@ class MaskTask(AbstractCalibrationTask):
         self.initNextStep()
 
         self.__plot = self.__createPlot(self._imageHolder)
+        self.__plot.setObjectName("plot-mask")
 
         markerModel = CalibrationContext.instance().getCalibrationModel().markerModel()
         self.__markerManager = MarkerManager(self.__plot, markerModel, pixelBasedPlot=True)

--- a/pyFAI/gui/calibration/PeakPickingTask.py
+++ b/pyFAI/gui/calibration/PeakPickingTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "21/11/2018"
+__date__ = "22/11/2018"
 
 import logging
 import numpy
@@ -898,6 +898,14 @@ class PeakPickingTask(AbstractCalibrationTask):
         qt.QTimer.singleShot(1, self.__autoExtractRings)
 
     def __autoExtractRings(self):
+        try:
+            self.__autoExtractRingsCompute()
+        finally:
+            self.__plot.unsetProcessing()
+            qt.QApplication.restoreOverrideCursor()
+            self._extract.setWaiting(False)
+
+    def __autoExtractRingsCompute(self):
         maxRings = self._maxRingToExtract.value()
         pointPerDegree = self._numberOfPeakPerDegree.value()
 
@@ -929,15 +937,31 @@ class PeakPickingTask(AbstractCalibrationTask):
 
         extractor = RingExtractor(image, mask, calibrant, detector, wavelength)
 
-        # FIXME numpy array can be allocated first
-        peaks = []
-        for peakModel in self.model().peakSelectionModel():
-            ringNumber = peakModel.ringNumber()
-            for coord in peakModel.coords():
-                peaks.append([coord[0], coord[1], ringNumber - 1])
-        peaks = numpy.array(peaks)
+        # Constant dependant of the ui file
+        FROM_PEAKS = 0
+        FROM_FIT = 1
+
+        geometrySourceIndex = self._geometrySource.currentIndex()
+        if geometrySourceIndex == FROM_PEAKS:
+            # FIXME numpy array can be allocated first
+            peaks = []
+            for peakModel in self.model().peakSelectionModel():
+                ringNumber = peakModel.ringNumber()
+                for coord in peakModel.coords():
+                    peaks.append([coord[0], coord[1], ringNumber - 1])
+            peaks = numpy.array(peaks)
+            geometryModel = None
+        elif geometrySourceIndex == FROM_FIT:
+            peaks = None
+            geometryModel = self.model().fittedGeometry()
+            if not geometryModel.isValid():
+                _logger.error("The fitted model is not valid. Extraction cancelled.")
+                return
+        else:
+            assert(False)
 
         newPeaksRaw = extractor.extract(peaks=peaks,
+                                        geometryModel=geometryModel,
                                         method="massif",
                                         maxRings=maxRings,
                                         pointPerDegree=pointPerDegree)
@@ -965,9 +989,6 @@ class PeakPickingTask(AbstractCalibrationTask):
         command.setRedoInhibited(True)
         self.__undoStack.push(command)
         command.setRedoInhibited(False)
-        self.__plot.unsetProcessing()
-        qt.QApplication.restoreOverrideCursor()
-        self._extract.setWaiting(False)
 
     def __getImageValue(self, x, y):
         """Get value of top most image at position (x, y).

--- a/pyFAI/gui/calibration/PeakPickingTask.py
+++ b/pyFAI/gui/calibration/PeakPickingTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "25/10/2018"
+__date__ = "21/11/2018"
 
 import logging
 import numpy
@@ -515,6 +515,7 @@ class PeakPickingTask(AbstractCalibrationTask):
         # Insert the plot on the layout
         holder = self._plotHolder
         self.__plot = _PeakPickingPlot(parent=holder)
+        self.__plot.setObjectName("plot-picking")
         holderLayout = qt.QVBoxLayout(holder)
         holderLayout.setContentsMargins(1, 1, 1, 1)
         holderLayout.addWidget(self.__plot)

--- a/pyFAI/gui/calibration/RingCalibration.py
+++ b/pyFAI/gui/calibration/RingCalibration.py
@@ -336,15 +336,15 @@ class RingCalibration(object):
         assert(self.__defaultConstraints is not None)
         return self.__defaultConstraints
 
-    def fromGeometryConstraintsModel(self, contraintsModel):
+    def fromGeometryConstraintsModel(self, constraintsModel):
         attrs = [
-            ("wavelength", contraintsModel.wavelength()),
-            ("dist", contraintsModel.distance()),
-            ("poni1", contraintsModel.poni1()),
-            ("poni2", contraintsModel.poni2()),
-            ("rot1", contraintsModel.rotation1()),
-            ("rot2", contraintsModel.rotation2()),
-            ("rot3", contraintsModel.rotation3()),
+            ("wavelength", constraintsModel.wavelength()),
+            ("dist", constraintsModel.distance()),
+            ("poni1", constraintsModel.poni1()),
+            ("poni2", constraintsModel.poni2()),
+            ("rot1", constraintsModel.rotation1()),
+            ("rot2", constraintsModel.rotation2()),
+            ("rot3", constraintsModel.rotation3()),
         ]
         fixed = pyFAI.utils.FixedParameters()
         bounds = {}

--- a/pyFAI/gui/calibration/RingCalibration.py
+++ b/pyFAI/gui/calibration/RingCalibration.py
@@ -328,6 +328,14 @@ class RingCalibration(object):
             if name in self.__fixed:
                 constraint.setFixed()
 
+    def defaultGeometryConstraintsModel(self):
+        """Returns the default constraints
+
+        Not the one used, but the one initially set to the refinement engine.
+        """
+        assert(self.__defaultConstraints is not None)
+        return self.__defaultConstraints
+
     def fromGeometryConstraintsModel(self, contraintsModel):
         attrs = [
             ("wavelength", contraintsModel.wavelength()),

--- a/pyFAI/gui/calibration/RingCalibration.py
+++ b/pyFAI/gui/calibration/RingCalibration.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/11/2018"
+__date__ = "22/11/2018"
 
 import logging
 import numpy
@@ -303,7 +303,7 @@ class RingCalibration(object):
             self.__previousRms = None
             self.__rms = None
 
-    def toGeometryConstriansModel(self, contraintsModel, reachFromGeoRef=True):
+    def toGeometryConstraintsModel(self, contraintsModel, reachFromGeoRef=True):
         if reachFromGeoRef is False:
             raise NotImplementedError("Not implemented")
         attrs = [
@@ -323,7 +323,7 @@ class RingCalibration(object):
             if name in self.__fixed:
                 constraint.setFixed()
 
-    def fromGeometryConstriansModel(self, contraintsModel):
+    def fromGeometryConstraintsModel(self, contraintsModel):
         attrs = [
             ("wavelength", contraintsModel.wavelength()),
             ("dist", contraintsModel.distance()),

--- a/pyFAI/gui/calibration/RingCalibration.py
+++ b/pyFAI/gui/calibration/RingCalibration.py
@@ -36,6 +36,7 @@ import collections
 from silx.image import marchingsquares
 import pyFAI.utils
 from ...geometryRefinement import GeometryRefinement
+from .model.GeometryConstraintsModel import GeometryConstraintsModel
 from ..peak_picker import PeakPicker
 from ..utils import timeutils
 
@@ -60,6 +61,7 @@ class RingCalibration(object):
         self.__rms = None
         self.__previousRms = None
         self.__peakResidual = None
+        self.__defaultConstraints = None
 
     def __initgeoRef(self):
         """
@@ -109,6 +111,9 @@ class RingCalibration(object):
 
         self.__peakPicker = peakPicker
         self.__geoRef = geoRef
+        # Store the default constraints
+        self.__defaultConstraints = GeometryConstraintsModel()
+        self.toGeometryConstraintsModel(self.__defaultConstraints)
 
     def init(self, peaks, method):
         self.__init(peaks, method)

--- a/pyFAI/gui/calibration/model/GeometryConstraintsModel.py
+++ b/pyFAI/gui/calibration/model/GeometryConstraintsModel.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/11/2018"
+__date__ = "22/11/2018"
 
 from .AbstractModel import AbstractModel
 from .ConstraintModel import ConstraintModel
@@ -106,6 +106,21 @@ class GeometryConstraintsModel(AbstractModel):
         model.rotation2().set(self.__rotation2)
         model.rotation3().set(self.__rotation3)
         return model
+
+    def set(self, other):
+        """Set this geometry constraints with the other informations.
+
+        :param GeometryConstraintsModel other:
+        """
+        self.lockSignals()
+        self.distance().set(other.distance())
+        self.wavelength().set(other.wavelength())
+        self.poni1().set(other.poni1())
+        self.poni2().set(other.poni2())
+        self.rotation1().set(other.rotation1())
+        self.rotation2().set(other.rotation2())
+        self.rotation3().set(other.rotation3())
+        self.unlockSignals()
 
     def fillDefault(self, other):
         """Fill unset values of this model with the other model

--- a/pyFAI/gui/calibration/model/GeometryConstraintsModel.py
+++ b/pyFAI/gui/calibration/model/GeometryConstraintsModel.py
@@ -68,6 +68,7 @@ class GeometryConstraintsModel(AbstractModel):
             return False
         if not self.__rotation3.isValid():
             return False
+        return True
 
     def distance(self):
         return self.__distance

--- a/pyFAI/gui/calibration/model/PlotViewModel.py
+++ b/pyFAI/gui/calibration/model/PlotViewModel.py
@@ -72,8 +72,13 @@ class PlotViewModel(DataModel):
     def setFromPlot(self, plot):
         pixelSize = self.__getPixelSize(plot)
         dataCoordAtPixelCoordZero = numpy.array(plot.pixelToData(x=0, y=0))
-        direction = plot.getYAxis().isInverted()
-        value = dataCoordAtPixelCoordZero, pixelSize, direction
+        isYaxisInverted = plot.getYAxis().isInverted()
+        isKeepAspectRatio = plot.isKeepDataAspectRatio()
+        interactionMode = plot.getInteractiveMode()["mode"]
+        if interactionMode not in set(['pan', 'zoom']):
+            interactionMode = 'pan'
+        plotConfig = isYaxisInverted, isKeepAspectRatio, interactionMode
+        value = dataCoordAtPixelCoordZero, pixelSize, plotConfig
         self.setValue(value)
 
     def __setViewLocation(self, plot, coord1, coord2):
@@ -88,10 +93,19 @@ class PlotViewModel(DataModel):
         xAxis.setLimits(*xLimits)
         yAxis.setLimits(*yLimits)
 
-    def synchronizePlot(self, plot):
+    def synchronizePlotConfig(self, plot):
         value = self.value()
-        dataCoordAtPixelCoordZero, pixelSize, direction = value
-        if not direction:
+        plotConfig = value[2]
+        isYaxisInverted, isKeepAspectRatio, interactionMode = plotConfig
+        plot.setKeepDataAspectRatio(isKeepAspectRatio)
+        plot.getYAxis().setInverted(isYaxisInverted)
+        plot.setInteractiveMode(interactionMode)
+
+    def synchronizePlotView(self, plot):
+        value = self.value()
+        dataCoordAtPixelCoordZero, pixelSize, plotConfig = value
+        isYaxisInverted = plotConfig[0]
+        if not isYaxisInverted:
             # Coord of pixel and data are switched sometimes
             pixelSize = numpy.array([pixelSize[0], -pixelSize[1]])
 

--- a/pyFAI/gui/utils/FilterBuilder.py
+++ b/pyFAI/gui/utils/FilterBuilder.py
@@ -30,7 +30,7 @@ from __future__ import division
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/10/2018"
+__date__ = "21/11/2018"
 
 import functools
 import collections
@@ -50,7 +50,7 @@ class FilterBuilder(object):
 
     def __normalizeExtensions(self, extensions):
         if isinstance(extensions, list):
-            list(extensions)
+            extensions = list(extensions)
         else:
             extensions = extensions.split(" ")
         return extensions
@@ -93,8 +93,8 @@ class FilterBuilder(object):
             allExtensions = " ".join(allExtensions)
             filters.append("All supported files (%s)" % allExtensions)
         for description, extensions in self.__formats.items():
-            extensions = ["*.%s" % ext for ext in allExtensions]
-            extensions = " ".join(allExtensions)
+            extensions = ["*.%s" % ext for ext in extensions]
+            extensions = " ".join(extensions)
             filters.append("%s (%s)" % (description, extensions))
         if self.__any:
             filters.append("All files (*)")

--- a/pyFAI/gui/widgets/CalibrantSelector.py
+++ b/pyFAI/gui/widgets/CalibrantSelector.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "16/10/2018"
+__date__ = "22/11/2018"
 
 import os.path
 
@@ -46,7 +46,7 @@ class CalibrantSelector(qt.QComboBox):
 
         # feed the widget with default calibrants
         items = pyFAI.calibrant.CALIBRANT_FACTORY.items()
-        items = sorted(items)
+        items = sorted(items, key=lambda x: x[0].lower())
         for calibrantName, calibrant in items:
             self.addItem(calibrantName, calibrant)
             icon = icons.getQIcon("pyfai:gui/icons/calibrant")

--- a/pyFAI/resources/gui/calibration-peakpicking.ui
+++ b/pyFAI/resources/gui/calibration-peakpicking.ui
@@ -90,6 +90,26 @@
          <string>Recalibrate</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_10">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_103">
+           <property name="text">
+            <string>Extract rings from 1st to:</string>
+           </property>
+           <property name="buddy">
+            <cstring>_maxRingToExtract</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1" colspan="2">
+          <widget class="QDoubleSpinBox" name="_numberOfPeakPerDegree">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
          <item row="3" column="0">
           <widget class="QLabel" name="label_104">
            <property name="text">
@@ -116,17 +136,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_103">
-           <property name="text">
-            <string>Max rings to extract:</string>
-           </property>
-           <property name="buddy">
-            <cstring>_maxRingToExtract</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="3">
+         <item row="5" column="0" colspan="3">
           <widget class="WaitingPushButton" name="_extract">
            <property name="minimumSize">
             <size>
@@ -139,14 +149,25 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1" colspan="2">
-          <widget class="QDoubleSpinBox" name="_numberOfPeakPerDegree">
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Guess geometry from:</string>
            </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
+          </widget>
+         </item>
+         <item row="4" column="1" colspan="2">
+          <widget class="QComboBox" name="_geometrySource">
+           <item>
+            <property name="text">
+             <string>Control points</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Fit screen</string>
+            </property>
+           </item>
           </widget>
          </item>
         </layout>

--- a/pyFAI/resources/gui/constraint-drop.ui
+++ b/pyFAI/resources/gui/constraint-drop.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>387</width>
-    <height>89</height>
+    <height>110</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -64,19 +64,22 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QPushButton" name="_resetMin">
      <property name="text">
       <string>Reset to default</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="5">
+   <item row="2" column="5">
     <widget class="QPushButton" name="_resetMax">
      <property name="text">
       <string>Reset to default</string>
      </property>
     </widget>
+   </item>
+   <item row="1" column="1" colspan="5">
+    <widget class="RangeSlider" name="_slider" native="true"/>
    </item>
   </layout>
  </widget>
@@ -90,6 +93,12 @@
    <class>UnitLabel</class>
    <extends>QLabel</extends>
    <header>pyFAI.gui.widgets.UnitLabel</header>
+  </customwidget>
+  <customwidget>
+   <class>RangeSlider</class>
+   <extends>QWidget</extends>
+   <header>silx.gui.widgets.RangeSlider</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
- Allow to extract peaks using the fitted geometry (combo box to select the behaviour)
- Fix refitting now take care of the constraints (i.e. rot3 fixed to 0 remains at 0 after the refit)
- Sync the view of all the plots in order to see exactly the same pixels of the image at the same place of the screen (there is still a blink frame, but we can't do much with the current silx implementation)
- Sync config of all the plots (y-orientation, aspect ratio, interactive mode)
- Fix issue with constraints range not ordered (min>max)
- Add a slider for the range constraint
- Fix empty initialization of the detector selector
- Fix extensions displayed in most file dialogs

Closes #969 
Closes #996 
Closes #1006 
Closes #981 
Closes #990