### PR TITLE
skip tests that are unreliable on 32-bit platforms by default

### DIFF
--- a/pyFAI/test/test_csr.py
+++ b/pyFAI/test/test_csr.py
@@ -182,7 +182,7 @@ class TestCSR(utilstest.ParametricTestCase):
         self.assertTrue(numpy.allclose(res_csr[4].T, res_scipy.normalization), "count is same as normalization")
         self.assertTrue(numpy.allclose(res_csr[3].T, res_scipy.signal), "sum_data is almost the same")
 
-    @unittest.skipIf(UtilsTest.low_mem, "test unreliable on 32bits processor")
+    @unittest.skipIf(UtilsTest.TEST_IS32_BIT, "test unreliable on 32bits processor")
     def test_2d_nosplit(self):
         self.ai.reset()
         result_histo = self.ai.integrate2d(self.data, self.N, unit="2th_deg", method="histogram")

--- a/pyFAI/test/test_histogram.py
+++ b/pyFAI/test/test_histogram.py
@@ -324,7 +324,7 @@ class TestHistogram2d(unittest.TestCase):
         self.assertTrue(delta == 0, msg="check all pixels were counted")
         self.assertTrue(v < self.epsilon, msg="checks delta is lower than %s" % self.epsilon)
 
-    @unittest.skipIf(UtilsTest.low_mem, "test unreliable on 32bits processor")
+    @unittest.skipIf(UtilsTest.TEST_IS32_BIT, "test unreliable on 32bits processor")
     def test_count_csr(self):
         """
         Test that the pixel count and the total intensity is conserved
@@ -339,7 +339,7 @@ class TestHistogram2d(unittest.TestCase):
         self.assertTrue(delta == 0, msg="check all pixels were counted")
         self.assertTrue(v < self.epsilon, msg="checks delta is lower than %s" % self.epsilon)
 
-    @unittest.skipIf(UtilsTest.low_mem, "test unreliable on 32bits processor")
+    @unittest.skipIf(UtilsTest.TEST_IS32_BIT, "test unreliable on 32bits processor")
     def test_numpy_vs_cython_vs_csr_2d(self):
         """
         Compare numpy histogram with cython simple implementation

--- a/pyFAI/test/utilstest.py
+++ b/pyFAI/test/utilstest.py
@@ -42,6 +42,7 @@ import contextlib
 import tempfile
 import getpass
 import functools
+import struct
 
 from silx.resources import ExternalResources
 from ..directories import testimages
@@ -82,6 +83,9 @@ class TestOptions(object):
 
         self.TEST_LOW_MEM = False
         """Skip tests using too much memory"""
+
+        self.TEST_IS32_BIT = False
+        """Skip tests on 32-bit systems"""
 
         self.options = None
         self.timeout = 60  # timeout in seconds for downloading images
@@ -166,6 +170,9 @@ class TestOptions(object):
             self.TEST_LOW_MEM = True
         elif os.environ.get('PYFAI_LOW_MEM', 'True') == 'False':
             self.TEST_LOW_MEM = True
+
+        if struct.calcsize("P") == 4:
+            self.TEST_IS32_BIT = True
 
     def add_parser_argument(self, parser):
         """Add extrat arguments to the test argument parser


### PR DESCRIPTION
These tests now fail all the time on armhf in Ubuntu, and I could pass lowmem to skip them I guess but it seems better to skip these tests by default and avoid losing the coverage of the other lowmem tests (which all seem to pass fine).