### PR TITLE
Fix path bug when packaging with PyInstaller

### DIFF
--- a/pyFAI/utils/__init__.py
+++ b/pyFAI/utils/__init__.py
@@ -163,7 +163,7 @@ def _get_data_path(filename):
     resources = [
         os.environ.get("PYFAI_DATA"),
         data_dir,
-        os.path.join(os.path.dirname(__file__), "..")]
+        os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))]
     try:
         import xdg.BaseDirectory
         resources += xdg.BaseDirectory.load_data_paths("pyFAI")

--- a/pyFAI/utils/__init__.py
+++ b/pyFAI/utils/__init__.py
@@ -163,6 +163,7 @@ def _get_data_path(filename):
     resources = [
         os.environ.get("PYFAI_DATA"),
         data_dir,
+        os.path.join(os.path.dirname(__file__), ".."),
         os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))]
     try:
         import xdg.BaseDirectory


### PR DESCRIPTION
Fixes issue #1344 by changing normalizing relative path into an absolution path.