### PR TITLE
Fix sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -829,7 +829,8 @@ class SourceDistWithCython(sdist):
             self.extensions,
             compiler_directives={'embedsignature': True,
                                  'language_level': 3},
-            force=True
+            force=True,
+            compile_time_env={"HAVE_OPENMP": False}
         )
 
 ################################################################################


### PR DESCRIPTION
This PR fixes the `sdist` target of setup.py by defining `HAVE_OPENMP` to False while building the tarball.