### PR TITLE
Fix pyFAI-calib2 for debian8

### DIFF
--- a/pyFAI/gui/widgets/LoadImageToolButton.py
+++ b/pyFAI/gui/widgets/LoadImageToolButton.py
@@ -47,7 +47,7 @@ class _LoadImageFromFileDialogAction(qt.QAction):
     """Action loading an image using the default `QFileDialog`."""
 
     def __init__(self, parent):
-        qt.QAction.__init__(self, parent=parent)
+        qt.QAction.__init__(self, parent)
         self.triggered.connect(self.__execute)
         self.setText("Use file dialog")
 
@@ -96,7 +96,7 @@ class _LoadImageFromImageDialogAction(qt.QAction):
     """Action loading an image using the silx ImageFileDialog."""
 
     def __init__(self, parent):
-        qt.QAction.__init__(self, parent=parent)
+        qt.QAction.__init__(self, parent)
         self.triggered.connect(self.__execute)
         self.setText("Use image dialog")
 


### PR DESCRIPTION
This PR makes `pyFAI-calib2` works with `PyQt5` from debian 8 (i.e., v5.3.2).
Feel free to reject if you don't want to support debian 8 (as Debian does).