### PR TITLE
Deprecated comma list file

### DIFF
--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "11/12/2018"
+__date__ = "14/12/2018"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -3109,6 +3109,7 @@ class AzimuthalIntegrator(Geometry):
 
     flatfield = property(get_flatfield, set_flatfield)
 
+    @deprecated(reason="Not maintained", since_version="0.17")
     def set_darkfiles(self, files=None, method="mean"):
         """Set the dark current from one or mutliple files, avaraged
         according to the method provided.
@@ -3123,9 +3124,11 @@ class AzimuthalIntegrator(Geometry):
         self.detector.set_darkfiles(files, method)
 
     @property
+    @deprecated(reason="Not maintained", since_version="0.17")
     def darkfiles(self):
         return self.detector.darkfiles
 
+    @deprecated(reason="Not maintained", since_version="0.17")
     def set_flatfiles(self, files, method="mean"):
         """Set the flat field from one or mutliple files, averaged
         according to the method provided.
@@ -3140,6 +3143,7 @@ class AzimuthalIntegrator(Geometry):
         self.detector.set_flatfiles(files, method)
 
     @property
+    @deprecated(reason="Not maintained", since_version="0.17")
     def flatfiles(self):
         return self.detector.flatfiles
 

--- a/pyFAI/detectors/_common.py
+++ b/pyFAI/detectors/_common.py
@@ -35,7 +35,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "19/11/2018"
+__date__ = "14/12/2018"
 __status__ = "stable"
 
 
@@ -53,6 +53,7 @@ from .. import utils
 from .. import average
 from ..utils import binning, expand2d, crc32
 from ..third_party.six import with_metaclass
+from ..utils.decorators import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -900,6 +901,7 @@ class Detector(with_metaclass(DetectorMeta, object)):
 
     flatfield = property(get_flatfield, set_flatfield)
 
+    @deprecated(reason="Not maintained", since_version="0.17")
     def set_flatfiles(self, files, method="mean"):
         """
         :param files: file(s) used to compute the flat-field.
@@ -937,6 +939,7 @@ class Detector(with_metaclass(DetectorMeta, object)):
 
     darkcurrent = property(get_darkcurrent, set_darkcurrent)
 
+    @deprecated(reason="Not maintained", since_version="0.17")
     def set_darkfiles(self, files=None, method="mean"):
         """
         :param files: file(s) used to compute the dark.

--- a/pyFAI/detectors/_common.py
+++ b/pyFAI/detectors/_common.py
@@ -660,10 +660,10 @@ class Detector(with_metaclass(DetectorMeta, object)):
 
     def set_pixel_corners(self, ary):
         """Sets the position of pixel corners with some additional validation
-        
-        :param ary: This a 4D array which contains: number of lines, 
-                                                    number of columns, 
-                                                    corner index, 
+
+        :param ary: This a 4D array which contains: number of lines,
+                                                    number of columns,
+                                                    corner index,
                                                     position in space Z, Y, X
         """
         if ary is None:

--- a/pyFAI/gui/test/test_integrate_widget.py
+++ b/pyFAI/gui/test/test_integrate_widget.py
@@ -34,7 +34,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "13/12/2018"
+__date__ = "17/12/2018"
 
 import os
 import sys
@@ -44,6 +44,7 @@ import logging
 
 from silx.gui import qt
 from ...gui.IntegrationDialog import IntegrationDialog
+from ...gui.widgets.WorkerConfigurator import WorkerConfigurator
 from pyFAI.test.utilstest import UtilsTest
 
 logger = logging.getLogger(__name__)
@@ -136,6 +137,24 @@ class TestIntegrationDialog(unittest.TestCase):
         self.assertEqual(len(result[0]), len(expected[0]))
         for i in range(len(result[0])):
             numpy.testing.assert_array_almost_equal(result[0][i], expected[0][i], decimal=1)
+
+    def test_config_flatdark_v1(self):
+        dico = {"dark_current": "a,b,c",
+                "flat_field": "a,b,d"}
+        widget = WorkerConfigurator()
+        widget.setConfig(dico)
+        dico = widget.getConfig()
+        self.assertEqual(dico["dark_current"], ["a", "b", "c"])
+        self.assertEqual(dico["flat_field"], ["a", "b", "d"])
+
+    def test_config_flatdark_v2(self):
+        dico = {"dark_current": ["a", "b", "c"],
+                "flat_field": ["a", "b", "d"]}
+        widget = WorkerConfigurator()
+        widget.setConfig(dico)
+        dico = widget.getConfig()
+        self.assertEqual(dico["dark_current"], ["a", "b", "c"])
+        self.assertEqual(dico["flat_field"], ["a", "b", "d"])
 
 
 def suite():

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -328,7 +328,7 @@ class WorkerConfigurator(qt.QWidget):
             if filenames is None:
                 return ""
             if isinstance(filenames, list):
-                return ",".join()
+                return ",".join(filenames)
             if "," in filenames:
                 logger.warning("Dark or flat files are described using comma separator list. You should use a python/json list of string instead.")
             filenames = filenames.strip()

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "14/12/2018"
+__date__ = "17/12/2018"
 __status__ = "development"
 
 import logging
@@ -64,7 +64,7 @@ class WorkerConfigurator(qt.QWidget):
     param of the ~`pyFAI.worker.Worker`.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent=None):
         qt.QWidget.__init__(self, parent)
         filename = get_ui_file("worker-configurator.ui")
         qt.loadUi(filename, self)

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -225,8 +225,9 @@ class WorkerConfigurator(qt.QWidget):
         if value is not None:
             config["nbpt_azim"] = value
 
-        config["detector"] = self.__detector.__class__.__name__
-        config["detector_config"] = self.__detector.get_config()
+        if self.__detector is not None:
+            config["detector"] = self.__detector.__class__.__name__
+            config["detector_config"] = self.__detector.get_config()
 
         return config
 

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "13/12/2018"
+__date__ = "14/12/2018"
 __status__ = "development"
 
 import logging
@@ -173,6 +173,17 @@ class WorkerConfigurator(qt.QWidget):
 
         :return: dict with all information.
         """
+        def splitFiles(filenames):
+            """In case files was provided with comma.
+
+            The file brower was in this case not working, but the returned
+            config will be valid.
+            """
+            filenames = filenames.strip()
+            if filenames == "":
+                return None
+            return [name.strip() for name in filenames.split(",")]
+
         config = {"version": 2,
                   "application": "pyfai-integrate",
                   "wavelength": self.__geometryModel.wavelength().value(),
@@ -190,8 +201,8 @@ class WorkerConfigurator(qt.QWidget):
                   "val_dummy": self._float("val_dummy", None),
                   "delta_dummy": self._float("delta_dummy", None),
                   "mask_file": str_(self.mask_file.text()).strip(),
-                  "dark_current": str_(self.dark_current.text()).strip(),
-                  "flat_field": str_(self.flat_field.text()).strip(),
+                  "dark_current": splitFiles(self.dark_current.text()),
+                  "flat_field": splitFiles(self.flat_field.text()),
                   "polarization_factor": float_(self.polarization_factor.value()),
                   "do_2D": bool(self.do_2D.isChecked()),
                   "chi_discontinuity_at_0": bool(self.chi_discontinuity_at_0.isChecked()),
@@ -307,6 +318,21 @@ class WorkerConfigurator(qt.QWidget):
 
             self.setDetector(detector)
 
+        def normalizeFiles(filenames):
+            """Normalize different versions of the filename list.
+
+            FIXME: The file brower will not work, but the returned config will
+            be valid
+            """
+            if filenames is None:
+                return ""
+            if isinstance(filenames, list):
+                return ",".join()
+            if "," in filenames:
+                logger.warning("Dark or flat files are described using comma separator list. You should use a python/json list of string instead.")
+            filenames = filenames.strip()
+            return filenames
+
         setup_data = {"do_dummy": self.do_dummy.setChecked,
                       "do_dark": self.do_dark.setChecked,
                       "do_flat": self.do_flat.setChecked,
@@ -315,8 +341,8 @@ class WorkerConfigurator(qt.QWidget):
                       "delta_dummy": lambda a: self.delta_dummy.setText(str_(a)),
                       "do_mask": self.do_mask.setChecked,
                       "mask_file": lambda a: self.mask_file.setText(str_(a)),
-                      "dark_current": lambda a: self.dark_current.setText(str_(a)),
-                      "flat_field": lambda a: self.flat_field.setText(str_(a)),
+                      "dark_current": lambda a: self.dark_current.setText(normalizeFiles(a)),
+                      "flat_field": lambda a: self.flat_field.setText(normalizeFiles(a)),
                       "polarization_factor": self.polarization_factor.setValue,
                       "nbpt_rad": lambda a: self.nbpt_rad.setText(str_(a)),
                       "do_2D": self.do_2D.setChecked,

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -429,6 +429,7 @@ class Worker(object):
                 result = numpy.vstack(integrated_result).T
 
         except Exception as err:
+            logger.debug("Backtrace", exc_info=True)
             err2 = ["error in integration do_2d: %s" % self.do_2D(),
                     str(err.__class__.__name__),
                     str(err),

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -518,7 +518,7 @@ class Worker(object):
             filenames = _read_filenames(filename)
             method = "mean"
             data = _reduce_images(filenames, method=method)
-            self.ai.deletector.set_darkcurrent(data)
+            self.ai.detector.set_darkcurrent(data)
             self.dark_current_image = "%s(%s)" % (method, ",".join(filenames))
 
         # Do it here while we have to store metadata
@@ -528,7 +528,7 @@ class Worker(object):
             filenames = _read_filenames(filename)
             method = "mean"
             data = _reduce_images(filenames, method=method)
-            self.ai.deletector.set_flatfield(data)
+            self.ai.detector.set_flatfield(data)
             self.flat_field_image = "%s(%s)" % (method, ",".join(filenames))
 
         # Uses it anyway in case do_2D is customed after the configuration

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -85,18 +85,19 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "13/12/2018"
+__date__ = "14/12/2018"
 __status__ = "development"
 
 import threading
 import os.path
 import logging
 import json
+import numpy
+import fabio
 
 logger = logging.getLogger(__name__)
 
-import numpy
-import fabio
+from . import average
 from .detectors import detector_factory
 from .azimuthalIntegrator import AzimuthalIntegrator
 from .distortion import Distortion
@@ -212,16 +213,47 @@ def _init_ai(ai, config, consume_keys=False, read_maps=True):
         filename = config.pop("dark_current", "")
         apply_process = config.pop("do_dark", True)
         if filename and apply_process:
-            filenames = [name.strip() for name in filename.split(",") if os.path.isfile(name.strip())]
+            filenames = _read_filenames(filename)
             ai.set_darkfiles(filenames)
 
         filename = config.pop("flat_field", "")
         apply_process = config.pop("do_flat", True)
         if filename and apply_process:
-            filenames = [name.strip() for name in filename.split(",") if os.path.isfile(name.strip())]
+            filenames = _read_filenames(filename)
             ai.set_flatfiles(filenames)
 
     return ai
+
+
+def _read_filenames(filenames):
+    """Returns a list of strings from a comma separated string list or a list.
+
+    :rtype: List[str]
+    """
+    if filenames is None:
+        return []
+    if isinstance(filenames, list):
+        return filenames
+    if "," in filenames:
+        logger.warning("Dark or flat files are described using comma separator list. You should use a python/json list of string instead.")
+    return filenames.split(",")
+
+
+def _reduce_images(self, filenames, method="mean"):
+    """
+    Reduce a set of filenames using a reduction method
+
+    :param List[str] filenames: List of files used to compute the data
+    :param str method: method used to compute the dark, "mean" or "median"
+    """
+    if len(filenames) == 0:
+        return None
+    if fabio is None:
+        raise RuntimeError("FabIO is missing")
+    if len(filenames) == 1:
+        return fabio.open(filenames[0]).data.astype(numpy.float32)
+    else:
+        return average.average_images(filenames, filter_=method, fformat=None, threshold=0)
 
 
 class Worker(object):
@@ -483,17 +515,21 @@ class Worker(object):
         filename = config.pop("dark_current", "")
         apply_process = config.pop("do_dark", True)
         if filename and apply_process:
-            filenames = [name.strip() for name in filename.split(",") if os.path.isfile(name.strip())]
-            self.ai.set_darkfiles(filenames)
-            self.dark_current_image = filenames
+            filenames = _read_filenames(filename)
+            method = "mean"
+            data = _reduce_images(filenames, method=method)
+            self.ai.deletector.set_darkcurrent(data)
+            self.dark_current_image = "%s(%s)" % (method, ",".join(filenames))
 
         # Do it here while we have to store metadata
         filename = config.pop("flat_field", "")
         apply_process = config.pop("do_flat", True)
         if filename and apply_process:
-            filenames = [name.strip() for name in filename.split(",") if os.path.isfile(name.strip())]
-            self.ai.set_flatfiles(filenames)
-            self.flat_field_image = self.ai.flatfiles
+            filenames = _read_filenames(filename)
+            method = "mean"
+            data = _reduce_images(filenames, method=method)
+            self.ai.deletector.set_flatfield(data)
+            self.flat_field_image = "%s(%s)" % (method, ",".join(filenames))
 
         # Uses it anyway in case do_2D is customed after the configuration
         value = config.pop("nbpt_azim", None)

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -85,7 +85,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "14/12/2018"
+__date__ = "17/12/2018"
 __status__ = "development"
 
 import threading
@@ -239,7 +239,7 @@ def _read_filenames(filenames):
     return filenames.split(",")
 
 
-def _reduce_images(self, filenames, method="mean"):
+def _reduce_images(filenames, method="mean"):
     """
     Reduce a set of filenames using a reduction method
 


### PR DESCRIPTION
This PR
- deprecate list of filenames provided to detector and azimuthal integrator (it could stay as an easy way to set but not as getter)
- enforce list of string for dark/flat config.

The idea is to use this (json version 2)
```
flat_field: ["foo1.edf", "foo2.edf", "foo3.edf"]
```
instead of this (json version 1)
```
flat_field: "foo1.edf,foo2.edf,foo3.edf"
```

Not tested