### PR TITLE
Specify some version number for supporting python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       - ocl-icd-libopencl1
       - opencl-headers
       - libnuma1
-      - ocl-icd-dev 
+      - ocl-icd-dev
       - ocl-icd-opencl-dev
 # command to install dependencies
 
@@ -27,7 +27,7 @@ before_install:
 
 install:
   - "python ci/info_platform.py"
-  - "pip install --upgrade pip"
+  - "pip install --upgrade pip setuptools wheel"
   - "pip install --upgrade numpy"
   - "pip install --upgrade cython mako pybind11"
   - "pip install --upgrade h5py "

--- a/ci/requirements_rtd.txt
+++ b/ci/requirements_rtd.txt
@@ -1,4 +1,5 @@
-numpy
+numpy <1.19 ; python_version <= '3.5'
+numpy; python_version>= '3.6'
 h5py
 fabio
 sphinx

--- a/ci/requirements_travis.txt
+++ b/ci/requirements_travis.txt
@@ -15,6 +15,8 @@ scipy
 matplotlib
 mako
 pybind11
+pytools <2020.3 ; python_version <= '3.5'
+pytools; python_version>= '3.6'
 pyopencl
 numexpr
 silx


### PR DESCRIPTION
Select elder version of pytools when using python 3.5

As this is for CI, I did not open an issue.