### PR TITLE
Rework file config io

### DIFF
--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "18/12/2018"
+__date__ = "03/01/2019"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -55,7 +55,7 @@ from .containers import Integrate1dResult, Integrate2dResult
 from .io import DefaultAiWriter
 error = None
 
-from .method_registry import IntegrationMethod, Method
+from .method_registry import IntegrationMethod
 
 # Register numpy integrators which are fail-safe
 IntegrationMethod(1, "no", "histogram", "python", old_method="numpy",
@@ -588,7 +588,7 @@ class AzimuthalIntegrator(Geometry):
         geometric arrays, mask, 2theta/chi range). Unless many tests
         will be done at each integration.
 
-        Nota: this deprecated code is maintained until a new histograming on GPU 
+        Nota: this deprecated code is maintained until a new histograming on GPU
         is available
 
         """
@@ -1482,9 +1482,8 @@ class AzimuthalIntegrator(Geometry):
                         normalization_factor=1.0,
                         metadata=None):
         """Demonstrator for the new azimuthal integrator taking care of the normalization,
-        
-        Early stage prototype, 
-         
+
+        Early stage prototype
         """
 
         if variance is not None:
@@ -2041,12 +2040,12 @@ class AzimuthalIntegrator(Geometry):
     integrate2d = _integrate2d_legacy
 
     def _integrate2d_ng(self, data, npt_rad, npt_azim=360,
-                    filename=None, correctSolidAngle=True, variance=None,
-                    error_model=None, radial_range=None, azimuth_range=None,
-                    mask=None, dummy=None, delta_dummy=None,
-                    polarization_factor=None, dark=None, flat=None,
-                    method="bbox", unit=units.Q, safe=True,
-                    normalization_factor=1.0, all=False, metadata=None):
+                        filename=None, correctSolidAngle=True, variance=None,
+                        error_model=None, radial_range=None, azimuth_range=None,
+                        mask=None, dummy=None, delta_dummy=None,
+                        polarization_factor=None, dark=None, flat=None,
+                        method="bbox", unit=units.Q, safe=True,
+                        normalization_factor=1.0, all=False, metadata=None):
         """
         Calculate the azimuthal regrouped 2d image in q(nm^-1)/chi(deg) by default
 
@@ -3194,4 +3193,3 @@ class AzimuthalIntegrator(Geometry):
         self._sem = threading.Semaphore()
         self._lock = threading.Semaphore()
         self.engines = {}
-

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -1116,6 +1116,9 @@ class Geometry(object):
         :return: dictionary with the current configuration
         """
         with self._sem:
+            # TODO: ponifile should not be used here
+            #     if it was only used for IO, it would be better to remove
+            #     this function
             poni = ponifile.PoniFile(data=self)
             return poni.as_dict()
 
@@ -1146,6 +1149,9 @@ class Geometry(object):
         :param config: dictionary with the configuration
         :return: itself
         """
+        # TODO: ponifile should not be used here
+        #     if it was only used for IO, it would be better to remove
+        #     this function
         poni = ponifile.PoniFile(config)
         self._init_from_poni(poni)
         return self

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -2081,9 +2081,6 @@ class Geometry(object):
         self._cached_array["q_corner"] = q_corner
 
     def get_wavelength(self):
-        if self._wavelength is None:
-            raise RuntimeWarning("Using wavelength without having defined"
-                                 " it previously ... excepted to fail !")
         return self._wavelength
 
     wavelength = property(get_wavelength, set_wavelength)

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -39,7 +39,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "11/12/2018"
+__date__ = "03/01/2019"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -48,8 +48,6 @@ from numpy import radians, degrees, arccos, arctan2, sin, cos, sqrt
 import numpy
 import os
 import threading
-import time
-import json
 from collections import namedtuple, OrderedDict
 
 from . import detectors
@@ -57,6 +55,7 @@ from . import units
 from .utils.decorators import deprecated
 from .utils import crc32
 from . import utils
+from .io import ponifile
 
 logger = logging.getLogger(__name__)
 
@@ -1116,20 +1115,29 @@ class Geometry(object):
 
         :return: dictionary with the current configuration
         """
-
-        config = OrderedDict([("poni_version", 2)])
         with self._sem:
-            config["detector"] = self.detector.__class__.__name__
-            config["detector_config"] = self.detector.get_config()
-            config["dist"] = self._dist
-            config["poni1"] = self._poni1
-            config["poni2"] = self._poni2
-            config["rot1"] = self._rot1
-            config["rot2"] = self._rot2
-            config["rot3"] = self._rot3
-            if self._wavelength:
-                config["wavelength"] = self._wavelength
-        return config
+            poni = ponifile.PoniFile(data=self)
+            return poni.as_dict()
+
+    def _init_from_poni(self, poni):
+        """Init the geometry from a poni object."""
+        if poni.detector is not None:
+            self.detector = poni.detector
+        if poni.dist is not None:
+            self._dist = poni.dist
+        if poni.poni1 is not None:
+            self._poni1 = poni.poni1
+        if poni.poni2 is not None:
+            self._poni2 = poni.poni2
+        if poni.rot1 is not None:
+            self._rot1 = poni.rot1
+        if poni.rot2 is not None:
+            self._rot2 = poni.rot2
+        if poni.rot3 is not None:
+            self._rot3 = poni.rot3
+        if poni.rot3 is not None:
+            self._wavelength = poni.wavelength
+        self.reset()
 
     def set_config(self, config):
         """
@@ -1138,50 +1146,8 @@ class Geometry(object):
         :param config: dictionary with the configuration
         :return: itself
         """
-        version = int(config.get("poni_version", 1))
-
-        if version == 1:
-            # Handle former version of PONI-file
-            if "detector" in config:
-                self.detector = detectors.detector_factory(config["detector"])
-            else:
-                self.detector = detectors.Detector()
-            if self.detector.force_pixel and ("pixelsize1" in config) and ("pixelsize2" in config):
-                pixel1 = float(config["pixelsize1"])
-                pixel2 = float(config["pixelsize2"])
-                self.detector = self.detector.__class__(pixel1=pixel1, pixel2=pixel2)
-            else:
-                self.detector = detectors.Detector()
-                if "pixelsize1" in config:
-                    self.detector.pixel1 = float(config["pixelsize1"])
-                if "pixelsize2" in config:
-                    self.detector.pixel2 = float(config["pixelsize2"])
-            if "splinefile" in config:
-                if config["splinefile"].lower() != "none":
-                    self.detector.set_splineFile(config["splinefile"])
-
-        elif version == 2:
-                detector_name = config["detector"]
-                detector_config = config["detector_config"]
-                self.detector = detectors.detector_factory(detector_name, detector_config)
-        else:
-            raise RuntimeError("PONI file verison %s too recent. Upgrade pyFAI.", version)
-
-        if "distance" in config:
-            self._dist = float(config["distance"])
-        if "poni1" in config:
-            self._poni1 = float(config["poni1"])
-        if "poni2" in config:
-            self._poni2 = float(config["poni2"])
-        if "rot1" in config:
-            self._rot1 = float(config["rot1"])
-        if "rot2" in config:
-            self._rot2 = float(config["rot2"])
-        if "rot3" in config:
-            self._rot3 = float(config["rot3"])
-        if "wavelength" in config:
-            self._wavelength = float(config["wavelength"])
-        self.reset()
+        poni = ponifile.PoniFile(config)
+        self._init_from_poni(poni)
         return self
 
     def save(self, filename):
@@ -1193,24 +1159,11 @@ class Geometry(object):
         """
         try:
             with open(filename, "a") as f:
-                f.write(("# Nota: C-Order, 1 refers to the Y axis,"
-                         " 2 to the X axis \n"))
-                f.write("# Calibration done at %s\n" % time.ctime())
-                f.write("poni_version: 2\n")
-                detector = self.detector
-                f.write("Detector: %s\n" % detector.__class__.__name__)
-                f.write("Detector_config: %s\n" % json.dumps(detector.get_config()))
-
-                f.write("Distance: %s\n" % self._dist)
-                f.write("Poni1: %s\n" % self._poni1)
-                f.write("Poni2: %s\n" % self._poni2)
-                f.write("Rot1: %s\n" % self._rot1)
-                f.write("Rot2: %s\n" % self._rot2)
-                f.write("Rot3: %s\n" % self._rot3)
-                if self._wavelength is not None:
-                    f.write("Wavelength: %s\n" % self._wavelength)
+                poni = ponifile.PoniFile(self)
+                poni.write(f)
         except IOError:
             logger.error("IOError while writing to file %s", filename)
+
     write = save
 
     @classmethod
@@ -1235,20 +1188,10 @@ class Geometry(object):
         :type filename: string
         :return: itself with updated parameters
         """
-        data = OrderedDict()
-        with open(filename) as opened_file:
-            for line in opened_file:
-                if line.startswith("#") or (":" not in line):
-                    continue
-                words = line.split(":", 1)
+        poni = ponifile.PoniFile(data=filename)
+        self._init_from_poni(poni)
+        return self
 
-                key = words[0].strip().lower()
-                try:
-                    value = words[1].strip()
-                except Exception as error:  # IGNORE:W0703:
-                    logger.error("Error %s with line: %s", error, line)
-                data[key] = value
-        return self.set_config(data)
     read = load
 
     def getPyFAI(self):

--- a/pyFAI/geometry.py
+++ b/pyFAI/geometry.py
@@ -1287,7 +1287,7 @@ class Geometry(object):
                           self._rot1, self._rot2, self._rot3]
             self.chiDiscAtPi = True  # position of the discontinuity of chi in radians, pi by default
             self.reset()
-#            self._wavelength = None
+            # self._wavelength = None
             self._oversampling = None
             if self.splineFile:
                 self.detector.set_splineFile(self.splineFile)
@@ -2096,6 +2096,7 @@ class Geometry(object):
 
     def del_ttha(self):
         self._cached_array["2th_center"] = None
+
     ttha = property(get_ttha, set_ttha, del_ttha, "2theta array in cache")
 
     def get_chia(self):
@@ -2106,6 +2107,7 @@ class Geometry(object):
 
     def del_chia(self):
         self._cached_array["chi_center"] = None
+
     chia = property(get_chia, set_chia, del_chia, "chi array in cache")
 
     def get_dssa(self):
@@ -2129,6 +2131,7 @@ class Geometry(object):
 
     def del_qa(self):
         self._cached_array["q_center"] = None
+
     qa = property(get_qa, set_qa, del_qa, "Q array in cache")
 
     def get_ra(self):
@@ -2139,6 +2142,7 @@ class Geometry(object):
 
     def del_ra(self):
         self.self._cached_array["r_center"] = None
+
     ra = property(get_ra, set_ra, del_ra, "R array in cache")
 
     def get_pixel1(self):

--- a/pyFAI/gui/IntegrationDialog.py
+++ b/pyFAI/gui/IntegrationDialog.py
@@ -37,7 +37,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "17/12/2018"
+__date__ = "04/01/2019"
 __status__ = "development"
 
 import logging
@@ -57,6 +57,7 @@ from .. import worker as worker_mdl
 from .widgets.WorkerConfigurator import WorkerConfigurator
 from ..io import DefaultAiWriter
 from ..io import HDF5Writer
+from ..io import integration_config
 from ..third_party import six
 from .utils import projecturl
 from ..utils import get_ui_file
@@ -290,6 +291,7 @@ class IntegrationDialog(qt.QWidget):
         :param dico: dictionary with description of the widget
         :type dico: dict
         """
+        dico = integration_config.normalize(dico)
         self.__workerConfigurator.setConfig(dico)
 
     def set_input_data(self, stack):

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -50,13 +50,13 @@ from ..dialog.OpenClDeviceDialog import OpenClDeviceDialog
 from ..dialog.GeometryDialog import GeometryDialog
 from ...detectors import detector_factory
 from ...utils import float_, str_, get_ui_file
-from ...azimuthalIntegrator import AzimuthalIntegrator
 from ...units import RADIAL_UNITS, to_unit
 from ..model.GeometryModel import GeometryModel
 from ..model.DataModel import DataModel
 from ..utils import units
 from ...utils import stringutil
 from ..utils import FilterBuilder
+from ...io.ponifile import PoniFile
 
 
 class WorkerConfigurator(qt.QWidget):
@@ -495,24 +495,23 @@ class WorkerConfigurator(qt.QWidget):
 
     def loadFromPoniFile(self, ponifile):
         try:
-            # TODO: It should not be needed to create an AI to parse a PONI file
-            ai = AzimuthalIntegrator.sload(ponifile)
+            poni = PoniFile(ponifile)
         except Exception as error:
             # FIXME: An error have to be displayed in the GUI
             logger.error("file %s does not look like a poni-file, error %s", ponifile, error)
             return
 
         model = self.__geometryModel
-        model.distance().setValue(ai.dist)
-        model.poni1().setValue(ai.poni1)
-        model.poni2().setValue(ai.poni2)
-        model.rotation1().setValue(ai.rot1)
-        model.rotation2().setValue(ai.rot2)
-        model.rotation3().setValue(ai.rot3)
+        model.distance().setValue(poni.dist)
+        model.poni1().setValue(poni.poni1)
+        model.poni2().setValue(poni.poni2)
+        model.rotation1().setValue(poni.rot1)
+        model.rotation2().setValue(poni.rot2)
+        model.rotation3().setValue(poni.rot3)
         # TODO: why is there an underscore to _wavelength here?
-        model.wavelength().setValue(ai._wavelength)
+        model.wavelength().setValue(poni.wavelength)
 
-        self.setDetector(ai.detector)
+        self.setDetector(poni.detector)
 
     def _float(self, kw, default=0):
         fval = default

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "03/01/2019"
+__date__ = "04/01/2019"
 __status__ = "development"
 
 import logging
@@ -508,7 +508,6 @@ class WorkerConfigurator(qt.QWidget):
         model.rotation1().setValue(poni.rot1)
         model.rotation2().setValue(poni.rot2)
         model.rotation3().setValue(poni.rot3)
-        # TODO: why is there an underscore to _wavelength here?
         model.wavelength().setValue(poni.wavelength)
 
         self.setDetector(poni.detector)

--- a/pyFAI/io/integration_config.py
+++ b/pyFAI/io/integration_config.py
@@ -1,0 +1,174 @@
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015-2019 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Module function to manage poni files.
+"""
+
+from __future__ import absolute_import, print_function, division
+
+__author__ = "Jerome Kieffer"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "04/01/2019"
+__docformat__ = 'restructuredtext'
+
+
+import logging
+import six
+
+from . import ponifile
+from .. import detectors
+
+_logger = logging.getLogger(__name__)
+
+
+def _normalize_v1_darkflat_files(config, key):
+    """Normalize dark and flat filename list from the version 1 to version 2.
+    """
+    if key not in config:
+        return
+
+    filenames = config[key]
+    if filenames is None:
+        return
+
+    if isinstance(filenames, list):
+        # Already a list, it's fine
+        return
+
+    if isinstance(filenames, six.string_types):
+        if "," in filenames:
+            # Create a list from a coma separated string list
+            filenames = filenames.split(",")
+            filenames = [f.strip() for f in filenames]
+            config[key] = filenames
+
+
+def _patch_v1_to_v2(config):
+    """Rework the config dictionary from version 1 to version 2
+
+    :param dict config: Dictionary reworked inplace.
+    """
+
+    value = config.pop("poni", None)
+    detector = None
+    if value:
+        # Use the poni file while it is not overwrited by a key of the config
+        # dictionary
+        poni = ponifile.PoniFile(value)
+        if "wavelength" not in config:
+            config["wavelength"] = poni.wavelength
+        if "dist" not in config:
+            config["dist"] = poni.dist
+        if "poni1" not in config:
+            config["poni1"] = poni.poni1
+        if "poni2" not in config:
+            config["poni2"] = poni.poni2
+        if "rot1" not in config:
+            config["rot1"] = poni.rot1
+        if "rot2" not in config:
+            config["rot2"] = poni.rot2
+        if "rot3" not in config:
+            config["rot3"] = poni.rot3
+        if "detector" not in config:
+            detector = poni.detector
+
+    # detector
+    value = config.pop("detector", None)
+    if value:
+        # NOTE: pixel1/pixel2/splineFile was not parsed here
+        detector_name = value.lower()
+        detector = detectors.detector_factory(detector_name)
+
+        if detector_name == "detector":
+            value = config.pop("pixel1", None)
+            if value:
+                detector.set_pixel1(value)
+            value = config.pop("pixel2", None)
+            if value:
+                detector.set_pixel2(value)
+        else:
+            # Drop it as it was not really used
+            _ = config.pop("pixel1", None)
+            _ = config.pop("pixel2", None)
+
+        splineFile = config.pop("splineFile", None)
+        if splineFile:
+            detector.set_splineFile(splineFile)
+
+    if detector is not None:
+        # Feed the detector as version2
+        config["detector"] = detector.__class__.__name__
+        config["detector_config"] = detector.get_config()
+
+    _normalize_v1_darkflat_files(config, "dark_current")
+    _normalize_v1_darkflat_files(config, "flat_field")
+
+    method = config.get("method", None)
+    use_opencl = config.pop("do_OpenCL", False)
+
+    if use_opencl is not None and method is not None:
+        if use_opencl:
+            _logger.warning("Both 'method' and 'do_OpenCL' are defined. 'do_OpenCL' is ignored.")
+
+    if method is None:
+        if use_opencl:
+            method = "csr_ocl"
+        else:
+            method = "splitbbox"
+        config["method"] = method
+
+    config["version"] = 2
+    config["application"] = "pyfai-integrate"
+
+
+def normalize(config, inplace=False):
+    """Normalize the configuration file to the one supported internally\
+    (the last one).
+
+    :param dict config: The configuration dictionary to read
+    :param bool inplace: In true, the dictionary is edited inplace
+    :raise ValueError: If the configuration do not match.
+    """
+    if not inplace:
+        config = config.copy()
+
+    version = config.get("version", 1)
+    if version == 1:
+        # NOTE: Previous way to describe an integration process before pyFAI 0.17
+        _patch_v1_to_v2(config)
+
+    application = config.get("application", None)
+    if application != "pyfai-integrate":
+        raise ValueError("Configuration application do not match. Found '%s'" % application)
+
+    if version == 2:
+        pass
+    elif version > 2:
+        _logger.error("Configuration file %d too recent. This version of pyFAI maybe too old to read this configuration", version)
+
+    return config

--- a/pyFAI/io/ponifile.py
+++ b/pyFAI/io/ponifile.py
@@ -1,0 +1,224 @@
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015-2019 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Module function to manage poni files.
+"""
+
+from __future__ import absolute_import, print_function, division
+
+__author__ = "Jerome Kieffer"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "03/01/2019"
+__docformat__ = 'restructuredtext'
+
+
+import collections
+import time
+import json
+import logging
+
+_logger = logging.getLogger(__name__)
+
+from .. import detectors
+from ..third_party import six
+
+
+class PoniFile(object):
+
+    def __init__(self, data=None):
+        self._detector = None
+        self._dist = None
+        self._poni1 = None
+        self._poni2 = None
+        self._rot1 = None
+        self._rot2 = None
+        self._rot3 = None
+        self._wavelength = None
+        if data is None:
+            pass
+        elif isinstance(data, dict):
+            self.read_from_dict(data)
+        elif isinstance(data, six.string_types):
+            self.read_from_file(data)
+        else:
+            self.read_from_duck(data)
+
+    def read_from_file(self, filename):
+        data = collections.OrderedDict()
+        with open(filename) as opened_file:
+            for line in opened_file:
+                if line.startswith("#") or (":" not in line):
+                    continue
+                words = line.split(":", 1)
+
+                key = words[0].strip().lower()
+                try:
+                    value = words[1].strip()
+                except Exception as error:  # IGNORE:W0703:
+                    _logger.error("Error %s with line: %s", error, line)
+                data[key] = value
+        self.read_from_dict(data)
+
+    def read_from_dict(self, config):
+        """Initialize this object using a dictionary.
+
+        .. note:: The dictionary is versionned.
+        """
+        version = int(config.get("poni_version", 1))
+
+        if version == 1:
+            # Handle former version of PONI-file
+            if "detector" in config:
+                self._detector = detectors.detector_factory(config["detector"])
+            else:
+                self._detector = detectors.Detector()
+            if self._detector.force_pixel and ("pixelsize1" in config) and ("pixelsize2" in config):
+                pixel1 = float(config["pixelsize1"])
+                pixel2 = float(config["pixelsize2"])
+                self._detector = self._detector.__class__(pixel1=pixel1, pixel2=pixel2)
+            else:
+                self._detector = detectors.Detector()
+                if "pixelsize1" in config:
+                    self._detector.pixel1 = float(config["pixelsize1"])
+                if "pixelsize2" in config:
+                    self._detector.pixel2 = float(config["pixelsize2"])
+            if "splinefile" in config:
+                if config["splinefile"].lower() != "none":
+                    self._detector.set_splineFile(config["splinefile"])
+
+        elif version == 2:
+                detector_name = config["detector"]
+                detector_config = config["detector_config"]
+                self._detector = detectors.detector_factory(detector_name, detector_config)
+        else:
+            raise RuntimeError("PONI file verison %s too recent. Upgrade pyFAI.", version)
+
+        if "distance" in config:
+            self._dist = float(config["distance"])
+        if "poni1" in config:
+            self._poni1 = float(config["poni1"])
+        if "poni2" in config:
+            self._poni2 = float(config["poni2"])
+        if "rot1" in config:
+            self._rot1 = float(config["rot1"])
+        if "rot2" in config:
+            self._rot2 = float(config["rot2"])
+        if "rot3" in config:
+            self._rot3 = float(config["rot3"])
+        if "wavelength" in config:
+            self._wavelength = float(config["wavelength"])
+
+    def read_from_duck(self, duck):
+        """Initialize the object using an object providing the same API.
+
+        The duck object must provide dist, poni1, poni2, rot1, rot2, rot3,
+        wavelength, and detector.
+        """
+        # TODO: It would be good to test attribute types
+        self._dist = duck.dist
+        self._poni1 = duck.poni1
+        self._poni2 = duck.poni2
+        self._rot1 = duck.rot1
+        self._rot2 = duck.rot2
+        self._rot3 = duck.rot3
+        self._wavelength = duck.wavelength
+        self._detector = duck.detector
+
+    def write(self, fd):
+        """Write this object to an open stream.
+        """
+        fd.write(("# Nota: C-Order, 1 refers to the Y axis,"
+                 " 2 to the X axis \n"))
+        fd.write("# Calibration done at %s\n" % time.ctime())
+        fd.write("poni_version: 2\n")
+        detector = self.detector
+        fd.write("Detector: %s\n" % detector.__class__.__name__)
+        fd.write("Detector_config: %s\n" % json.dumps(detector.get_config()))
+
+        fd.write("Distance: %s\n" % self._dist)
+        fd.write("Poni1: %s\n" % self._poni1)
+        fd.write("Poni2: %s\n" % self._poni2)
+        fd.write("Rot1: %s\n" % self._rot1)
+        fd.write("Rot2: %s\n" % self._rot2)
+        fd.write("Rot3: %s\n" % self._rot3)
+        if self._wavelength is not None:
+            fd.write("Wavelength: %s\n" % self._wavelength)
+
+    def as_dict(self):
+        config = collections.OrderedDict([("poni_version", 2)])
+        config["detector"] = self.detector.__class__.__name__
+        config["detector_config"] = self.detector.get_config()
+        config["dist"] = self._dist
+        config["poni1"] = self._poni1
+        config["poni2"] = self._poni2
+        config["rot1"] = self._rot1
+        config["rot2"] = self._rot2
+        config["rot3"] = self._rot3
+        if self._wavelength:
+            config["wavelength"] = self._wavelength
+        return config
+
+    @property
+    def detector(self):
+        """:rtype: Union[None,float]"""
+        return self._detector
+
+    @property
+    def dist(self):
+        """:rtype: Union[None,float]"""
+        return self._dist
+
+    @property
+    def poni1(self):
+        """:rtype: Union[None,float]"""
+        return self._poni1
+
+    @property
+    def poni2(self):
+        """:rtype: Union[None,float]"""
+        return self._poni2
+
+    @property
+    def rot1(self):
+        """:rtype: Union[None,float]"""
+        return self._rot1
+
+    @property
+    def rot2(self):
+        """:rtype: Union[None,float]"""
+        return self._rot2
+
+    @property
+    def rot3(self):
+        """:rtype: Union[None,float]"""
+        return self._rot3
+
+    @property
+    def wavelength(self):
+        """:rtype: Union[None,float]"""
+        return self._wavelength

--- a/pyFAI/test/test_all.py
+++ b/pyFAI/test/test_all.py
@@ -33,7 +33,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "17/10/2018"
+__date__ = "04/01/2019"
 
 import sys
 import unittest
@@ -83,6 +83,7 @@ from . import test_spline
 from . import test_sparse_builder
 from . import test_goniometer
 from . import test_integrate_app
+from . import test_integrate_config
 from . import test_pyfai_api
 from ..opencl import test as test_opencl
 from ..gui import test as test_gui
@@ -106,6 +107,7 @@ def suite():
     testsuite.addTest(test_saxs.suite())
     testsuite.addTest(test_integrate.suite())
     testsuite.addTest(test_integrate_app.suite())
+    testsuite.addTest(test_integrate_config.suite())
     testsuite.addTest(test_bilinear.suite())
     testsuite.addTest(test_distortion.suite())
     testsuite.addTest(test_flat.suite())

--- a/pyFAI/test/test_integrate_config.py
+++ b/pyFAI/test/test_integrate_config.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015-2018 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"Test suite for worker"
+
+from __future__ import absolute_import, division, print_function
+
+__author__ = "Valentin Valls"
+__contact__ = "valentin.valls@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "04/01/2019"
+
+
+import unittest
+import logging
+from ..io import integration_config
+from . import utilstest
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestIntegrationConfigV1(unittest.TestCase):
+
+    def test_poni(self):
+        config = {"poni": utilstest.UtilsTest.getimage("Pilatus1M.poni"),
+                  "wavelength": 50}
+        config = integration_config.normalize(config)
+        self.assertNotIn("poni", config)
+        # From PONI file
+        self.assertEqual(config["dist"], 1.58323111834)
+        # From dict
+        self.assertEqual(config["wavelength"], 50)
+
+    def test_single_flatdark(self):
+        config = {"dark_current": "abc",
+                  "flat_field": "abd"}
+        config = integration_config.normalize(config)
+        self.assertEqual(config["dark_current"], "abc")
+        self.assertEqual(config["flat_field"], "abd")
+
+    def test_coma_flatdark(self):
+        config = {"dark_current": "a,b,c",
+                  "flat_field": "a,b,d"}
+        config = integration_config.normalize(config)
+        self.assertEqual(config["dark_current"], ["a", "b", "c"])
+        self.assertEqual(config["flat_field"], ["a", "b", "d"])
+
+    def test_pilatus(self):
+        config = {"detector": "pilatus2m"}
+        config = integration_config.normalize(config)
+        self.assertEqual(config["detector"], "Pilatus2M")
+        self.assertIsInstance(config["detector_config"], dict)
+
+    def test_detector(self):
+        config = {"detector": "detector",
+                  "pixel1": 1.0,
+                  "pixel2": 1.0}
+        config = integration_config.normalize(config)
+        self.assertNotIn("pixel1", config)
+        self.assertNotIn("pixel2", config)
+        self.assertEqual(config["detector"], "Detector")
+        self.assertEqual(config["detector_config"]["pixel1"], 1.0)
+        self.assertEqual(config["detector_config"]["pixel2"], 1.0)
+
+    def test_frelon(self):
+        spline_file = utilstest.UtilsTest.getimage("frelon.spline")
+        config = {"detector": "frelon",
+                  "splineFile": spline_file}
+        config = integration_config.normalize(config)
+        self.assertNotIn("splineFile", config)
+        self.assertEqual(config["detector"], "FReLoN")
+        self.assertEqual(config["detector_config"]["splineFile"], spline_file)
+
+    def test_opencl(self):
+        config = {"do_OpenCL": True}
+        config = integration_config.normalize(config)
+        self.assertNotIn("do_OpenCL", config)
+        self.assertEqual(config["method"], "csr_ocl")
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loader(TestIntegrationConfigV1))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/pyFAI/test/test_worker.py
+++ b/pyFAI/test/test_worker.py
@@ -34,7 +34,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "17/12/2018"
+__date__ = "04/01/2019"
 
 
 import unittest
@@ -315,27 +315,10 @@ class TestWorkerConfig(unittest.TestCase):
         numpy.save(cls.c, ones * 3)
         numpy.save(cls.d, ones * 4)
 
-    def test_flatdark_v1(self):
-        abc = ",".join([self.a, self.b, self.c])
-        abd = ",".join([self.a, self.b, self.d])
-        config = {"dark_current": abc,
-                  "flat_field": abd,
-                  "poni": utilstest.UtilsTest.getimage("Pilatus1M.poni"),
-                  "detector": "Detector",
-                  "detector_config": {"pixel1": 1, "pixel2": 1, "max_shape": (2, 2)},
-                  "do_2D": False,
-                  "nbpt_rad": 2,
-                  "do_solid_angle": False,
-                  "method": "splitbbox"}
-        worker = Worker()
-        worker.set_config(config)
-        data = numpy.ones(shape=self.shape)
-        worker.process(data=data)
-        self.assertTrue(numpy.isclose(worker.ai.detector.get_darkcurrent()[0, 0], (1 + 2 + 3) / 3))
-        self.assertTrue(numpy.isclose(worker.ai.detector.get_flatfield()[0, 0], (1 + 2 + 4) / 3))
-
-    def test_flatdark_v2(self):
-        config = {"dark_current": [self.a, self.b, self.c],
+    def test_flatdark(self):
+        config = {"version": 2,
+                  "application": "pyfai-integrate",
+                  "dark_current": [self.a, self.b, self.c],
                   "flat_field": [self.a, self.b, self.d],
                   "poni": utilstest.UtilsTest.getimage("Pilatus1M.poni"),
                   "detector": "Detector",

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -380,8 +380,6 @@ class Worker(object):
         if self.azimuth_range is not None:
             kwarg["azimuth_range"] = self.azimuth_range
 
-        print(kwarg)
-
         error = None
         try:
             if self.do_2D():
@@ -489,7 +487,6 @@ class Worker(object):
             filenames = _read_filenames(filename)
             method = "mean"
             data = _reduce_images(filenames, method=method)
-            print(data)
             self.ai.detector.set_darkcurrent(data)
             self.dark_current_image = "%s(%s)" % (method, ",".join(filenames))
 
@@ -500,7 +497,6 @@ class Worker(object):
             filenames = _read_filenames(filename)
             method = "mean"
             data = _reduce_images(filenames, method=method)
-            print(data)
             self.ai.detector.set_flatfield(data)
             self.flat_field_image = "%s(%s)" % (method, ",".join(filenames))
 


### PR DESCRIPTION
This isolate io for file config into the `io` package. It remove duplicated code and provide a safer compatibility with older config version (while dict are mess).

- Isolate `ponifile`read/write (we could do more: ideally `get/set_config` from azimuthalInteg should not contain `version`, as version should only be part of the storage -> the file)
- helper for integration-config (the json file).