### PR TITLE
Fix tests with --no-opencl

### DIFF
--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "05/02/2019"
+__date__ = "25/02/2019"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -176,7 +176,11 @@ else:
     # IntegrationMethod(2, "full", "CSR", "cython", old_method="full_csr",
     #                   class_funct=(splitPixelFullCSR.FullSplitCSR_2d, splitPixelFullCSR.FullSplitCSR_2d.integrate))
 
-from .opencl import ocl
+try:
+    from .opencl import ocl
+except ImportError:
+    ocl = None
+
 if ocl:
     devices_list = []
     devtype_list = []

--- a/pyFAI/opencl/__init__.py
+++ b/pyFAI/opencl/__init__.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "2012-2017 European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "11/01/2019"
+__date__ = "25/02/2019"
 __status__ = "stable"
 
 import os
@@ -47,9 +47,11 @@ import pyFAI
 
 if not pyFAI.use_opencl:
     pyopencl = None
+    ocl = None
 elif os.environ.get("PYFAI_OPENCL") in ["0", "False"]:
     logger.info("Use of OpenCL has been disables from environment variable: PYFAI_OPENCL=0")
     pyopencl = None
+    ocl = None
 else:
     from silx.opencl.common import *
     from .. import resources

--- a/pyFAI/opencl/test/__init__.py
+++ b/pyFAI/opencl/test/__init__.py
@@ -24,14 +24,17 @@
 
 __authors__ = ["J. Kieffer"]
 __license__ = "MIT"
-__date__ = "29/11/2016"
+__date__ = "25/02/2019"
 
 import unittest
-from . import test_addition
+from ...test.utilstest import UtilsTest
 
 
 def suite():
     testSuite = unittest.TestSuite()
-    testSuite.addTests(test_addition.suite())
+
+    if UtilsTest.opencl:
+        from . import test_addition
+        testSuite.addTests(test_addition.suite())
 
     return testSuite

--- a/pyFAI/test/test_preproc.py
+++ b/pyFAI/test/test_preproc.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "26/11/2018"
+__date__ = "25/02/2019"
 
 
 import os
@@ -47,7 +47,6 @@ logger = logging.getLogger(__name__)
 
 from ..engines import preproc as python_preproc
 from ..ext import preproc as cython_preproc
-from ..opencl import ocl, preproc as ocl_preproc
 from .utilstest import UtilsTest
 
 
@@ -152,6 +151,7 @@ class TestPreproc(unittest.TestCase):
 
     @unittest.skipIf(UtilsTest.opencl is False, "User request to skip OpenCL tests")
     def test_opencl(self):
+        from ..opencl import ocl, preproc as ocl_preproc
         if ocl is None:
             self.skipTest("OpenCL not available")
         self.one_test(ocl_preproc)


### PR DESCRIPTION
`run_tests --no-opencl` was not anymore working

Maybe since silx opencl integration?