### PR TITLE
Synchronize setup.py with that of silx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # coding: utf8
 # /*##########################################################################
 #
-# Copyright (C) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -114,10 +114,10 @@ classifiers = ["Development Status :: 5 - Production/Stable",
                "Topic :: Scientific/Engineering :: Physics"
                ]
 
+
 # ########## #
 # version.py #
 # ########## #
-
 
 class build_py(_build_py):
     """
@@ -137,6 +137,7 @@ class build_py(_build_py):
 class PyTest(Command):
     """Command to start tests running the script: run_tests.py"""
     user_options = []
+
     description = "Execute the unittests"
 
     def initialize_options(self):
@@ -175,7 +176,9 @@ if sphinx is None:
 
 class BuildMan(Command):
     """Command to build man pages"""
+
     description = "Build man pages of the provided entry points"
+
     user_options = []
 
     def initialize_options(self):
@@ -512,7 +515,7 @@ class Build(_build):
                 # By default Xcode5 & XCode6 do not support OpenMP, Xcode4 is OK.
                 osx = tuple([int(i) for i in platform.mac_ver()[0].split(".")])
                 if osx >= (10, 8):
-                    logger.warning("OpenMP support ignored. Your platform do not support it")
+                    logger.warning("OpenMP support ignored. Your platform does not support it.")
                     use_openmp = False
 
         # Remove attributes used by distutils parsing
@@ -579,7 +582,7 @@ class BuildExt(build_ext):
 
     LINK_ARGS_CONVERTER = {'-fopenmp': ''}
 
-    description = 'Build pyFAI extensions'
+    description = 'Build extensions'
 
     def finalize_options(self):
         build_ext.finalize_options(self)
@@ -810,7 +813,7 @@ class SourceDistWithCython(sdist):
     without suppport of OpenMP.
     """
 
-    description = "Create a source distribution including cythonozed files (tarball, zip file, etc.)"
+    description = "Create a source distribution including cythonized files (tarball, zip file, etc.)"
 
     def finalize_options(self):
         sdist.finalize_options(self)
@@ -828,7 +831,6 @@ class SourceDistWithCython(sdist):
                                  'language_level': 3},
             force=True
         )
-
 
 ################################################################################
 # Debian source tree
@@ -951,9 +953,17 @@ class PyFaiTestData(Command):
 
 def get_project_configuration(dry_run):
     """Returns project arguments for setup"""
+    # Use installed numpy version as minimal required version
+    # This is useful for wheels to advertise the numpy version they were built with
+    if dry_run:
+        numpy_requested_version = ""
+    else:
+        from numpy.version import version as numpy_version
+        numpy_requested_version = ">=%s" % numpy_version
+        logger.info("Install requires: numpy %s", numpy_requested_version)
 
     install_requires = [
-        "numpy",
+        "numpy%s" % numpy_requested_version,
         # h5py was removed from dependencies cause it creates an issue with
         # Debian 8. Pip is not aware that h5py is installed and pkg_resources
         # check dependencies and in this case raise an exception
@@ -969,8 +979,7 @@ def get_project_configuration(dry_run):
 
     setup_requires = [
         "setuptools",
-        "numpy",
-        "cython"]
+        "numpy"]
 
     package_data = {
         'pyFAI.resources': [
@@ -1022,6 +1031,7 @@ def get_project_configuration(dry_run):
         build_ext=BuildExt,
         build_man=BuildMan,
         clean=CleanCommand,
+        sdist=SourceDistWithCython,
         debian_src=sdist_debian,
         testimages=PyFaiTestData,
     )
@@ -1052,11 +1062,11 @@ def get_project_configuration(dry_run):
                         long_description=get_readme(),
                         install_requires=install_requires,
                         setup_requires=setup_requires,
+                        extras_require=extras_require,
                         cmdclass=cmdclass,
                         package_data=package_data,
                         zip_safe=False,
                         entry_points=entry_points,
-                        extras_require=extras_require,
                         )
     return setup_kwargs
 
@@ -1075,7 +1085,7 @@ def setup_package():
                         'clean', '--name')))
 
     if dry_run:
-        # DRY_RUN implies actions which do not require dependancies, like NumPy
+        # DRY_RUN implies actions which do not require dependencies, like NumPy
         try:
             from setuptools import setup
             logger.info("Use setuptools.setup")
@@ -1087,10 +1097,11 @@ def setup_package():
             from setuptools import setup
         except ImportError:
             from numpy.distutils.core import setup
-            logger.info("Use numpydistutils.setup")
+            logger.info("Use numpy.distutils.setup")
 
     setup_kwargs = get_project_configuration(dry_run)
     setup(**setup_kwargs)
+
 
 if __name__ == "__main__":
     setup_package()


### PR DESCRIPTION
This PR synchronizes the setup.py with the current one from silx.
In particular:

- `sdist` now build the cythonized files
- The `numpy` version is was compiled with is advertise as a minimum required version
- `cython` is no more in setup_requires (we could argue about that...)
