### PR TITLE
HDF5 path compliant

### DIFF
--- a/pyFAI/app/average.py
+++ b/pyFAI/app/average.py
@@ -33,7 +33,7 @@ __author__ = "Jerome Kieffer, Picca Frédéric-Emmanuel"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "18/02/2019"
+__date__ = "01/03/2019"
 __status__ = "production"
 
 import os
@@ -96,6 +96,25 @@ def parse_algorithms(options):
     return result
 
 
+def cleanup_input_paths(input_paths):
+    """Clean up filename using :: to access to data inside file.
+
+    :returns: Returns a list of paths without directory separator inside the filename
+    location.
+    """
+    result = []
+    for path in input_paths:
+        if "::" in path:
+            if not os.path.exists(path):
+                filename, datapath = path.split("::", 1)
+                datapath = datapath.replace("/", "_")
+                datapath = datapath.replace("\\", "_")
+                datapath = datapath.strip("_")
+                path = filename + "__" + datapath
+        result.append(path)
+    return result
+
+
 def parse_writer(input_images, options, algorithms):
     """Return a writer by using information from the command line"""
     output = options.output
@@ -115,8 +134,10 @@ def parse_writer(input_images, options, algorithms):
         suffix += "_{image_count}_files.{file_format}"
         template = prefix + "{method_name}" + suffix
 
+    input_paths = cleanup_input_paths(input_images)
+
     formats = {
-        "common_prefix": os.path.commonprefix(input_images),
+        "common_prefix": os.path.commonprefix(input_paths),
         "image_count": len(input_images),
         "cutoff": options.cutoff,
         "file_format": file_format,

--- a/pyFAI/app/calib2.py
+++ b/pyFAI/app/calib2.py
@@ -383,11 +383,11 @@ def setup_model(model, options):
 
     if options.mask:
         try:
-            with settings.mask().lockContext() as model:
-                model.setFilename(options.mask)
+            with settings.mask().lockContext() as image_model:
+                image_model.setFilename(options.mask)
                 data = pyFAI.io.image.read_image_data(options.mask)
-                model.setValue(data)
-                model.setSynchronized(True)
+                image_model.setValue(data)
+                image_model.setSynchronized(True)
         except Exception as e:
             displayExceptionBox("Error while loading the mask", e)
 
@@ -396,10 +396,11 @@ def setup_model(model, options):
     elif len(args) == 1:
         image_file = args[0]
         try:
-            with settings.image().lockContext() as model:
-                model.setFilename(options.mask)
+            with settings.image().lockContext() as image_model:
+                image_model.setFilename(image_file)
                 data = pyFAI.io.image.read_image_data(image_file)
-                model.setSynchronized(True)
+                image_model.setValue(data)
+                image_model.setSynchronized(True)
         except Exception as e:
             displayExceptionBox("Error while loading the image", e)
     else:

--- a/pyFAI/app/calib2.py
+++ b/pyFAI/app/calib2.py
@@ -28,7 +28,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "03/01/2019"
+__date__ = "28/02/2019"
 __status__ = "production"
 
 import logging
@@ -384,9 +384,11 @@ def setup_model(model, options):
 
     if options.mask:
         try:
-            settings.maskFile().setValue(options.mask)
-            with fabio.open(options.mask) as mask:
-                settings.mask().setValue(mask.data)
+            with settings.mask().lockContext() as model:
+                model.setFilename(options.mask)
+                with fabio.open(options.mask) as mask:
+                    model.setValue(mask.data)
+                model.setSynchronized(True)
         except Exception as e:
             displayExceptionBox("Error while loading the mask", e)
 
@@ -395,9 +397,11 @@ def setup_model(model, options):
     elif len(args) == 1:
         image_file = args[0]
         try:
-            settings.imageFile().setValue(image_file)
-            with fabio.open(image_file) as image:
-                settings.image().setValue(image.data)
+            with settings.image().lockContext() as model:
+                model.setFilename(options.mask)
+                with fabio.open(image_file) as image:
+                    model.setValue(image.data)
+                model.setSynchronized(True)
         except Exception as e:
             displayExceptionBox("Error while loading the image", e)
     else:

--- a/pyFAI/app/calib2.py
+++ b/pyFAI/app/calib2.py
@@ -28,7 +28,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "28/02/2019"
+__date__ = "01/03/2019"
 __status__ = "production"
 
 import logging
@@ -44,8 +44,7 @@ logger_uncaught = logging.getLogger("pyFAI-calib2.UNCAUGHT")
 import pyFAI.resources
 import pyFAI.calibrant
 import pyFAI.detectors
-
-import fabio
+import pyFAI.io.image
 
 
 try:
@@ -386,8 +385,8 @@ def setup_model(model, options):
         try:
             with settings.mask().lockContext() as model:
                 model.setFilename(options.mask)
-                with fabio.open(options.mask) as mask:
-                    model.setValue(mask.data)
+                data = pyFAI.io.image.read_image_data(options.mask)
+                model.setValue(data)
                 model.setSynchronized(True)
         except Exception as e:
             displayExceptionBox("Error while loading the mask", e)
@@ -399,8 +398,7 @@ def setup_model(model, options):
         try:
             with settings.image().lockContext() as model:
                 model.setFilename(options.mask)
-                with fabio.open(image_file) as image:
-                    model.setValue(image.data)
+                data = pyFAI.io.image.read_image_data(image_file)
                 model.setSynchronized(True)
         except Exception as e:
             displayExceptionBox("Error while loading the image", e)

--- a/pyFAI/app/integrate.py
+++ b/pyFAI/app/integrate.py
@@ -676,6 +676,7 @@ def process(input_data, output, config, monitor_name, observer, write_mode=HDF5W
         logger.error("Processing cancelled")
         logger.info("To write HDF5, convenient options can be provided to decide what to do.")
         logger.info("Options: --delete (always delete the file) --append (create a new entry) --overwrite (overwrite this entry)")
+        writer.close()
         return 1
 
     # Integrate all the provided frames one by one

--- a/pyFAI/app/integrate.py
+++ b/pyFAI/app/integrate.py
@@ -710,8 +710,10 @@ def process(input_data, output, config, monitor_name, observer, write_mode=HDF5W
     if observer.is_interruption_requested():
         logger.error("Processing was aborted")
         observer.processing_interrupted()
+        result = 2
     else:
         observer.processing_succeeded()
+        result = 0
     observer.processing_finished()
 
     statistics.execution_finished()
@@ -720,7 +722,7 @@ def process(input_data, output, config, monitor_name, observer, write_mode=HDF5W
     logger.info("[Per frames] Reading time: %.0fms; Processing time: %.0fms", statistics.reading_per_frame() * 1000, statistics.processing_per_frame() * 1000)
     logger.info("[Total] Reading time: %.3fs; Processing time: %.3fs", statistics.total_reading(), statistics.total_processing())
     logger.info("Execution done in %.3fs !", statistics.total_execution())
-    return 0
+    return result
 
 
 def integrate_shell(options, args):

--- a/pyFAI/app/integrate.py
+++ b/pyFAI/app/integrate.py
@@ -396,7 +396,7 @@ class DataSource(object):
                                    header=fimg.header,
                                    source_filename=filename)
             else:
-                self._frames_per_items.append(iitem)
+                self._frames_per_items.append(1)
                 with self._statistics.time_reading():
                     data = fabio_image.data[...]
                 yield DataInfo(source=item,

--- a/pyFAI/gui/ApplicationContext.py
+++ b/pyFAI/gui/ApplicationContext.py
@@ -174,11 +174,6 @@ class ApplicationContext(object):
         self.__configureDialog(dialog)
 
         if previousFile is not None:
-            if os.path.exists(previousFile):
-                if os.path.isdir(previousFile):
-                    directory = previousFile
-                else:
-                    directory = os.path.dirname(previousFile)
-                dialog.setDirectory(directory)
+            dialog.selectUrl(previousFile)
 
         return dialog

--- a/pyFAI/gui/ApplicationContext.py
+++ b/pyFAI/gui/ApplicationContext.py
@@ -60,6 +60,7 @@ class ApplicationContext(object):
         assert(ApplicationContext.__instance is None)
         self.__parent = None
         self.__dialogStates = {}
+        self.__dialogGeometry = {}
         self.__settings = settings
         ApplicationContext.__instance = self
 
@@ -135,9 +136,13 @@ class ApplicationContext(object):
             dialog.setDirectory(currentDirectory)
         else:
             dialog.restoreState(dialogState)
+        geometry = self.__dialogGeometry.get(type(dialog), None)
+        if geometry is not None:
+            dialog.setGeometry(geometry)
 
     def __saveDialogState(self, dialog):
         self.__dialogStates[type(dialog)] = dialog.saveState()
+        self.__dialogGeometry[type(dialog)] = dialog.geometry()
 
     def createFileDialog(self, parent, previousFile=None):
         """Create a file dialog configured with a default path.

--- a/pyFAI/gui/model/AbstractModel.py
+++ b/pyFAI/gui/model/AbstractModel.py
@@ -27,8 +27,10 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "17/12/2018"
+__date__ = "28/02/2019"
 
+
+import contextlib
 from silx.gui import qt
 
 
@@ -56,7 +58,23 @@ class AbstractModel(qt.QObject):
             self.changed.emit()
             return True
 
+    def isLocked(self):
+        """Returns True if the events are locked.
+
+        :rtype: bool
+        """
+        return self.__isLocked > 0
+
+    @contextlib.contextmanager
+    def lockContext(self):
+        """Context manager to lock and unlock signals."""
+        self.lockSignals()
+        yield self
+        self.unlockSignals()
+
     def lockSignals(self):
+        """Lock the change events
+        """
         self.__isLocked = self.__isLocked + 1
 
     def unlockSignals(self):

--- a/pyFAI/gui/model/ExperimentSettingsModel.py
+++ b/pyFAI/gui/model/ExperimentSettingsModel.py
@@ -27,40 +27,37 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/12/2018"
+__date__ = "28/02/2019"
 
 from .AbstractModel import AbstractModel
 from .DetectorModel import DetectorModel
 from .CalibrantModel import CalibrantModel
 from .DataModel import DataModel
 from .MaskedImageModel import MaskedImageModel
-from .ImageModel import ImageModel
+from .ImageModel import ImageFromFilenameModel
 
 
 class ExperimentSettingsModel(AbstractModel):
 
     def __init__(self, parent=None):
         super(ExperimentSettingsModel, self).__init__(parent)
-        self.__image = ImageModel()
-        self.__mask = ImageModel()
+        self.__image = ImageFromFilenameModel()
+        self.__mask = ImageFromFilenameModel()
         self.__maskedImage = MaskedImageModel(None, self.__image, self.__mask)
+        self.__dark = ImageFromFilenameModel()
         self.__isDetectorMask = True
 
-        self.__dark = ImageModel()
-        self.__imageFile = DataModel()
-        self.__maskFile = DataModel()
-        self.__darkFile = DataModel()
         self.__wavelength = DataModel()
         self.__polarizationFactor = DataModel()
         self.__calibrantModel = CalibrantModel()
         self.__detectorModel = DetectorModel()
 
         self.__image.changed.connect(self.wasChanged)
+        self.__image.filenameChanged.connect(self.wasChanged)
         self.__mask.changed.connect(self.wasChanged)
+        self.__mask.filenameChanged.connect(self.wasChanged)
         self.__dark.changed.connect(self.wasChanged)
-        self.__imageFile.changed.connect(self.wasChanged)
-        self.__maskFile.changed.connect(self.wasChanged)
-        self.__darkFile.changed.connect(self.wasChanged)
+        self.__dark.filenameChanged.connect(self.wasChanged)
         self.__wavelength.changed.connect(self.wasChanged)
         self.__polarizationFactor.changed.connect(self.wasChanged)
         self.__calibrantModel.changed.connect(self.wasChanged)
@@ -71,7 +68,7 @@ class ExperimentSettingsModel(AbstractModel):
         self.__mask.changed.connect(self.__notAnymoreADetectorMask)
 
     def __updateDetectorMask(self):
-        if self.maskFile().value() is not None:
+        if self.mask().filename() is not None:
             # It exists a custom mask
             return
 
@@ -142,15 +139,6 @@ class ExperimentSettingsModel(AbstractModel):
 
     def dark(self):
         return self.__dark
-
-    def imageFile(self):
-        return self.__imageFile
-
-    def maskFile(self):
-        return self.__maskFile
-
-    def darkFile(self):
-        return self.__darkFile
 
     def wavelength(self):
         return self.__wavelength

--- a/pyFAI/gui/model/ImageModel.py
+++ b/pyFAI/gui/model/ImageModel.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/12/2018"
+__date__ = "27/02/2019"
 
 import numpy
 from .DataModel import DataModel
@@ -52,3 +52,29 @@ class ImageModel(DataModel):
                 # Filter same images
                 return
         super(ImageModel, self).setValue(value)
+
+
+class ImageFilenameModel(DataModel):
+    """Model storing an image using it's filename."""
+
+    def hasFilename(self):
+        """True if this model contains a filename.
+
+        :rtype: bool
+        """
+        return self.value() is not None
+
+    def filename(self):
+        """Returns the filename associated with this model.
+
+        :rtype: Union[None,str]
+        """
+        return self.value()
+
+    def setFilename(self, filename):
+        """
+        Set a filename to this model
+
+        :param str filename: The new filename
+        """
+        return self.setValue(filename)

--- a/pyFAI/gui/model/ImageModel.py
+++ b/pyFAI/gui/model/ImageModel.py
@@ -27,9 +27,12 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "27/02/2019"
+__date__ = "28/02/2019"
 
 import numpy
+
+from silx.gui import qt
+
 from .DataModel import DataModel
 
 
@@ -57,6 +60,8 @@ class ImageModel(DataModel):
 class ImageFilenameModel(DataModel):
     """Model storing an image using it's filename."""
 
+    filenameChanged = DataModel.changed
+
     def hasFilename(self):
         """True if this model contains a filename.
 
@@ -78,3 +83,90 @@ class ImageFilenameModel(DataModel):
         :param str filename: The new filename
         """
         return self.setValue(filename)
+
+
+class ImageFromFilenameModel(DataModel):
+    """Model storing an image array which could come from a filename.
+
+    This model deal with unsynchronized filename/data.
+    """
+
+    filenameChanged = qt.Signal()
+
+    def __init__(self, parent=None):
+        self.__filename = None
+        self.__wasChanged = False
+        DataModel.__init__(self, parent=parent)
+
+    def setValue(self, value):
+        """Set the value of this image model."""
+        if value is not None:
+            if not isinstance(value, numpy.ndarray):
+                raise TypeError("A numpy array is expected, but %s was found." % value.__class__.__name__)
+            if len(value.shape) != 2:
+                raise TypeError("A 2d array is expected, but %s was found." % value.shape)
+            if value.dtype.kind not in "uif":
+                raise TypeError("A numeric array is expected, but %s was found." % value.dtype.kind)
+            previous = self.value()
+            if previous is value:
+                # Filter same images
+                return
+            if previous is not None and numpy.array_equal(value, previous):
+                # Filter same images
+                return
+        super(ImageFromFilenameModel, self).setValue(value)
+        self.__isSynchronized = False
+
+    def hasFilename(self):
+        """True if this model contains a filename.
+
+        :rtype: bool
+        """
+        return self.__filename is not None
+
+    def filename(self):
+        """Returns the filename associated with this model.
+
+        :rtype: Union[None,str]
+        """
+        return self.__filename
+
+    def unlockSignals(self):
+        self.__filenameWasChanged()
+        self.__wasChanged = False
+        return DataModel.unlockSignals(self)
+
+    def __filenameWasChanged(self):
+        """Emit the change event in case of the model was not locked.
+
+        :returns: True if the signal was emitted.
+        """
+        if self.isLocked():
+            self.__wasChanged = True
+            return False
+        else:
+            self.filenameChanged.emit()
+            return True
+
+    def setFilename(self, filename):
+        """
+        Set a filename to this model
+
+        :param str filename: The new filename
+        """
+        self.__filename = filename
+        self.__isSynchronized = False
+        self.__filenameWasChanged()
+
+    def setSynchronized(self, isSynchronized):
+        """"
+        Set if the filename and the data are synchronized.
+        """
+        self.__isSynchronized = isSynchronized
+
+    def isSynchronized(self):
+        """Returns True if the filename and the data are synchronized.
+
+        Both contains the same data.
+        """
+        return self.__isSynchronized

--- a/pyFAI/gui/tasks/MaskTask.py
+++ b/pyFAI/gui/tasks/MaskTask.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "03/01/2019"
+__date__ = "28/02/2019"
 
 import logging
 import os.path
@@ -84,10 +84,10 @@ class _MaskToolsWidget(silx.gui.plot.MaskToolsWidget.MaskToolsWidget):
         experimentSettings = model.experimentSettingsModel()
 
         # Reach from the previous mask
-        previousFile = experimentSettings.maskFile().value()
+        previousFile = experimentSettings.mask().filename()
         directory = self.__extractDirectory(previousFile)
         if directory is None:
-            previousFile = experimentSettings.imageFile().value()
+            previousFile = experimentSettings.image().filename()
             directory = self.__extractDirectory(previousFile)
         if directory is None:
             directory = os.getcwd()
@@ -118,8 +118,9 @@ class _MaskToolsWidget(silx.gui.plot.MaskToolsWidget.MaskToolsWidget):
     def __maskFilenameUpdated(self, filename):
         model = CalibrationContext.instance().getCalibrationModel()
         experimentSettings = model.experimentSettingsModel()
-        maskModel = experimentSettings.maskFile()
-        maskModel.setValue(filename)
+        with experimentSettings.mask().lockContext() as mask:
+            mask.setFilename(filename)
+            mask.setSynchronized(True)
 
     def setSelectionMask(self, mask, copy=True):
         self.sigMaskChanged.disconnect(self.__emitUserMaskChanged)

--- a/pyFAI/gui/widgets/FileEdit.py
+++ b/pyFAI/gui/widgets/FileEdit.py
@@ -193,19 +193,22 @@ class FileEdit(qt.QLineEdit):
     def __applyFilename(self, filename):
         model = self.__model
         if isinstance(model, ImageFromFilenameModel):
-            try:
-                with fabio.open(filename) as image:
-                    data = image.data
-            except Exception as e:
-                message = "Filename '%s' not supported.<br />%s", (filename, str(e))
-                qt.QMessageBox.critical(self, "Loading image error", message)
-                _logger.error("Error while loading %s" % filename)
-                _logger.debug("Backtrace", exc_info=True)
+            if filename is not None:
+                try:
+                    with fabio.open(filename) as image:
+                        data = image.data
+                except Exception as e:
+                    message = "Filename '%s' not supported.<br />%s", (filename, str(e))
+                    qt.QMessageBox.critical(self, "Loading image error", message)
+                    _logger.error("Error while loading %s" % filename)
+                    _logger.debug("Backtrace", exc_info=True)
+                    return
             else:
-                with model.lockContext():
-                    model.setValue(data)
-                    model.setFilename(filename)
-                    model.setSynchronized(True)
+                data, filename = None, None
+            with model.lockContext():
+                model.setValue(data)
+                model.setFilename(filename)
+                model.setSynchronized(True)
 
         elif isinstance(model, (DataModel, ImageFilenameModel)):
             previous = self.__model.value()

--- a/pyFAI/gui/widgets/FileEdit.py
+++ b/pyFAI/gui/widgets/FileEdit.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "01/02/2019"
+__date__ = "28/02/2019"
 
 import logging
 from silx.gui import qt
@@ -90,13 +90,7 @@ class FileEdit(qt.QLineEdit):
             return
 
         path = urls[0].toLocalFile()
-        previous = self.__model.value()
-        try:
-            self.__model.setValue(path)
-        except Exception as e:
-            qt.QMessageBox.critical(self, "Drop cancelled", str(e))
-            if self.__model.value() is not previous:
-                self.__model.setValue(previous)
+        self.__applyFilename(path)
 
     def setModel(self, model):
         if self.__model is not None:
@@ -148,7 +142,7 @@ class FileEdit(qt.QLineEdit):
             value = text
 
         try:
-            self.__model.setValue(value)
+            self.__applyFilename(value)
             # Avoid sending further signals
             self.__previousText = text
             self.sigValueAccepted.emit()
@@ -158,7 +152,7 @@ class FileEdit(qt.QLineEdit):
 
     def __cancelText(self):
         """Reset the edited value to the original one"""
-        value = self.__model.value()
+        value = self.__getFilename()
         if value is None:
             text = ""
         else:
@@ -179,3 +173,15 @@ class FileEdit(qt.QLineEdit):
     """Apply the current edited value to the widget when it lose the
     focus. By default the previous value is displayed.
     """
+
+    def __getFilename(self):
+        return self.__model.value()
+
+    def __applyFilename(self, filename):
+        previous = self.__model.value()
+        try:
+            self.__model.setValue(filename)
+        except Exception as e:
+            qt.QMessageBox.critical(self, "Filename '%s' not supported: %s", (filename, str(e)))
+            if self.__model.value() is not previous:
+                self.__model.setValue(previous)

--- a/pyFAI/gui/widgets/FileEdit.py
+++ b/pyFAI/gui/widgets/FileEdit.py
@@ -27,16 +27,16 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "28/02/2019"
+__date__ = "01/03/2019"
 
 import logging
 
-import fabio
 from silx.gui import qt
 
 from ..model.DataModel import DataModel
 from ..model.ImageModel import ImageFromFilenameModel
 from ..model.ImageModel import ImageFilenameModel
+import pyFAI.io.image
 
 
 _logger = logging.getLogger(__name__)
@@ -202,8 +202,7 @@ class FileEdit(qt.QLineEdit):
             if isinstance(model, ImageFromFilenameModel):
                 if filename is not None:
                     try:
-                        with fabio.open(filename) as image:
-                            data = image.data
+                        data = pyFAI.io.image.read_image_data(filename)
                     except Exception as e:
                         message = "Filename '%s' not supported.<br />%s" % (filename, str(e))
                         title = "Loading image error"

--- a/pyFAI/gui/widgets/FileEdit.py
+++ b/pyFAI/gui/widgets/FileEdit.py
@@ -24,7 +24,6 @@
 # ###########################################################################*/
 
 from __future__ import absolute_import
-from pyFAI.gui.model.ImageModel import ImageFilenameModel
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
@@ -37,6 +36,7 @@ from silx.gui import qt
 
 from ..model.DataModel import DataModel
 from ..model.ImageModel import ImageFromFilenameModel
+from ..model.ImageModel import ImageFilenameModel
 
 
 _logger = logging.getLogger(__name__)

--- a/pyFAI/gui/widgets/LoadImageToolButton.py
+++ b/pyFAI/gui/widgets/LoadImageToolButton.py
@@ -1,0 +1,164 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+from __future__ import absolute_import
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "27/02/2019"
+
+import os
+
+from silx.gui import qt
+
+from ..model.ImageModel import ImageFilenameModel
+from ..ApplicationContext import ApplicationContext
+from ..utils.FilterBuilder import FilterBuilder
+
+
+class _LoadImageFromFileDialogAction(qt.QAction):
+    """Action loading an image using the default `QFileDialog`."""
+
+    def __init__(self, parent):
+        qt.QAction.__init__(self, parent=parent)
+        self.triggered.connect(self.__execute)
+        self.setText("Use file dialog")
+
+    def __execute(self):
+        previousFile = self.parent().model().filename()
+        if previousFile is None:
+            previousFile = os.getcwd()
+
+        context = ApplicationContext.instance()
+        dialog = context.createFileDialog(self.parent(),
+                                          previousFile=previousFile)
+
+        builder = FilterBuilder()
+        builder.addImageFormat("EDF image files", "edf edf.gz")
+        builder.addImageFormat("TIFF image files", "tif tiff tif.gz tiff.gz")
+        builder.addImageFormat("NumPy binary files", "npy")
+        builder.addImageFormat("CBF files", "cbf")
+        builder.addImageFormat("MarCCD image files", "mccd")
+        builder.addImageFormat("Fit2D mask files", "msk")
+        dialog.setNameFilters(builder.getFilters())
+
+        dialog.setWindowTitle(self.parent().dialogTitle())
+        dialog.setModal(True)
+        dialog.setFileMode(qt.QFileDialog.ExistingFile)
+
+        result = dialog.exec_()
+        if result:
+            filename = dialog.selectedFiles()[0]
+            self.parent()._setFilename(filename)
+
+
+class _LoadImageFromImageDialogAction(qt.QAction):
+    """Action loading an image using the silx ImageFileDialog."""
+
+    def __init__(self, parent):
+        qt.QAction.__init__(self, parent=parent)
+        self.triggered.connect(self.__execute)
+        self.setText("Use image dialog")
+
+    def __execute(self):
+        previousFile = self.parent().model().filename()
+
+        context = ApplicationContext.instance()
+        dialog = context.createImageFileDialog(self.parent(),
+                                               previousFile=previousFile)
+        dialog.setWindowTitle(self.parent().dialogTitle())
+        dialog.setModal(True)
+
+        result = dialog.exec_()
+        if result:
+            url = dialog.selectedUrl()
+            self.parent()._setFilename(url)
+
+
+class LoadImageToolButton(qt.QToolButton):
+    """ToolButton updating a DataModel using the selection from a file dialog.
+    """
+
+    def __init__(self, parent=None):
+        super(LoadImageToolButton, self).__init__(parent)
+        self.__model = None
+        self.__isEnabled = True
+        self.__dialogTitle = "Select an image"
+
+        loadFileAction = _LoadImageFromFileDialogAction(self)
+        loadImageAction = _LoadImageFromImageDialogAction(self)
+
+        self.addAction(loadImageAction)
+        self.addAction(loadFileAction)
+        self.setDefaultAction(loadImageAction)
+
+    def setEnabled(self, enabled):
+        if self.__isEnabled == enabled:
+            return
+        self.__isEnabled = enabled
+        self.__updateEnabledState()
+
+    def isEnabled(self):
+        return self.__isEnabled
+
+    def __updateEnabledState(self):
+        enabledState = self.__model is not None and self.__isEnabled
+        qt.QToolButton.setEnabled(self, enabledState)
+
+    def _setFilename(self, filename):
+        if self.__model is None:
+            return
+        if isinstance(self.__model, ImageFilenameModel):
+            self.__model.setFilename(filename)
+        else:
+            return self.__model.setValue(filename)
+
+    def filename(self):
+        if self.__model is None:
+            return None
+        if isinstance(self.__model, ImageFilenameModel):
+            return self.__model.filename()
+        return self.__model.value()
+
+    def setModel(self, model):
+        self.__model = model
+        self.__updateEnabledState()
+
+    def model(self):
+        return self.__model
+
+    def dialogTitle(self):
+        """Returns the specified dialog title
+
+        :rtype: str
+        """
+        return self.__dialogTitle
+
+    def setDialogTitle(self, title):
+        """Specify a title for the dialog
+
+        :param str title: Title of the dialog
+        """
+        return self.__dialogTitle

--- a/pyFAI/gui/widgets/MonitorNameEdit.py
+++ b/pyFAI/gui/widgets/MonitorNameEdit.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+from __future__ import absolute_import
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "01/03/2019"
+
+import logging
+
+from silx.gui import qt
+from silx.io.url import DataUrl
+
+_logger = logging.getLogger(__name__)
+
+
+class MonitorNameEdit(qt.QLineEdit):
+    """
+    QLineEdit specialied to select a monitor name from HDF5 file.
+    """
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasFormat("application/x-silx-uri"):
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        mimeData = event.mimeData()
+        if mimeData.hasFormat("application/x-silx-uri"):
+            byteString = event.mimeData().data("application/x-silx-uri")
+            path = byteString.data().decode("utf-8")
+            url = DataUrl(path)
+            self.setText(url.data_path())
+        else:
+            qt.QMessageBox.critical(self, "Drop cancelled", "A HDF5 path is expected")
+            return

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/02/2019"
+__date__ = "01/03/2019"
 __status__ = "development"
 
 import logging
@@ -111,12 +111,15 @@ class WorkerConfigurator(qt.QWidget):
         self.file_import.clicked.connect(self.__selectFile)
 
         # Connect mask/dark/flat
+        self.mask_file.setModel(self.__model.maskFileModel)
         self.file_mask_file.setDialogTitle("Open a mask image")
         self.file_mask_file.setModel(self.__model.maskFileModel)
         self.__model.maskFileModel.changed.connect(self.__maskFileChanged)
+        self.dark_current.setModel(self.__model.darkFileModel)
         self.file_dark_current.setDialogTitle("Open a dark image")
         self.file_dark_current.setModel(self.__model.darkFileModel)
         self.__model.darkFileModel.changed.connect(self.__darkFileChanged)
+        self.flat_field.setModel(self.__model.flatFileModel)
         self.file_flat_field.setDialogTitle("Open a flatfield image")
         self.file_flat_field.setModel(self.__model.flatFileModel)
         self.__model.flatFileModel.changed.connect(self.__flatFileChanged)
@@ -524,30 +527,18 @@ class WorkerConfigurator(qt.QWidget):
         if model.hasFilename():
             self.do_mask.setChecked(True)
             self.__updateDisabledStates()
-        value = model.filename()
-        if value is None:
-            value = ""
-        self.mask_file.setText(value)
 
     def __darkFileChanged(self):
         model = self.__model.darkFileModel
         if model.hasFilename():
             self.do_dark.setChecked(True)
             self.__updateDisabledStates()
-        value = model.filename()
-        if value is None:
-            value = ""
-        self.dark_current.setText(value)
 
     def __flatFileChanged(self):
         model = self.__model.flatFileModel
         if model.hasFilename():
             self.do_flat.setChecked(True)
             self.__updateDisabledStates()
-        value = model.filename()
-        if value is None:
-            value = ""
-        self.flat_field.setText(value)
 
     def loadFromJsonFile(self, filename):
         """Initialize the widget using a json file."""

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -213,7 +213,7 @@ class WorkerConfigurator(qt.QWidget):
             filenames = filenames.strip()
             if filenames == "":
                 return None
-            return [name.strip() for name in filenames.split(",")]
+            return [name.strip() for name in filenames.split("|")]
 
         config = collections.OrderedDict()
 
@@ -357,7 +357,7 @@ class WorkerConfigurator(qt.QWidget):
             if filenames is None:
                 return ""
             if isinstance(filenames, list):
-                return ",".join(filenames)
+                return "|".join(filenames)
             filenames = filenames.strip()
             return filenames
 

--- a/pyFAI/gui/widgets/WorkerConfigurator.py
+++ b/pyFAI/gui/widgets/WorkerConfigurator.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/02/2019"
+__date__ = "27/02/2019"
 __status__ = "development"
 
 import logging
@@ -57,10 +57,19 @@ from ..model.DataModel import DataModel
 from ..utils import units
 from ...utils import stringutil
 from ..utils import FilterBuilder
+from ..model.ImageModel import ImageFilenameModel
 from ..utils import validators
 from ...io.ponifile import PoniFile
 from ...io import integration_config
 from ... import method_registry
+
+
+class _WorkerModel(object):
+
+    def __init__(self):
+        self.maskFileModel = ImageFilenameModel()
+        self.darkFileModel = ImageFilenameModel()
+        self.flatFileModel = ImageFilenameModel()
 
 
 class WorkerConfigurator(qt.QWidget):
@@ -72,6 +81,8 @@ class WorkerConfigurator(qt.QWidget):
         qt.QWidget.__init__(self, parent)
         filename = get_ui_file("worker-configurator.ui")
         qt.loadUi(filename, self)
+
+        self.__model = _WorkerModel()
 
         self.__openclDevice = None
         self.__method = None
@@ -96,11 +107,20 @@ class WorkerConfigurator(qt.QWidget):
         self.method_config_button.clicked.connect(self.selectMethod)
         self.show_geometry.clicked.connect(self.selectGeometry)
 
-        # connect file selection windows
+        # Connect file selection windows
         self.file_import.clicked.connect(self.__selectFile)
-        self.file_mask_file.clicked.connect(self.__selectMaskFile)
-        self.file_dark_current.clicked.connect(self.__selectDarkCurrent)
-        self.file_flat_field.clicked.connect(self.__selectFlatField)
+
+        # Connect mask/dark/flat
+        self.file_mask_file.setDialogTitle("Open a mask image")
+        self.file_mask_file.setModel(self.__model.maskFileModel)
+        self.__model.maskFileModel.changed.connect(self.__maskFileChanged)
+        self.file_dark_current.setDialogTitle("Open a dark image")
+        self.file_dark_current.setModel(self.__model.darkFileModel)
+        self.__model.darkFileModel.changed.connect(self.__darkFileChanged)
+        self.file_flat_field.setDialogTitle("Open a flatfield image")
+        self.file_flat_field.setModel(self.__model.flatFileModel)
+        self.__model.flatFileModel.changed.connect(self.__flatFileChanged)
+
         self.do_2D.toggled.connect(self.__dimChanged)
 
         npt_validator = qt.QIntValidator()
@@ -348,9 +368,9 @@ class WorkerConfigurator(qt.QWidget):
                       "val_dummy": lambda a: self.val_dummy.setText(str_(a)),
                       "delta_dummy": lambda a: self.delta_dummy.setText(str_(a)),
                       "do_mask": self.do_mask.setChecked,
-                      "mask_file": lambda a: self.mask_file.setText(str_(a)),
-                      "dark_current": lambda a: self.dark_current.setText(normalizeFiles(a)),
-                      "flat_field": lambda a: self.flat_field.setText(normalizeFiles(a)),
+                      "mask_file": lambda a: self.__model.maskFileModel.setFilename(str_(a)),
+                      "dark_current": lambda a: self.__model.darkFileModel.setFilename(normalizeFiles(a)),
+                      "flat_field": lambda a: self.__model.flatFileModel.setFilename(normalizeFiles(a)),
                       "polarization_factor": self.polarization_factor.setValue,
                       "nbpt_rad": lambda a: self.nbpt_rad.setText(str_(a)),
                       "nbpt_azim": lambda a: self.nbpt_azim.setText(str_(a)),
@@ -499,26 +519,35 @@ class WorkerConfigurator(qt.QWidget):
         else:
             logger.error("File %s unsupported", filename)
 
-    def __selectMaskFile(self):
-        logger.debug("select_maskfile")
-        maskfile = self.getOpenFileName("Open a mask image")
-        if maskfile:
-            self.mask_file.setText(maskfile or "")
+    def __maskFileChanged(self):
+        model = self.__model.maskFileModel
+        if model.hasFilename():
             self.do_mask.setChecked(True)
+            self.__updateDisabledStates()
+        value = model.filename()
+        if value is None:
+            value = ""
+        self.mask_file.setText(value)
 
-    def __selectDarkCurrent(self):
-        logger.debug("select_darkcurrent")
-        darkcurrent = self.getOpenFileName("Open a dark image")
-        if darkcurrent:
-            self.dark_current.setText(str_(darkcurrent))
+    def __darkFileChanged(self):
+        model = self.__model.darkFileModel
+        if model.hasFilename():
             self.do_dark.setChecked(True)
+            self.__updateDisabledStates()
+        value = model.filename()
+        if value is None:
+            value = ""
+        self.dark_current.setText(value)
 
-    def __selectFlatField(self):
-        logger.debug("select_flatfield")
-        flatfield = self.getOpenFileName("Open a flatfield image")
-        if flatfield:
-            self.flat_field.setText(str_(flatfield))
+    def __flatFileChanged(self):
+        model = self.__model.flatFileModel
+        if model.hasFilename():
             self.do_flat.setChecked(True)
+            self.__updateDisabledStates()
+        value = model.filename()
+        if value is None:
+            value = ""
+        self.flat_field.setText(value)
 
     def loadFromJsonFile(self, filename):
         """Initialize the widget using a json file."""

--- a/pyFAI/io/__init__.py
+++ b/pyFAI/io/__init__.py
@@ -45,7 +45,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "26/02/2019"
+__date__ = "01/03/2019"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -482,6 +482,16 @@ class HDF5Writer(Writer):
         if self.hdf5:
             self.flush()
             with self._sem:
+                # Remove any links to HDF5 file
+                self.entry = None
+                self.nxdata = None
+                self.config = None
+                self.process = None
+                self.dataset = None
+                self.radial_values = None
+                self.azimuthal_values = None
+                self.fast_motor = None
+                # Close the file
                 self.hdf5.close()
                 self.hdf5 = None
 

--- a/pyFAI/io/image.py
+++ b/pyFAI/io/image.py
@@ -49,6 +49,10 @@ def read_image_data(image_path):
             data = image.data
     elif image_path.startswith("silx:") or image_path.startswith("fabio:"):
         data = silx.io.get_data(image_path)
+    elif "::" in image_path:
+        # Could be a fabio path
+        with fabio.open(image_path) as image:
+            data = image.data
     else:
         raise IOError("Data from path '%s' is not supported or missing")
 

--- a/pyFAI/io/image.py
+++ b/pyFAI/io/image.py
@@ -54,7 +54,7 @@ def read_image_data(image_path):
         with fabio.open(image_path) as image:
             data = image.data
     else:
-        raise IOError("Data from path '%s' is not supported or missing")
+        raise IOError("Data from path '%s' is not supported or missing" % image_path)
 
     if len(data.shape) != 2:
         raise TypeError("Path identify a %dd-array, but a 2d is array is expected" % (image_path, len(data.shape)))

--- a/pyFAI/io/image.py
+++ b/pyFAI/io/image.py
@@ -1,0 +1,60 @@
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015-2019 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Module function to read images.
+"""
+
+import os.path
+import fabio
+import silx.io
+
+
+def read_image_data(image_path):
+    """
+    Returns a numpy.array image from a file name or a URL.
+
+    :param str image_path: Path of the image file
+    :rtype: numpy.ndarray
+    :raises IOError: if the data is not reachable
+    :raises TypeError: if the data is not an image (wrong size, wrong dimension)
+    """
+    if fabio is None:
+        raise RuntimeError("FabIO is missing")
+    if os.path.exists(image_path):
+        with fabio.open(image_path) as image:
+            data = image.data
+    elif image_path.startswith("silx:") or image_path.startswith("fabio:"):
+        data = silx.io.get_data(image_path)
+    else:
+        raise IOError("Data from path '%s' is not supported or missing")
+
+    if len(data.shape) != 2:
+        raise TypeError("Path identify a %dd-array, but a 2d is array is expected" % (image_path, len(data.shape)))
+    if data.dtype.kind not in "fui":
+        raise TypeError("Path identify an %s-kind array, but a numerical kind is expected" % (image_path, data.dtype.kind))
+
+    return data

--- a/pyFAI/resources/gui/calibration-experiment.ui
+++ b/pyFAI/resources/gui/calibration-experiment.ui
@@ -248,7 +248,10 @@
         </property>
         <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
          <item row="0" column="2">
-          <widget class="QToolButton" name="_imageLoader">
+          <widget class="LoadImageToolButton" name="_imageLoader">
+           <property name="toolTip">
+            <string>Load an image to calibrate</string>
+           </property>
            <property name="text">
             <string>...</string>
            </property>
@@ -272,7 +275,10 @@
           </widget>
          </item>
          <item row="5" column="2">
-          <widget class="QToolButton" name="_darkLoader">
+          <widget class="LoadImageToolButton" name="_darkLoader">
+           <property name="toolTip">
+            <string>Load a dark current file</string>
+           </property>
            <property name="text">
             <string>...</string>
            </property>
@@ -300,7 +306,10 @@
           </widget>
          </item>
          <item row="4" column="2">
-          <widget class="QToolButton" name="_maskLoader">
+          <widget class="LoadImageToolButton" name="_maskLoader">
+           <property name="toolTip">
+            <string>Load a mask file</string>
+           </property>
            <property name="text">
             <string>...</string>
            </property>
@@ -406,9 +415,19 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>DetectorLabel</class>
+   <extends>QLabel</extends>
+   <header>pyFAI.gui.widgets.DetectorLabel</header>
+  </customwidget>
+  <customwidget>
    <class>QuantityEdit</class>
    <extends>QLineEdit</extends>
    <header>pyFAI.gui.widgets.QuantityEdit</header>
+  </customwidget>
+  <customwidget>
+   <class>LoadImageToolButton</class>
+   <extends>QToolButton</extends>
+   <header>pyFAI.gui.widgets.LoadImageToolButton</header>
   </customwidget>
   <customwidget>
    <class>FileEdit</class>
@@ -430,11 +449,6 @@
    <class>ElidedLabel</class>
    <extends>QLabel</extends>
    <header>pyFAI.gui.widgets.ElidedLabel</header>
-  </customwidget>
-  <customwidget>
-   <class>DetectorLabel</class>
-   <extends>QLabel</extends>
-   <header>pyFAI.gui.widgets.DetectorLabel</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pyFAI/resources/gui/worker-configurator.ui
+++ b/pyFAI/resources/gui/worker-configurator.ui
@@ -202,7 +202,7 @@
        </widget>
       </item>
       <item row="2" column="1" colspan="3">
-       <widget class="QLineEdit" name="flat_field">
+       <widget class="FileEdit" name="flat_field">
         <property name="toolTip">
          <string>File containing the flat-field image</string>
         </property>
@@ -266,14 +266,14 @@
        </widget>
       </item>
       <item row="0" column="1" colspan="3">
-       <widget class="QLineEdit" name="mask_file">
+       <widget class="FileEdit" name="mask_file">
         <property name="toolTip">
          <string>File containing the image of the mask</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1" colspan="3">
-       <widget class="QLineEdit" name="dark_current">
+       <widget class="FileEdit" name="dark_current">
         <property name="toolTip">
          <string>File containing the dark image</string>
         </property>
@@ -651,6 +651,11 @@
    <class>MonitorNameEdit</class>
    <extends>QLineEdit</extends>
    <header>pyFAI.gui.widgets.MonitorNameEdit</header>
+  </customwidget>
+  <customwidget>
+   <class>FileEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pyFAI.gui.widgets.FileEdit</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pyFAI/resources/gui/worker-configurator.ui
+++ b/pyFAI/resources/gui/worker-configurator.ui
@@ -550,9 +550,12 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QLineEdit" name="monitor_name">
+       <widget class="MonitorNameEdit" name="monitor_name">
         <property name="toolTip">
          <string>Monitor name to reach normalization from the header of the input data</string>
+        </property>
+        <property name="text">
+         <string/>
         </property>
        </widget>
       </item>
@@ -643,6 +646,11 @@
    <class>LoadImageToolButton</class>
    <extends>QToolButton</extends>
    <header>pyFAI.gui.widgets.LoadImageToolButton</header>
+  </customwidget>
+  <customwidget>
+   <class>MonitorNameEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pyFAI.gui.widgets.MonitorNameEdit</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pyFAI/resources/gui/worker-configurator.ui
+++ b/pyFAI/resources/gui/worker-configurator.ui
@@ -216,14 +216,20 @@
        </widget>
       </item>
       <item row="1" column="4">
-       <widget class="QToolButton" name="file_dark_current">
+       <widget class="LoadImageToolButton" name="file_dark_current">
+        <property name="toolTip">
+         <string>Select a dark current file</string>
+        </property>
         <property name="text">
          <string>...</string>
         </property>
        </widget>
       </item>
       <item row="2" column="4">
-       <widget class="QToolButton" name="file_flat_field">
+       <widget class="LoadImageToolButton" name="file_flat_field">
+        <property name="toolTip">
+         <string>Select a flat field file</string>
+        </property>
         <property name="text">
          <string>...</string>
         </property>
@@ -250,7 +256,10 @@
        </widget>
       </item>
       <item row="0" column="4">
-       <widget class="QToolButton" name="file_mask_file">
+       <widget class="LoadImageToolButton" name="file_mask_file">
+        <property name="toolTip">
+         <string>Select a mask file</string>
+        </property>
         <property name="text">
          <string>...</string>
         </property>
@@ -629,6 +638,11 @@
    <class>MethodLabel</class>
    <extends>QLabel</extends>
    <header>pyFAI.gui.widgets.MethodLabel</header>
+  </customwidget>
+  <customwidget>
+   <class>LoadImageToolButton</class>
+   <extends>QToolButton</extends>
+   <header>pyFAI.gui.widgets.LoadImageToolButton</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pyFAI/test/__init__.py
+++ b/pyFAI/test/__init__.py
@@ -34,7 +34,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "25/08/2017"
+__date__ = "01/03/2019"
 
 import sys
 import os
@@ -44,6 +44,18 @@ import unittest
 from . import utilstest
 # not importing test_all here to prevent premature initialization of UtilsTest
 # and preventing the test skipping
+
+
+# Issue https://github.com/silx-kit/fabio/pull/291
+# Relative to fabio 0.8
+import fabio
+if fabio.hdf5image.Hdf5Image.close.__module__ != "fabio.hdf5image":
+    def close(self):
+        if self.hdf5 is not None:
+            self.hdf5.close()
+            self.hdf5 = None
+            self.dataset = None
+    fabio.hdf5image.Hdf5Image.close = close
 
 
 def suite():

--- a/pyFAI/test/test_all.py
+++ b/pyFAI/test/test_all.py
@@ -33,7 +33,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "19/02/2019"
+__date__ = "01/03/2019"
 
 import sys
 import unittest
@@ -64,6 +64,7 @@ from . import test_sparse
 from . import test_csr
 from . import test_blob_detection
 from . import test_io
+from . import test_io_image
 from . import test_calibrant
 from . import test_polarization
 from . import test_split_pixel
@@ -119,6 +120,7 @@ def suite():
     testsuite.addTest(test_csr.suite())
     testsuite.addTest(test_blob_detection.suite())
     testsuite.addTest(test_io.suite())
+    testsuite.addTest(test_io_image.suite())
     testsuite.addTest(test_calibrant.suite())
     testsuite.addTest(test_polarization.suite())
     testsuite.addTest(test_split_pixel.suite())

--- a/pyFAI/test/test_io_image.py
+++ b/pyFAI/test/test_io_image.py
@@ -42,6 +42,7 @@ import logging
 import os.path
 import shutil
 import numpy
+import h5py
 
 from silx.io.url import DataUrl
 
@@ -60,10 +61,16 @@ class TestReadImage(unittest.TestCase):
         os.makedirs(cls.directory)
 
         cls.a = os.path.join(cls.directory, "a.npy")
+        cls.b = os.path.join(cls.directory, "b.h5")
 
         cls.shape = (2, 2)
         ones = numpy.ones(shape=cls.shape)
         numpy.save(cls.a, ones)
+
+        with h5py.File(cls.b) as h5:
+            h5["/image"] = ones
+            h5["/number"] = 10
+            h5["/group/foo"] = 10
 
     @classmethod
     def tearDownClass(cls):
@@ -83,6 +90,11 @@ class TestReadImage(unittest.TestCase):
     def test_not_existing_file(self):
         with self.assertRaises(Exception):
             image_mdl.read_image_data("fooobar.not.existing")
+
+    def test_fabio_hdf5_file(self):
+        abs_b = os.path.abspath(self.b)
+        image = image_mdl.read_image_data(abs_b + "::/image")
+        self.assertIsNotNone(image)
 
 
 def suite():

--- a/pyFAI/test/test_io_image.py
+++ b/pyFAI/test/test_io_image.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015-2018 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"Test suite for worker"
+
+from __future__ import absolute_import, division, print_function
+
+__author__ = "Valentin Valls"
+__contact__ = "valentin.valls@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "01/03/2019"
+
+
+import unittest
+import logging
+import os.path
+import shutil
+import numpy
+
+from silx.io.url import DataUrl
+
+from ..io import image as image_mdl
+from . import utilstest
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestReadImage(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.directory = os.path.join(utilstest.test_options.tempdir, cls.__name__)
+        os.makedirs(cls.directory)
+
+        cls.a = os.path.join(cls.directory, "a.npy")
+
+        cls.shape = (2, 2)
+        ones = numpy.ones(shape=cls.shape)
+        numpy.save(cls.a, ones)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.directory)
+
+    def test_image_path(self):
+        abs_a = os.path.abspath(self.a)
+        image = image_mdl.read_image_data(abs_a)
+        self.assertIsNotNone(image)
+
+    def test_silx_url(self):
+        abs_a = os.path.abspath(self.a)
+        url = DataUrl(abs_a).path()
+        image = image_mdl.read_image_data(url)
+        self.assertIsNotNone(image)
+
+    def test_not_existing_file(self):
+        with self.assertRaises(Exception):
+            image_mdl.read_image_data("fooobar.not.existing")
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(loader(TestReadImage))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/pyFAI/test/test_worker.py
+++ b/pyFAI/test/test_worker.py
@@ -38,9 +38,13 @@ __date__ = "26/02/2019"
 
 
 import unittest
-import numpy
 import logging
 import os.path
+import shutil
+import numpy
+
+from silx.io.url import DataUrl
+
 from .. import units
 from .. import worker as worker_mdl
 from ..worker import Worker, PixelwiseWorker
@@ -48,7 +52,6 @@ from ..azimuthalIntegrator import AzimuthalIntegrator
 from ..containers import Integrate1dResult
 from ..containers import Integrate2dResult
 from . import utilstest
-import shutil
 
 
 logger = logging.getLogger(__name__)
@@ -339,6 +342,20 @@ class TestWorkerConfig(unittest.TestCase):
         self.assertTrue(numpy.isclose(worker.ai.detector.get_darkcurrent()[0, 0], (1 + 2 + 3) / 3))
         self.assertTrue(numpy.isclose(worker.ai.detector.get_flatfield()[0, 0], (1 + 2 + 4) / 3))
 
+    def test_readimagedata_imagepath(self):
+        abs_a = os.path.abspath(self.a)
+        image = worker_mdl._read_image_data(abs_a)
+        self.assertIsNotNone(image)
+
+    def test_readimagedata_silxurl(self):
+        abs_a = os.path.abspath(self.a)
+        url = DataUrl(abs_a).path()
+        image = worker_mdl._read_image_data(url)
+        self.assertIsNotNone(image)
+
+    def test_readimagedata_notexisting(self):
+        with self.assertRaises(Exception):
+            worker_mdl._read_image_data("fooobar.not.existing")
 
 
 def suite():

--- a/pyFAI/test/test_worker.py
+++ b/pyFAI/test/test_worker.py
@@ -34,14 +34,15 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "04/01/2019"
+__date__ = "26/02/2019"
 
 
 import unittest
 import numpy
 import logging
 import os.path
-from .. import units, worker
+from .. import units
+from .. import worker as worker_mdl
 from ..worker import Worker, PixelwiseWorker
 from ..azimuthalIntegrator import AzimuthalIntegrator
 from ..containers import Integrate1dResult
@@ -263,21 +264,21 @@ class TestWorker(unittest.TestCase):
 
         # Without error propagation
         # Numpy path
-        worker.USE_CYTHON = False
+        worker_mdl.USE_CYTHON = False
         pww = PixelwiseWorker(dark=dark, flat=flat, dummy=-5, dtype="float64")
         res_np = pww.process(raw, normalization_factor=6.0)
         err = abs(res_np - signal / 6.0).max()
         self.assertLess(err, precision, "Numpy calculation are OK: %s" % err)
 
         # Cython path
-        worker.USE_CYTHON = True
+        worker_mdl.USE_CYTHON = True
         res_cy = pww.process(raw, normalization_factor=7.0)
         err = abs(res_cy - signal / 7.0).max()
         self.assertLess(err, precision, "Cython calculation are OK: %s" % err)
 
         # With Poissonian errors
         # Numpy path
-        worker.USE_CYTHON = False
+        worker_mdl.USE_CYTHON = False
         pww = PixelwiseWorker(dark=dark)
         res_np, err_np = pww.process(raw, variance=ref, normalization_factor=2.0)
         delta_res = abs(res_np - ref / 2.0).max()
@@ -287,7 +288,7 @@ class TestWorker(unittest.TestCase):
         self.assertLess(delta_err, precision, "Numpy error calculation are OK: %s" % err)
 
         # Cython path
-        worker.USE_CYTHON = True
+        worker_mdl.USE_CYTHON = True
         res_cy, err_cy = pww.process(raw, variance=ref, normalization_factor=2.0)
         delta_res = abs(res_cy - ref / 2.0).max()
         delta_err = abs(err_cy - numpy.sqrt(ref) / 2.0).max()

--- a/pyFAI/test/test_worker.py
+++ b/pyFAI/test/test_worker.py
@@ -316,6 +316,10 @@ class TestWorkerConfig(unittest.TestCase):
         numpy.save(cls.c, ones * 3)
         numpy.save(cls.d, ones * 4)
 
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.directory)
+
     def test_flatdark(self):
         config = {"version": 2,
                   "application": "pyfai-integrate",
@@ -335,9 +339,6 @@ class TestWorkerConfig(unittest.TestCase):
         self.assertTrue(numpy.isclose(worker.ai.detector.get_darkcurrent()[0, 0], (1 + 2 + 3) / 3))
         self.assertTrue(numpy.isclose(worker.ai.detector.get_flatfield()[0, 0], (1 + 2 + 4) / 3))
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.directory)
 
 
 def suite():

--- a/pyFAI/test/test_worker.py
+++ b/pyFAI/test/test_worker.py
@@ -34,7 +34,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "26/02/2019"
+__date__ = "01/03/2019"
 
 
 import unittest
@@ -341,21 +341,6 @@ class TestWorkerConfig(unittest.TestCase):
         worker.process(data=data)
         self.assertTrue(numpy.isclose(worker.ai.detector.get_darkcurrent()[0, 0], (1 + 2 + 3) / 3))
         self.assertTrue(numpy.isclose(worker.ai.detector.get_flatfield()[0, 0], (1 + 2 + 4) / 3))
-
-    def test_readimagedata_imagepath(self):
-        abs_a = os.path.abspath(self.a)
-        image = worker_mdl._read_image_data(abs_a)
-        self.assertIsNotNone(image)
-
-    def test_readimagedata_silxurl(self):
-        abs_a = os.path.abspath(self.a)
-        url = DataUrl(abs_a).path()
-        image = worker_mdl._read_image_data(url)
-        self.assertIsNotNone(image)
-
-    def test_readimagedata_notexisting(self):
-        with self.assertRaises(Exception):
-            worker_mdl._read_image_data("fooobar.not.existing")
 
 
 def suite():

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -167,7 +167,7 @@ def _init_ai(ai, config, consume_keys=False, read_maps=True):
     if read_maps:
         filename = config.pop("mask_file", "")
         apply_process = config.pop("do_mask", True)
-        if filename and os.path.exists(filename) and apply_process:
+        if filename and apply_process:
             try:
                 data = _read_image_data(filename)
             except Exception as error:
@@ -214,6 +214,8 @@ def _read_image_data(image_path):
     """
     if fabio is None:
         raise RuntimeError("FabIO is missing")
+    if not os.path.exists(image_path):
+        raise RuntimeError("Filename '%s' does not exist" % image_path)
     with fabio.open(image_path) as image:
         return image.data
 
@@ -482,7 +484,7 @@ class Worker(object):
         # Do it here before reading the AI to be able to catch the io
         filename = config.pop("mask_file", "")
         apply_process = config.pop("do_mask", True)
-        if filename and os.path.exists(filename) and apply_process:
+        if filename and apply_process:
             try:
                 data = _read_image_data(filename)
             except Exception as error:

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -177,20 +177,20 @@ def _init_ai(ai, config, consume_keys=False, read_maps=True):
         filename = config.pop("dark_current", "")
         apply_process = config.pop("do_dark", True)
         if filename and apply_process:
-            filenames = _read_filenames(filename)
+            filenames = _normalize_filenames(filename)
             ai.set_darkfiles(filenames)
 
         filename = config.pop("flat_field", "")
         apply_process = config.pop("do_flat", True)
         if filename and apply_process:
-            filenames = _read_filenames(filename)
+            filenames = _normalize_filenames(filename)
             ai.set_flatfiles(filenames)
 
     return ai
 
 
-def _read_filenames(filenames):
-    """Returns a list of strings from a comma separated string list or a list.
+def _normalize_filenames(filenames):
+    """Returns a list of strings from a string or a list of strings.
 
     :rtype: List[str]
     """
@@ -198,8 +198,10 @@ def _read_filenames(filenames):
         return []
     if isinstance(filenames, list):
         return filenames
-    # It's a single filename
-    return [filenames]
+    if isinstance(filenames, six.string_types):
+        # It's a single filename
+        return [filenames]
+    raise TypeError("Unsupported type %s for a list of filenames" % type(filenames))
 
 
 def _reduce_images(filenames, method="mean"):
@@ -480,7 +482,7 @@ class Worker(object):
         filename = config.pop("dark_current", "")
         apply_process = config.pop("do_dark", True)
         if filename and apply_process:
-            filenames = _read_filenames(filename)
+            filenames = _normalize_filenames(filename)
             method = "mean"
             data = _reduce_images(filenames, method=method)
             self.ai.detector.set_darkcurrent(data)
@@ -490,7 +492,7 @@ class Worker(object):
         filename = config.pop("flat_field", "")
         apply_process = config.pop("do_flat", True)
         if filename and apply_process:
-            filenames = _read_filenames(filename)
+            filenames = _normalize_filenames(filename)
             method = "mean"
             data = _reduce_images(filenames, method=method)
             self.ai.detector.set_flatfield(data)


### PR DESCRIPTION
This PR allow to have a full HDF5 workflow from acquisition to integration.

- Support HDF5 path on integrate
    - Support fabio URLs `h5::dataset`
    - Support silx URLs
- Support HDF5 path on integrate-gui
    - Support silx URLs
    - Support fabio URLs `h5::dataset`
    - Allow to DnD mask/dark/flat from silx view
    - Allow to load mask/dark/flat using HDF5 dialog
    - Allow to DnD the monitor name
- Support HDF5 path on calib2
    - Support silx URLs
    - Support fabio URLs `h5::dataset`
    - Allow to DnD mask from silx view
    - Allow to load mask using HDF5 dialog
- Support HDF5 path on average
    - Support fabio URLs `h5::dataset`

I try to do it from ID22 data (from P. O. Autran)
- HDF5/Nexus file from acquisition from calibant (`LaB6_60keV_380_tfout_1.h5`)
- HDF5/Nexus from acquisition from sample (`H76238.h5`)
- Plus a HDF5 containing image for mask/dark/flat (`extra_data.h5`)

Here is the recipe
```
pyFAI-average LaB6_60keV_380_tfout_1.h5::/scan_0/image/data -q 0.20-0.90 --monitor-name=/scan_0/measurement/bmon
# Generates LaB6_60keV_380_tfout_1.h5__scan_0_image_dataquantiles_1_files.edf
pyFAI-calib2 -m extra_data.h5::/mask LaB6_60keV_380_tfout_1.h5__scan_0_image_dataquantiles_1_files.edf -e 60 -c LaB6
pyFAI-calib2 # The same and load image/mask with dialog
pyFAI-calib2 # The same and DnD data from silx view
# Saves foo.poni
pyFAI-integrate # Use the dialog to load mask/flat/dark from file
pyFAI-integrate # DnD mask/flat/dark from silx view (and DnD the monitor name)
# Saves foo.json
pyFAI-integrate -j foo.json -o result.h5 H76238.h::/scan_0/image/data --no-gui
silx view result.h5
```