### PR TITLE
Add binder environment to run cookbook and tutorials

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ pyFAI: Fast Azimuthal Integration in Python
 
 Main development website: https://github.com/silx-kit/pyFAI
 
-|Build Status| |Appveyor Status|
+|Build Status| |Appveyor Status| |myBinder Launcher|
 
 pyFAI is an azimuthal integration library that tries to be fast (as fast as C
 and even more using OpenCL and GPU).
@@ -234,3 +234,5 @@ Indirect contributors (ideas...)
    :target: https://travis-ci.org/silx-kit/pyFAI
 .. |Appveyor Status| image:: https://ci.appveyor.com/api/projects/status/github/silx-kit/pyfai?svg=true
    :target: https://ci.appveyor.com/project/ESRF/pyfai
+   |myBinder Launcher| image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/silx-kit/pyFAI/master?filepath=binder%2Findex.ipynb

--- a/binder/index.ipynb
+++ b/binder/index.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [pyFAI](https://github.com/silx-kit/pyFAI) cookbooks and tutorials\n",
+    "\n",
+    "See the [full documentation](http://www.silx.org/doc/pyFAI/latest/) for more information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cookbooks\n",
+    "\n",
+    "- [Integration with python](../doc/source/usage/cookbook/integration_with_python.ipynb)\n",
+    "- [Integration with scripts](../doc/source/usage/cookbook/integration_with_scripts.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tutorials\n",
+    "\n",
+    "- [Introduction](../doc/source/usage/tutorial/Introduction/introduction.ipynb)\n",
+    "- [CCD calibration](../doc/source/usage/tutorial/CCD_Calibration/CCD_calibration.ipynb)\n",
+    "- [Calibrant](../doc/source/usage/tutorial/Calibrant/Calibrant.ipynb)\n",
+    "- [New calibrant](../doc/source/usage/tutorial/Calibrant/new_calibrant.ipynb)\n",
+    "- [Distortion](../doc/source/usage/tutorial/Distortion/Distortion.ipynb)\n",
+    "- [Geometry](../doc/source/usage/tutorial/Geometry/geometry.ipynb)\n",
+    "- Goniometer:\n",
+    "\n",
+    "  - [Rotation-Pilatus100k](../doc/source/usage/tutorial/Goniometer/Rotation-Pilatus100k/Multi120_Pilatus100k.ipynb)\n",
+    "  - [Rotation-XPADS540](../doc/source/usage/tutorial/Goniometer/Rotation-XPADS540/D2AM-15.ipynb)\n",
+    "  - [Translation-Pilatus6M](../doc/source/usage/tutorial/Goniometer/Translation-Pilatus6M/TTcalibration.ipynb)\n",
+    "  \n",
+    "- [Inpainting](../doc/source/usage/tutorial/Inpainting/Inpainting.ipynb)\n",
+    "- [LogScale](../doc/source/usage/tutorial/LogScale/Guinier.ipynb)\n",
+    "- [MakeCalibrant](../doc/source/usage/tutorial/MakeCalibrant/make_calibrant.ipynb)\n",
+    "- [MultiGeometry](../doc/source/usage/tutorial/MultiGeometry/MultiGeometry.ipynb)\n",
+    "- Soleil:\n",
+    "\n",
+    "  - [Cristal_Mythen](../doc/source/usage/tutorial/Soleil/Cristal_Mythen.ipynb)\n",
+    "  - [Diffabs_Calibration_K6C](../doc/source/usage/tutorial/Soleil/Soleil_Diffabs_Calibration_K6C.ipynb)\n",
+    "  - [Diffabs_Diffraction_Tomography](../doc/source/usage/tutorial/Soleil/Soleil_Diffabs_Diffraction_Tomography.ipynb)\n",
+    "\n",
+    "- Thick Detector:\n",
+    "\n",
+    "  - [Deconvolution](../doc/source/usage/tutorial/ThickDetector/deconvolution.ipynb)\n",
+    "  - [Goniometer id28](../doc/source/usage/tutorial/ThickDetector/goniometer_id28.ipynb)\n",
+    "  - [Raytracing](../doc/source/usage/tutorial/ThickDetector/raytracing.ipynb)\n",
+    "\n",
+    "- [Variance](../doc/source/usage/tutorial/Variance/Variance.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Setup jupyter bash kernel
+python -m bash_kernel.install
+
+# Download resources
+RESOURCES_URL="http://www.silx.org/pub/pyFAI"
+echo "Download notebooks from ${RESOURCES_URL}"
+
+COOKBOOK_DIR="doc/source/usage/cookbook"
+COOKBOOK_FILES="LaB6_29.4keV.tif
+LaB6_29.4keV.poni
+F_K4320T_Cam43_30012013_distorsion.spline"
+
+for FILE in ${COOKBOOK_FILES}; do
+    URL="${RESOURCES_URL}/cookbook/calibration/${FILE}";
+    echo "Download ${URL}";
+    wget "${URL}" -O ${COOKBOOK_DIR}/${FILE};
+done

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,3 @@
+pyFAI
+ipympl
+bash_kernel


### PR DESCRIPTION
This PR adds a binder environment description to run pyFAI cookbooks and tutorials in Binder and a myBinder badge in the README to start it.
As it is, it installs the latest release, but uses notebooks from the tip of the project.

From what I tested, it mostly works, but some notebooks fail, I guess due to the 2GB RAM max limit on myBinder.

The PR can be tested here: https://mybinder.org/v2/gh/t20100/pyFAI/binder?filepath=binder%2Findex.ipynb