### PR TITLE
A couple of small error fixed:

### DIFF
--- a/pyFAI/app/benchmark.py
+++ b/pyFAI/app/benchmark.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer, Picca Frédéric-Emmanuel"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "07/05/2019"
+__date__ = "09/05/2019"
 __status__ = "development"
 
 import logging
@@ -76,7 +76,7 @@ def main():
                         help="Limit the size of the dataset to X Mpixel images (for computer with limited memory)")
     parser.add_argument("-n", "--number",
                         dest="number", default=10, type=int,
-                        help="Number of repetition of the test, by default 10")
+                        help="Number of repetition of the test (or time used for each test), by default 10")
     parser.add_argument("-2d", "--2dimention",
                         action="store_true", dest="twodim", default=False,
                         help="Benchmark also algorithm for 2D-regrouping")

--- a/pyFAI/app/benchmark.py
+++ b/pyFAI/app/benchmark.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer, Picca Frédéric-Emmanuel"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "09/10/2018"
+__date__ = "07/05/2019"
 __status__ = "development"
 
 import logging
@@ -110,7 +110,8 @@ def main():
                         do_2d=options.twodim,
                         devices=devices)
 
-    pyFAI.benchmark.pylab.ion()
+    if pyFAI.benchmark.pylab is not None:
+        pyFAI.benchmark.pylab.ion()
     six.moves.input("Enter to quit")
 
 

--- a/pyFAI/benchmark/__init__.py
+++ b/pyFAI/benchmark/__init__.py
@@ -335,6 +335,7 @@ class Bench(object):
             print("Working on device: %s platform: %s device: %s" % (devicetype, platform, device))
             label = ("1D %s %s %s %s" % (devicetype, self.LABELS[method], platform, device)).replace(" ", "_")
             method += "_%i,%i" % (opencl["platformid"], opencl["deviceid"])
+            print("method=%s" % method)
             memory_error = (pyopencl.MemoryError, MemoryError, pyopencl.RuntimeError, RuntimeError)
         else:
             print("Working on processor: %s" % self.get_cpu())
@@ -357,7 +358,7 @@ class Bench(object):
                 res = bench_test.stmt()
                 self.print_init(time.time() - t0)
             except memory_error as error:
-                print(error)
+                print("MemoryError: %s" % error)
                 break
             self.update_mp()
             if check:
@@ -373,7 +374,7 @@ class Bench(object):
                     try:
                         integrator = bench_test.ai.engines.get(key).engine
                     except MemoryError as error:
-                        print(error)
+                        print("MemoryError %s" % error)
                     else:
                         if "lut" in method:
                             print("lut: shape= %s \t nbytes %.3f MB " % (integrator.lut.shape, integrator.lut_nbytes / 2 ** 20))
@@ -717,18 +718,18 @@ def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,
         print("Devices:", ocl_devices)
     if do_1d:
         bench.bench_1d("splitBBox")
-        bench.bench_1d("lut", True)
+#         bench.bench_1d("lut", True)
         bench.bench_1d("csr", True)
         for device in ocl_devices:
             print("Working on device: " + str(device))
-            bench.bench_1d("lut_ocl", True, {"platformid": device[0], "deviceid": device[1]})
+#             bench.bench_1d("lut_ocl", True, {"platformid": device[0], "deviceid": device[1]})
             bench.bench_1d("csr_ocl", True, {"platformid": device[0], "deviceid": device[1]})
 
     if do_2d:
         bench.bench_2d("splitBBox")
         bench.bench_2d("lut", True)
         for device in ocl_devices:
-            bench.bench_1d("lut_ocl", True, {"platformid": device[0], "deviceid": device[1]})
+#             bench.bench_1d("lut_ocl", True, {"platformid": device[0], "deviceid": device[1]})
             bench.bench_1d("csr_ocl", True, {"platformid": device[0], "deviceid": device[1]})
 
     bench.save()

--- a/pyFAI/benchmark/__init__.py
+++ b/pyFAI/benchmark/__init__.py
@@ -360,6 +360,10 @@ class Bench(object):
             except memory_error as error:
                 print("MemoryError: %s" % error)
                 break
+            if first:
+                if "ocl_csr_integr" in bench_test.ai.engines:
+                    print("Actual device used:", bench_test.ai.engines["ocl_csr_integr"].engine.ctx.devices[0])
+
             self.update_mp()
             if check:
                 module = sys.modules.get(AzimuthalIntegrator.__module__)
@@ -414,6 +418,7 @@ class Bench(object):
                     first = False
                 else:
                     self.new_point(size, tmin)
+
         self.print_sep()
         self.meth.append(label)
         self.results[label] = results

--- a/pyFAI/method_registry.py
+++ b/pyFAI/method_registry.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "07/05/2019"
+__date__ = "09/05/2019"
 __status__ = "development"
 
 from logging import getLogger
@@ -194,7 +194,7 @@ class IntegrationMethod:
         if "ocl" in old_method:
             impl = "opencl"
             elements = old_method.split("_")
-            if len(elements) >= 1:
+            if len(elements) >= 2:
                 target_string = elements[-1]
                 if target_string == "cpu":
                     target = "cpu"

--- a/pyFAI/method_registry.py
+++ b/pyFAI/method_registry.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/03/2019"
+__date__ = "07/05/2019"
 __status__ = "development"
 
 from logging import getLogger
@@ -194,7 +194,7 @@ class IntegrationMethod:
         if "ocl" in old_method:
             impl = "opencl"
             elements = old_method.split("_")
-            if len(elements) == 2:
+            if len(elements) >= 1:
                 target_string = elements[-1]
                 if target_string == "cpu":
                     target = "cpu"

--- a/pyFAI/resources/openCL/ocl_azim_CSR.cl
+++ b/pyFAI/resources/openCL/ocl_azim_CSR.cl
@@ -213,7 +213,7 @@ csr_integrate_single(  const   global  float   *weights,
             //Kahan summation allows single precision arithmetics with error compensation
             //http://en.wikipedia.org/wiki/Kahan_summation_algorithm
             // defined in kahan.cl
-            sum_data_K = kahan_sum(sum_data_K, pown(coef, coef_power) * data);
+            sum_data_K = kahan_sum(sum_data_K, ((coef_power == 2) ? coef*coef: coef) * data);
             sum_count_K = kahan_sum(sum_count_K, coef);
         };//end if dummy
     };//for j


### PR DESCRIPTION
* The benchmark tool was ending in error when no display was available
* The OpenCL code was still using the *pown* function, not available on certain platforms
* The benchmarking tool has been simplified, removing the LUT implementation as it is not of prime importance
* There has been a bug in the OpenCL device selection since the introduction of the registry. Now the benchmarking tool prints out the actual used device, not only the one it wish to use.