### PR TITLE
Fixed the 3D preview of CirPad detector.

### DIFF
--- a/pyFAI/gui/dialog/Detector3dDialog.py
+++ b/pyFAI/gui/dialog/Detector3dDialog.py
@@ -124,7 +124,7 @@ class CreateSceneThread(qt.QThread):
 
         # Merge all pixels together
         pixels = pixels[...]
-        pixels.shape = -1, 4, 3
+        pixels = numpy.reshape(pixels,(-1, 4, 3))
 
         image = self.__image
         mask = self.__mask

--- a/pyFAI/gui/dialog/Detector3dDialog.py
+++ b/pyFAI/gui/dialog/Detector3dDialog.py
@@ -124,7 +124,7 @@ class CreateSceneThread(qt.QThread):
 
         # Merge all pixels together
         pixels = pixels[...]
-        pixels = numpy.reshape(pixels,(-1, 4, 3))
+        pixels = numpy.reshape(pixels, (-1, 4, 3))
 
         image = self.__image
         mask = self.__mask


### PR DESCRIPTION
The loading was freezing, and we get this error : 
`ERROR:pyFAI.gui.dialog.Detector3dDialog:incompatible shape for a non-contiguous array`
Now it works with this change.