### PR TITLE
Fix numpy build dependency 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
-    "numpy",
+    "oldest-supported-numpy",
     "scipy",
     "sphinx",
     "nbsphinx",


### PR DESCRIPTION
Fixes https://github.com/silx-kit/pyFAI/issues/1537 by using https://github.com/scipy/oldest-supported-numpy as build dependency.

I am suggesting this bugfix but I didn't check if this is fully working - I don't have easy access to a windows system with a development environment setup.