### PR TITLE
Fix collections.MutableSets compat with python3.10

### DIFF
--- a/pyFAI/utils/orderedset.py
+++ b/pyFAI/utils/orderedset.py
@@ -27,7 +27,7 @@
 import collections
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
 
     def __init__(self, iterable=None):
         self.end = end = []


### PR DESCRIPTION
collections.MutableSet was deprecated a long time ago and removed with python3.10.
https://docs.python.org/3/whatsnew/3.10.html#removed
https://bugs.python.org/issue37324

Using the old class name leads to test failures such as this one:

```
======================================================================
ERROR: test_import_all_modules (pyFAI.test.test_bug_regression.TestBugRegression)
Try to import every single module in the package
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<BUILDDIR>>/pyfai-0.20.0+dfsg1/.pybuild/cpython3_3.10_pyfai/build/pyFAI/test/test_bug_regression.py", line 286, in test_import_all_modules
    raise err
  File "/<<BUILDDIR>>/pyfai-0.20.0+dfsg1/.pybuild/cpython3_3.10_pyfai/build/pyFAI/test/test_bug_regression.py", line 271, in test_import_all_modules
    load_source(fqn, path)
  File "/<<BUILDDIR>>/pyfai-0.20.0+dfsg1/.pybuild/cpython3_3.10_pyfai/build/pyFAI/test/test_bug_regression.py", line 78, in load_source
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/<<BUILDDIR>>/pyfai-0.20.0+dfsg1/.pybuild/cpython3_3.10_pyfai/build/pyFAI/utils/orderedset.py", line 30, in <module>
    class OrderedSet(collections.MutableSet):
AttributeError: module 'collections' has no attribute 'MutableSet'
```