### PR TITLE
Fixed typo in sphinx config

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,7 +71,7 @@ extensions = [
 if sphinx.__version__ < "1.4":
     extensions.append('sphinx.ext.pngmath')
 
-if not on_rtd:
+if on_rtd:
     import sphinx_rtd_theme
 
     extensions.append('sphinx_rtd_theme')


### PR DESCRIPTION
This PR aims at fixing debian packaging which looks to be broken by PR #1420 (see https://gitlab.esrf.fr/silx/bob/pyfai/-/pipelines/38048):
```
File "conf.py", line 75, in <module>
ImportError: No module named 'sphinx_rtd_theme'
```

If the goal was to use RTD sphinx theme by default, then it needs to be added to debian control build environment.