### PR TITLE
Avoid empty bins in sigma-clipping

### DIFF
--- a/ci/requirements_rtd.txt
+++ b/ci/requirements_rtd.txt
@@ -10,3 +10,4 @@ silx
 nbsphinx
 sphinx-rtd-theme
 docutils<0.19
+ipython_genutils

--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "01/02/2022"
+__date__ = "11/03/2022"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -3340,6 +3340,7 @@ class AzimuthalIntegrator(Geometry):
             raise RuntimeError("Not yet implemented. Sorry")
         result = Integrate1dResult(intpl.position * unit.scale, intpl.intensity, intpl.sigma)
         result._set_method_called("sigma_clip_ng")
+        result._set_method(method)
         result._set_compute_engine(str(method))
         result._set_percentile(thres)
         result._set_unit(unit)


### PR DESCRIPTION
Investigation on empty bins when performing sigma-clipping with Poisson error model