### PR TITLE
2d OpenCL integrator ranges

### DIFF
--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -2347,6 +2347,8 @@ class AzimuthalIntegrator(Geometry):
                                                                      unit=unit, empty=empty,
                                                                      mask_checksum=mask_crc
                                                                      )
+                                integr.pos0_range = cython_integr.pos0_range
+                                integr.pos1_range = cython_integr.pos1_range
 
                         elif (method.impl_lower == "python"):
                             with ocl_py_engine.lock:


### PR DESCRIPTION
Copied integration ranges in integrate2d_ng opencl implementation from cython integrator to prevent integrator reset
when integrating with the same boundaries again.

Fix to issue #1788

Sorry for the line endings, the relevant changes (i.e. additions) are in lines 2350 & 2351