### PR TITLE
Sparsify

### DIFF
--- a/pyFAI/app/sparsify.py
+++ b/pyFAI/app/sparsify.py
@@ -42,7 +42,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "28/01/2021"
+__date__ = "03/03/2021"
 __status__ = "status"
 
 import os
@@ -252,7 +252,8 @@ def process(options):
                         bin_centers=integrator.bin_centers,
                         radius=ai._cached_array["r_center"],
                         mask=mask,
-                        ctx=ctx)
+                        ctx=ctx,
+                        profile=options.profile)
 
     logger.debug("Start sparsification")
     frames = []
@@ -290,13 +291,12 @@ def process(options):
                 ai=ai,
                 source=options.images if options.save_source else None,
                 extra=parameters)
-    
+
     if options.profile:
         try:
-            res = pf.log_profile(True)
+            pf.log_profile(True)
         except Exception:
-            res = pf.log_profile()
-        print(os.linesep.join(res))
+            pf.log_profile()
     return EXIT_SUCCESS
 
 

--- a/pyFAI/app/sparsify.py
+++ b/pyFAI/app/sparsify.py
@@ -107,6 +107,8 @@ def parse():
                         help="show information for each frame")
     parser.add_argument("--debug", action='store_true', dest="debug", default=False,
                         help="show debug information")
+    parser.add_argument("--profile", action='store_true', dest="profile", default=False,
+                        help="show profiling information")
     group = parser.add_argument_group("main arguments")
 #     group.add_argument("-l", "--list", action="store_true", dest="list", default=None,
 #                        help="show the list of available formats and exit")
@@ -288,6 +290,13 @@ def process(options):
                 ai=ai,
                 source=options.images if options.save_source else None,
                 extra=parameters)
+    
+    if options.profile:
+        try:
+            res = pf.log_profile(True)
+        except Exception:
+            res = pf.log_profile()
+        print(os.linesep.join(res))
     return EXIT_SUCCESS
 
 

--- a/pyFAI/opencl/azim_csr.py
+++ b/pyFAI/opencl/azim_csr.py
@@ -28,7 +28,7 @@
 
 __authors__ = ["Jérôme Kieffer", "Giannis Ashiotis"]
 __license__ = "MIT"
-__date__ = "01/02/2021"
+__date__ = "03/03/2021"
 __copyright__ = "2014-2020, ESRF, Grenoble"
 __contact__ = "jerome.kieffer@esrf.fr"
 
@@ -162,9 +162,9 @@ class OCL_CSR_Integrator(OpenclProcessing):
                          BufferDescription("indptr", (self.bins + 1), numpy.int32, mf.READ_ONLY),
                          BufferDescription("sum_data", self.bins, numpy.float32, mf.WRITE_ONLY),
                          BufferDescription("sum_count", self.bins, numpy.float32, mf.WRITE_ONLY),
-                         BufferDescription("averint", self.bins, numpy.float32, mf.WRITE_ONLY),
-                         BufferDescription("stderr", self.bins, numpy.float32, mf.WRITE_ONLY),
-                         BufferDescription("stderrmean", self.bins, numpy.float32, mf.WRITE_ONLY),
+                         BufferDescription("averint", self.bins, numpy.float32, mf.READ_WRITE),
+                         BufferDescription("stderr", self.bins, numpy.float32, mf.READ_WRITE),
+                         BufferDescription("stderrmean", self.bins, numpy.float32, mf.READ_WRITE),
                          BufferDescription("merged", self.bins, numpy.float32, mf.WRITE_ONLY),
                          BufferDescription("merged8", (self.bins, 8), numpy.float32, mf.WRITE_ONLY),
                          ]

--- a/pyFAI/opencl/peak_finder.py
+++ b/pyFAI/opencl/peak_finder.py
@@ -29,7 +29,7 @@
 
 __authors__ = ["Jérôme Kieffer"]
 __license__ = "MIT"
-__date__ = "20/01/2021"
+__date__ = "03/03/2021"
 __copyright__ = "2014-2020, ESRF, Grenoble"
 __contact__ = "jerome.kieffer@esrf.fr"
 
@@ -100,7 +100,7 @@ class OCL_PeakFinder(OCL_CSR_Integrator):
         nbin = lut[2].size - 1
         extra_buffers = [
                          BufferDescription("radius1d", nbin, numpy.float32, mf.READ_ONLY),
-                         BufferDescription("counter", 1, numpy.float32, mf.WRITE_ONLY),
+                         BufferDescription("counter", 1, numpy.float32, mf.READ_WRITE),
                          ]
 
         OCL_CSR_Integrator.__init__(self, lut, image_size, checksum,


### PR DESCRIPTION
This PR fixes multiple errors in the sparsification program:
* Reading from various buffers which were declared write-only
* Ensure the bin index is in the proper range (issue with the upper-most bin in linear interpolation)

Enhancement: 
* Add a profiling option to the command line
* Do not memset local buffers which do not need it.

Thanks OCLgrind !