### PR TITLE
Fix upper limit in clamp OpenCL invocations to avoid buffer overflow

### DIFF
--- a/pyFAI/resources/openCL/peakfinder.cl
+++ b/pyFAI/resources/openCL/peakfinder.cl
@@ -45,7 +45,7 @@ inline int pf8_calc_buffer2(int dim0, int dim1, int hw){
     int wsy = get_local_size(0);
     int wsx = get_local_size(1);
     int width = wsx + 2 * hw;
-    return (clamp(dim0, -hw, wsy + hw) + hw)*width + clamp(dim1, -hw, wsx + hw) + hw;
+    return (clamp(dim0, -hw, wsy + hw - 1) + hw)*width + clamp(dim1, -hw, wsx + hw - 1) + hw;
 }
 
 
@@ -75,7 +75,7 @@ inline float2 correct_pixel2(
         float radius = radius2d[gid];
         if (isfinite(radius) && (radius>=radius_min) && (radius<radius_max)) {
             float step = radius1d[1] - radius1d[0];
-            float pos = clamp((radius - radius1d[0]) / step, 0.0f, (float)NBINS);
+            float pos = clamp((radius - radius1d[0]) / step, 0.0f, (float)(NBINS - 1));
             int index = convert_int_rtz(pos);
             float delta = pos - index;
             if (index + 1 < NBINS) {

--- a/pyFAI/resources/openCL/sparsify.cl
+++ b/pyFAI/resources/openCL/sparsify.cl
@@ -83,7 +83,7 @@ kernel void find_intense(       global  float4 *preproc4,  // both input and out
                 value.s1 = 0.0f;
             } // empty pixel
             float step = radius1d[1] - radius1d[0];
-            float pos = clamp((radius - radius1d[0]) / step, 0.0f, (float)NBINS);
+            float pos = clamp((radius - radius1d[0]) / step, 0.0f, (float)(NBINS - 1));
             int index = convert_int_rtz(pos);
             float delta = pos - index;
             if (index + 1 < NBINS) {


### PR DESCRIPTION
Hi!

By looking at the code, I have the impression that the `clamp`  invocations in the OpenCL code do not account for the correct upper  `DIM - 1` limit of the corresponding array indexes. If this is the case, they do not completely protect against buffer overflows.

What do you think? Is that correct?

Cheers