### PR TITLE
Speed up 3D initialization

### DIFF
--- a/pyFAI/gui/dialog/Detector3dDialog.py
+++ b/pyFAI/gui/dialog/Detector3dDialog.py
@@ -141,7 +141,7 @@ class CreateSceneThread(qt.QThread):
         values[2::4] = pixelValues
         values[3::4] = pixelValues
 
-        plus = numpy.array([0, 0, 1, 2, 2, 3, 0], dtype=numpy.uint32)
+        plus = numpy.array([0, 1, 2, 2, 3, 0], dtype=numpy.uint32)
         indexes = (numpy.atleast_2d(4 * numpy.arange(vertices.shape[0] // 4, dtype=numpy.uint32)).T + plus).ravel()
         indexes = indexes.astype(numpy.uint32)
 
@@ -151,7 +151,7 @@ class CreateSceneThread(qt.QThread):
 
         item = mesh.ColormapMesh()
         item.moveToThread(qt.QApplication.instance().thread())
-        item.setData(mode="triangle_strip",
+        item.setData(mode="triangles",
                      position=vertices,
                      value=values,
                      indices=indexes,

--- a/pyFAI/gui/dialog/Detector3dDialog.py
+++ b/pyFAI/gui/dialog/Detector3dDialog.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/01/2019"
+__date__ = "28/01/2019"
 
 import numpy
 import time
@@ -197,8 +197,12 @@ class CreateSceneThread(qt.QThread):
             triangle_index += 3
             color_index += 1
 
-        self.__positions_array = positions_array
-        self.__colors_array = colors_array
+        item = mesh.Mesh()
+        item.moveToThread(qt.QApplication.instance().thread())
+        item.setData(position=positions_array,
+                     color=colors_array,
+                     copy=False)
+        self.__detectorItem = item
 
         self.emitProgressValue(100, force=True)
         return True
@@ -207,9 +211,9 @@ class CreateSceneThread(qt.QThread):
         return self.__geometry is not None
 
     def getDetectorItem(self):
-        item = mesh.Mesh()
-        item.setData(position=self.__positions_array, color=self.__colors_array)
+        item = self.__detectorItem
         item.setLabel("Detector")
+        self.__detectorItem = None
         return item
 
     def getSampleItem(self):

--- a/pyFAI/gui/dialog/Detector3dDialog.py
+++ b/pyFAI/gui/dialog/Detector3dDialog.py
@@ -135,6 +135,12 @@ class CreateSceneThread(qt.QThread):
         else:
             pixelValues = numpy.zeros(vertices.shape[0] // 4)
 
+        if self.__mask is not None:
+            mask = self.__mask.reshape(-1)
+            if pixelValues.dtype.kind in "ui":
+                pixelValues = pixelValues.astype(numpy.float)
+            pixelValues[mask != 0] = numpy.float("nan")
+
         values = numpy.empty(shape=(vertices.shape[0]))
         values[0::4] = pixelValues
         values[1::4] = pixelValues

--- a/pyFAI/gui/dialog/Detector3dDialog.py
+++ b/pyFAI/gui/dialog/Detector3dDialog.py
@@ -105,6 +105,10 @@ class CreateSceneThread(qt.QThread):
                 self.__isAborted = True
 
     def runProcess(self):
+        result = self.__createDetectorMesh(self)
+        return result
+
+    def __createDetectorMesh(self):
         self.emitProgressValue(0, force=True)
 
         if self.__geometry is not None:


### PR DESCRIPTION
Use the coming-soon silx `ColormapMesh` to speed up the computation of the 3D shapes.

The result is about 2s with the Aarhus detector, which is much incredibly better. Previously it was about 2m or more.

It's only available with a not yet merged branch of silx.