### PR TITLE
Copied integration ranges in integrate2d_ng opencl implementation from

### DIFF
--- a/pyFAI/azimuthalIntegrator.py
+++ b/pyFAI/azimuthalIntegrator.py
@@ -2347,6 +2347,8 @@ class AzimuthalIntegrator(Geometry):
                                                                      unit=unit, empty=empty,
                                                                      mask_checksum=mask_crc
                                                                      )
+                                integr.pos0_range = cython_integr.pos0_range
+                                integr.pos1_range = cython_integr.pos1_range
 
                         elif (method.impl_lower == "python"):
                             with ocl_py_engine.lock:


### PR DESCRIPTION
cython integrator to prevent integrator reset.

replaces cbc99979e016f08f6dc8eeb71676a629597325be

close #1788 
close #1789 