### PR TITLE
[calib2] Only use the first element to sort fits

### DIFF
--- a/pyFAI/gui/helper/RingCalibration.py
+++ b/pyFAI/gui/helper/RingCalibration.py
@@ -254,7 +254,7 @@ class RingCalibration(object):
         scores.append((score, geoRef, "with-guess"))
 
         # Use the better one
-        scores.sort()
+        scores.sort(key=lambda x: x[0])
         score, geoRef, _ = scores[0]
         scores = None
 


### PR DESCRIPTION
I did not test it.

I only test the piece of code using ipython (Python3)

Relative to #1281