### PR TITLE
AttributeError when calling AbstractCalibration.preprocess()

### DIFF
--- a/pyFAI/gui/cli_calibration.py
+++ b/pyFAI/gui/cli_calibration.py
@@ -1482,7 +1482,7 @@ decrease the value if arcs are mixed together.""", default=None)
         AbstractCalibration.preprocess(self)
 
         if self.gaussianWidth is not None:
-            self.peakPicker.massif.setValleySize(self.gaussianWidth)
+            self.peakPicker.massif.valley_size = self.gaussianWidth
         else:
             self.peakPicker.massif.initValleySize()
         if self.gui:


### PR DESCRIPTION
'Massif' object has no attribute 'setValleySize'

It seems that this method has been removed from the Massif class, so this PR sets the value of valley_size directly to avoid an AttributeError.  
