### PR TITLE
An alternative approach to OpenMP support in histogram

### DIFF
--- a/pyFAI/ext/_histogram_nomp.pyx
+++ b/pyFAI/ext/_histogram_nomp.pyx
@@ -34,9 +34,11 @@ __license__ = "MIY"
 __copyright__ = "2011-2016, ESRF"
 __contact__ = "jerome.kieffer@esrf.fr"
 
+include "regrid_common.pxi"
+
 from libc.math cimport floor, sqrt
 import logging
-logger = logging.getLogger(__name__ + "_nomp")
+logger = logging.getLogger(__name__)
 
 
 @cython.cdivision(True)

--- a/pyFAI/ext/_histogram_omp.pyx
+++ b/pyFAI/ext/_histogram_omp.pyx
@@ -45,6 +45,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+_COMPILED_WITH_OPENMP = _openmp.COMPILED_WITH_OPENMP
+
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/pyFAI/ext/_openmp.pxd
+++ b/pyFAI/ext/_openmp.pxd
@@ -1,0 +1,31 @@
+# /*##########################################################################
+#
+# Copyright (C) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+cdef extern from "src/openmp.h":
+    const int COMPILED_WITH_OPENMP
+    void omp_set_num_threads(int) nogil
+    int omp_get_num_threads() nogil
+    int omp_get_max_threads() nogil
+    int omp_get_thread_num() nogil
+    int omp_get_num_procs() nogil

--- a/pyFAI/ext/histogram.py
+++ b/pyFAI/ext/histogram.py
@@ -35,9 +35,9 @@ __copyright__ = "2011-2016, ESRF"
 __contact__ = "jerome.kieffer@esrf.fr"
 
 
-cimport pyFAI.ext._openmp as _openmp
+from pyFAI.ext._histogram_omp import _COMPILED_WITH_OPENMP
 
-if _openmp.COMPILED_WITH_OPENMP:
+if _COMPILED_WITH_OPENMP:
     from pyFAI.ext._histogram_omp import *
 else:
     from pyFAI.ext._histogram_nomp import *

--- a/pyFAI/ext/histogram.pyx
+++ b/pyFAI/ext/histogram.pyx
@@ -35,9 +35,9 @@ __copyright__ = "2011-2016, ESRF"
 __contact__ = "jerome.kieffer@esrf.fr"
 
 
-include "regrid_common.pxi"
+cimport pyFAI.ext._openmp as _openmp
 
-IF HAVE_OPENMP:
-    include "histogram_omp.pxi"
-ELSE:
-    include "histogram_nomp.pxi"
+if _openmp.COMPILED_WITH_OPENMP:
+    from pyFAI.ext._histogram_omp import *
+else:
+    from pyFAI.ext._histogram_nomp import *

--- a/pyFAI/ext/setup.py
+++ b/pyFAI/ext/setup.py
@@ -74,7 +74,6 @@ def configuration(parent_package='', top_path=None):
         create_extension_config('splitPixelFull'),
         create_extension_config('splitPixelFullLUT'),
         create_extension_config('splitBBox'),
-        create_extension_config('histogram', can_use_openmp=True),
         create_extension_config('splitBBoxLUT', can_use_openmp=True),
         create_extension_config('splitBBoxCSR', can_use_openmp=True),
         create_extension_config('splitPixelFullCSR', can_use_openmp=True),

--- a/pyFAI/ext/setup.py
+++ b/pyFAI/ext/setup.py
@@ -66,6 +66,8 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('ext', parent_package, top_path)
 
     ext_modules = [
+        create_extension_config('_histogram_nomp'),
+        create_extension_config('_histogram_omp', can_use_openmp=True),
         create_extension_config("_geometry", can_use_openmp=True),
         create_extension_config("reconstruct", can_use_openmp=True),
         create_extension_config('splitPixel'),

--- a/pyFAI/ext/src/openmp.h
+++ b/pyFAI/ext/src/openmp.h
@@ -1,0 +1,44 @@
+/*##########################################################################
+#
+# Copyright (C) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+#ifndef __PYFAI_OPENMP_H__
+#define __PYFAI_OPENMP_H__
+
+#ifdef _OPENMP
+#include "omp.h"
+
+static const int COMPILED_WITH_OPENMP = 1;
+
+#else
+
+static const int COMPILED_WITH_OPENMP = 0;
+
+#define omp_set_num_threads(a)
+#define omp_get_num_threads() (1)
+#define omp_get_max_threads()(1)
+#define omp_get_thread_num() (0)
+#define omp_get_num_procs() (1)
+
+#endif /*_OPENMP*/
+
+#endif /*__PYFAI_OPENMP_H__*/

--- a/setup.py
+++ b/setup.py
@@ -632,7 +632,6 @@ class BuildExt(build_ext):
                 compiler_directives={'embedsignature': True,
                                      'language_level': 3},
                 force=self.force_cython,
-                compile_time_env={"HAVE_OPENMP": self.use_openmp}
             )
             ext.sources = patched_exts[0].sources
 

--- a/setup.py
+++ b/setup.py
@@ -829,7 +829,6 @@ class SourceDistWithCython(sdist):
             compiler_directives={'embedsignature': True,
                                  'language_level': 3},
             force=True,
-            compile_time_env={"HAVE_OPENMP": False}
         )
 
 ################################################################################


### PR DESCRIPTION
This PR proposes to move the choice of which implementation of the histogram to use from cythonization phase to C compilation phase.
To do so, both implementations of the histogram are built as separated Cython extensions (using stubs for OpenMP if it is not available).
The choice of implementation in the `histogram` module is done at runtime depending whether it was built with or without OpenMP.
There is a breach there as on can build the `_histogram*` modules without OpenMP and then the `histogram` module with OpenMP.... This can be (and should be) prevented, by checking if the `_histogram_omp` module was built with OpenMP. The `histogram` module can then be a pure Python module. If you are interested I can update this PR for it.

This looks to work, but requires more testing... Don't hesitate to close if not appropriate !