### PR TITLE
Fix guess poni

### DIFF
--- a/pyFAI/gui/calibration/RingCalibration.py
+++ b/pyFAI/gui/calibration/RingCalibration.py
@@ -134,7 +134,6 @@ class RingCalibration(object):
         self.__wavelength = wavelength
         self.__rms = None
         self.__previousRms = None
-        self.__peakResidual = None
         self.__defaultConstraints = None
 
         self.__init(peaks, method)
@@ -186,7 +185,6 @@ class RingCalibration(object):
             self.fromGeometryConstraintsModel(constraintsModel)
 
         self.__rms = self.__geoRef.refine(1000000)
-        self.__peakResidual = self.__rms
         self.__previousRms = None
 
         peakPicker = PeakPicker(data=self.__image,
@@ -262,10 +260,6 @@ class RingCalibration(object):
         The unit is the radian.
         """
         return self.__previousRms
-
-    def getPeakResidual(self):
-        """Returns the residual computed from the peak selection."""
-        return self.__peakResidual
 
     def getTwoThetaArray(self):
         """

--- a/pyFAI/gui/calibration/RingCalibration.py
+++ b/pyFAI/gui/calibration/RingCalibration.py
@@ -216,7 +216,7 @@ class RingCalibration(object):
         parameters = geoRef.getParams()
         scores.append((score, parameters, rms))
 
-        # ReachUse the better one
+        # Use the better one
         scores.sort()
         _score, parameters, rms = scores[0]
         geoRef.setParams(parameters)

--- a/pyFAI/gui/calibration/RingCalibration.py
+++ b/pyFAI/gui/calibration/RingCalibration.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "23/11/2018"
+__date__ = "04/12/2018"
 
 import logging
 import numpy
@@ -49,6 +49,8 @@ class GeometryRefinementContext(object):
     Right now, GeometryRefinement store the bound but do not store the fixed
     constraints. It make the context difficult to manage and to trust.
     """
+
+    PARAMETERS = ["wavelength", "dist", "poni1", "poni2", "rot1", "rot2", "rot3"]
 
     def __init__(self, *args, **kwargs):
         self.__geoRef = GeometryRefinement(*args, **kwargs)
@@ -83,6 +85,15 @@ class GeometryRefinementContext(object):
 
     def setBounds(self, bounds):
         self.__bounds = bounds
+
+    def setParams(self, params):
+        """Set the fit parameter values from the list of values"""
+        for value, name in zip(params, self.PARAMETERS):
+            setattr(self.__geoRef, name, value)
+
+    def getParams(self):
+        """Returns list of parameters"""
+        return [getattr(self.__geoRef, p) for p in self.PARAMETERS]
 
     def chi2(self):
         if "wavelength" in self.__fixed:


### PR DESCRIPTION
The first guess from the peak was not using `guess_poni`.

Now it was fixed as it is done in the peak extraction.

Returning the better of 2 passes with and without `guess_poni`.