### PR TITLE
Some polish, doc, types

### DIFF
--- a/pyFAI/calibrant.py
+++ b/pyFAI/calibrant.py
@@ -376,7 +376,7 @@ class Calibrant(object):
         """
         h = hash(self._wavelength)
         for d in self.dSpacing:
-                h = h ^ hash(d)
+            h = h ^ hash(d)
         return h
 
     def __copy__(self):

--- a/pyFAI/calibrant.py
+++ b/pyFAI/calibrant.py
@@ -45,6 +45,7 @@ import os
 import logging
 import numpy
 import itertools
+from typing import Optional, List
 from math import sin, asin, cos, sqrt, pi, ceil
 import threading
 from .utils import get_calibration_dir
@@ -317,7 +318,7 @@ class Calibrant(object):
     are known. They are expressed in Angstrom (in the file)
     """
 
-    def __init__(self, filename=None, dSpacing=None, wavelength=None):
+    def __init__(self, filename: Optional[str]=None, dSpacing: Optional[List[float]]=None, wavelength: Optional[float]=None):
         object.__init__(self)
         self._filename = filename
         self._wavelength = wavelength
@@ -406,7 +407,7 @@ class Calibrant(object):
 
     filename = property(get_filename)
 
-    def load_file(self, filename=None):
+    def load_file(self, filename: str):
         with self._sem:
             self._load_file(filename)
 
@@ -734,7 +735,7 @@ class calibrant_factory(CalibrantFactory):
     pass
 
 
-def get_calibrant(calibrant_name, wavelength=None):
+def get_calibrant(calibrant_name: str, wavelength: float=None) -> Calibrant:
     """Returns a new instance of the calibrant by it's name.
 
     :param str calibrant_name: Name of the calibrant

--- a/pyFAI/calibrant.py
+++ b/pyFAI/calibrant.py
@@ -314,8 +314,23 @@ class Cell(object):
 
 class Calibrant(object):
     """
-    A calibrant is a reference compound where the d-spacing (interplanar distances)
-    are known. They are expressed in Angstrom (in the file)
+    A calibrant is a named reference compound where the d-spacing are known.
+
+    The d-spacing (interplanar distances) are expressed in Angstrom (in the file).
+
+    If the access is don't from a file, the IO are delayed. If it is not desired
+    one could explicitly access to :meth:`load_file`.
+
+    .. code-block:: python
+
+        c = Calibrant()
+        c.load_file("my_calibrant.D")
+
+    :param filename: A filename containing the description (usually with .D extension).
+                     The access to the file description is delayed until the information
+                     is needed.
+    :param dSpacing: A list of d spacing in Angstrom.
+    :param wavelength: A wavelength in meter
     """
 
     def __init__(self, filename: Optional[str]=None, dSpacing: Optional[List[float]]=None, wavelength: Optional[float]=None):
@@ -408,6 +423,11 @@ class Calibrant(object):
     filename = property(get_filename)
 
     def load_file(self, filename: str):
+        """
+        Load a calibrant.from file.
+
+        :param filename: The filename containing the calibrant description.
+        """
         with self._sem:
             self._load_file(filename)
 
@@ -738,8 +758,8 @@ class calibrant_factory(CalibrantFactory):
 def get_calibrant(calibrant_name: str, wavelength: float=None) -> Calibrant:
     """Returns a new instance of the calibrant by it's name.
 
-    :param str calibrant_name: Name of the calibrant
-    :param float wavelength: initialize the calibrant with the given wavelength (in m)
+    :param calibrant_name: Name of the calibrant
+    :param wavelength: initialize the calibrant with the given wavelength (in m)
     """
     cal = CALIBRANT_FACTORY(calibrant_name)
     if wavelength:

--- a/pyFAI/detectors/_common.py
+++ b/pyFAI/detectors/_common.py
@@ -121,9 +121,14 @@ class Detector(metaclass=DetectorMeta):
     @classmethod
     def factory(cls, name: str, config: Union[None, str, Dict[str, Any]]=None) -> Detector:
         """
-        A kind of factory...
+        Create a pyFAI detector from a name.
 
-        :param name: name of a detector
+        If the detector is a known detector class, `config` in injected as constructor
+        arguments.
+
+        If the `name` is an existing hdf5 filename, the `config` argument is ignored.
+
+        :param name: A name of a detector or an existing hdf5 detector description file.
         :type name: str
         :param config: configuration of the detector
         :type config: dict or JSON representation of it.

--- a/pyFAI/detectors/_common.py
+++ b/pyFAI/detectors/_common.py
@@ -29,6 +29,8 @@
 
 """Description of all detectors with a factory to instantiate them"""
 
+from __future__ import annotations
+
 __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
@@ -43,6 +45,7 @@ import posixpath
 import threading
 from collections import OrderedDict
 import json
+from typing import Dict, Any, Union
 
 from .. import io
 from .. import spline
@@ -116,7 +119,7 @@ class Detector(metaclass=DetectorMeta):
     _MUTABLE_ATTRS = ('_mask', '_flatfield', "_darkcurrent", "_pixel_corners")
 
     @classmethod
-    def factory(cls, name, config=None):
+    def factory(cls, name: str, config: Union[None, str, Dict[str, Any]]=None) -> Detector:
         """
         A kind of factory...
 

--- a/pyFAI/gui/model/CalibrantModel.py
+++ b/pyFAI/gui/model/CalibrantModel.py
@@ -27,23 +27,25 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "16/10/2020"
 
+from typing import Optional
 from .AbstractModel import AbstractModel
+from ...calibrant import Calibrant
 
 
 class CalibrantModel(AbstractModel):
 
     def __init__(self, parent=None):
         super(CalibrantModel, self).__init__(parent)
-        self.__calibrant = None
+        self.__calibrant: Optional[Calibrant] = None
 
-    def isValid(self):
+    def isValid(self) -> bool:
         return self.__calibrant is not None
 
-    def setCalibrant(self, calibrant):
+    def setCalibrant(self, calibrant: Optional[Calibrant]):
         if self.__calibrant is calibrant:
             return
         self.__calibrant = calibrant
         self.wasChanged()
 
-    def calibrant(self):
+    def calibrant(self) -> Optional[Calibrant]:
         return self.__calibrant

--- a/pyFAI/gui/model/CalibrantModel.py
+++ b/pyFAI/gui/model/CalibrantModel.py
@@ -40,6 +40,8 @@ class CalibrantModel(AbstractModel):
         return self.__calibrant is not None
 
     def setCalibrant(self, calibrant):
+        if self.__calibrant is calibrant:
+            return
         self.__calibrant = calibrant
         self.wasChanged()
 

--- a/pyFAI/gui/model/GeometryModel.py
+++ b/pyFAI/gui/model/GeometryModel.py
@@ -71,7 +71,7 @@ class GeometryModel(AbstractModel):
         return True
 
     def isValid(self, checkWaveLength=True):
-        """Check if all the modele have a meaning.
+        """Check if all the model have a meaning.
 
         :param bool checkWaveLength: If true (default) the wavelength is
             checked

--- a/pyFAI/gui/utils/unitutils.py
+++ b/pyFAI/gui/utils/unitutils.py
@@ -36,7 +36,12 @@ def tthToRad(twoTheta: numpy.ndarray, unit: units.Unit, wavelength: float=None, 
     """
     Convert a two theta angle from original `unit` to radian.
 
-    `directDist = ai.getFit2D()["directDist"]`
+    The `directDist` argument can be extracted from an azimuthal integrator the
+    following way:
+
+    .. code-block:: python
+
+        directDist = ai.getFit2D()["directDist"]
     """
     if isinstance(twoTheta, numpy.ndarray):
         pass
@@ -70,6 +75,16 @@ def tthToRad(twoTheta: numpy.ndarray, unit: units.Unit, wavelength: float=None, 
 
 
 def from2ThRad(twoTheta, unit, wavelength=None, directDist=None, ai=None):
+    """
+    Convert a two theta angle to this `unit`.
+
+    The `directDist` argument can be extracted from an azimuthal integrator the
+    following way:
+
+    .. code-block:: python
+
+        directDist = ai.getFit2D()["directDist"]
+    """
     if isinstance(twoTheta, numpy.ndarray):
         pass
     elif isinstance(twoTheta, collections.abc.Iterable):

--- a/pyFAI/gui/utils/unitutils.py
+++ b/pyFAI/gui/utils/unitutils.py
@@ -32,7 +32,7 @@ import collections.abc
 from pyFAI import units
 
 
-def tthToRad(twoTheta, unit, wavelength=None, directDist=None):
+def tthToRad(twoTheta: numpy.ndarray, unit: units.Unit, wavelength: float=None, directDist: float=None):
     """
     Convert a two theta angle from original `unit` to radian.
 

--- a/pyFAI/gui/widgets/CalibrantPreview.py
+++ b/pyFAI/gui/widgets/CalibrantPreview.py
@@ -113,13 +113,13 @@ class CalibrantPreview(qt.QFrame):
         toolTip = []
         for f in fileds:
             field_name, field_value, suffix = f
-            field = u"<li><b>%s</b>: %s</li>" % (field_name, field_value)
+            field = u'<li style="white-space:pre"><b>%s</b>: %s</li>' % (field_name, field_value)
             if suffix is not None:
                 field = u"%s (%s)" % (field, suffix)
             toolTip.append(field)
 
         toolTip = u"\n".join(toolTip)
-        toolTip = u"<html><ul>%s</ul></html>" % toolTip
+        toolTip = u'<html><ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0">%s</ul></html>' % toolTip
         self.setToolTip(toolTip)
 
     def __getPixmap(self, size=360):

--- a/pyFAI/gui/widgets/CalibrantSelector.py
+++ b/pyFAI/gui/widgets/CalibrantSelector.py
@@ -38,6 +38,16 @@ from ..model.CalibrantModel import CalibrantModel
 
 
 class CalibrantSelector(qt.QComboBox):
+    """Dropdown widget to select a calibrant.
+
+    It is a view on top of a calibrant model (see :meth:`setModel`, :meth:`model`)
+
+    The calibrant can be selected from a list of calibrant known by pyFAI.
+
+    An extra option to load a calibrant from a file can be enabled with
+    :meth:`setFileLoadable`. The widget does not handle the dialog or the IO
+    but provides a signal :prop:`sigLoadFileRequested` which have to be connected.
+    """
 
     sigLoadFileRequested = qt.Signal()
 

--- a/pyFAI/gui/widgets/CalibrantSelector.py
+++ b/pyFAI/gui/widgets/CalibrantSelector.py
@@ -23,6 +23,8 @@
 #
 # ###########################################################################*/
 
+from __future__ import absolute_import
+
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "16/10/2020"
@@ -54,7 +56,7 @@ class CalibrantSelector(qt.QComboBox):
         self.__calibrantCount = self.count()
         self.__isFileLoadable = False
 
-        self.__model = None
+        self.__model: CalibrantModel = None
         self.setModel(CalibrantModel())
         self.currentIndexChanged[int].connect(self.__currentIndexChanged)
 
@@ -96,7 +98,7 @@ class CalibrantSelector(qt.QComboBox):
     def __loadFileRequested(self):
         self.sigLoadFileRequested.emit()
 
-    def setModel(self, model):
+    def setModel(self, model: CalibrantModel):
         if self.__model is not None:
             self.__model.changed.disconnect(self.__modelChanged)
         self.__model = model
@@ -142,5 +144,5 @@ class CalibrantSelector(qt.QComboBox):
                     self.__calibrantCount += 1
                 self.setCurrentIndex(index)
 
-    def model(self):
+    def model(self) -> CalibrantModel:
         return self.__model

--- a/pyFAI/gui/widgets/CalibrantSelector.py
+++ b/pyFAI/gui/widgets/CalibrantSelector.py
@@ -41,6 +41,7 @@ class CalibrantSelector(qt.QComboBox):
 
     def __init__(self, parent=None):
         super(CalibrantSelector, self).__init__(parent)
+        self.setStyleSheet("QComboBox {combobox-popup: 0;}")
 
         # feed the widget with default calibrants
         items = pyFAI.calibrant.CALIBRANT_FACTORY.items()

--- a/pyFAI/gui/widgets/DetectorLabel.py
+++ b/pyFAI/gui/widgets/DetectorLabel.py
@@ -44,7 +44,13 @@ _logger = logging.getLogger(__name__)
 
 
 class DetectorLabel(qt.QLabel):
-    """Readonly line display"""
+    """Read-only widget to display a :class:`Detector`.
+
+    It can be setup as
+
+    - a detector holder (see :meth:`setDetector`, :meth:`detector`)
+    - a view on top of a model (see :meth:`setDetectorModel`, :meth:`detectorModel`)
+    """
 
     _BASE_TEMPLATE = "<html><head/><body>%s</body></html>"
 

--- a/pyFAI/gui/widgets/DetectorLabel.py
+++ b/pyFAI/gui/widgets/DetectorLabel.py
@@ -23,16 +23,22 @@
 #
 # ###########################################################################*/
 
+from __future__ import absolute_import
+
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "17/12/2021"
 
 import logging
+from typing import Optional
 
 from silx.gui import qt
 import html
 
 import pyFAI.detectors
+from pyFAI.detectors import Detector
+from ..model.DetectorModel import DetectorModel
+
 
 _logger = logging.getLogger(__name__)
 
@@ -57,8 +63,8 @@ class DetectorLabel(qt.QLabel):
 
     def __init__(self, parent=None):
         super(DetectorLabel, self).__init__(parent)
-        self.__model = None
-        self.__detector = None
+        self.__model: Optional[DetectorModel] = None
+        self.__detector: Optional[Detector] = None
 
     def dragEnterEvent(self, event):
         if self.__model is not None:
@@ -94,7 +100,7 @@ class DetectorLabel(qt.QLabel):
 
         self.__model.setDetector(detector)
 
-    def __getModelName(self, detector):
+    def __getModelName(self, detector: Detector):
         if isinstance(detector, pyFAI.detectors.NexusDetector):
             if hasattr(detector, "name"):
                 name = detector.name
@@ -111,7 +117,7 @@ class DetectorLabel(qt.QLabel):
             modelName = detectorClass.__name__
         return modelName
 
-    def detector(self):
+    def detector(self) -> Optional[Detector]:
         if self.__detector is not None:
             return self.__detector
         if self.__model is not None:
@@ -175,7 +181,7 @@ class DetectorLabel(qt.QLabel):
         self.setText(text)
         self.setToolTip(tooltip)
 
-    def setDetectorModel(self, model):
+    def setDetectorModel(self, model: DetectorModel):
         self.__detector = None
         if self.__model is not None:
             self.__model.changed.disconnect(self.__modelChanged)
@@ -187,10 +193,10 @@ class DetectorLabel(qt.QLabel):
     def __modelChanged(self):
         self.__updateDisplay()
 
-    def detectorModel(self):
+    def detectorModel(self) -> Optional[DetectorModel]:
         return self.__model
 
-    def setDetector(self, detector):
+    def setDetector(self, detector: Optional[Detector]):
         self.__model = None
         self.__detector = detector
         self.__updateDisplay()

--- a/pyFAI/gui/widgets/DetectorLabel.py
+++ b/pyFAI/gui/widgets/DetectorLabel.py
@@ -44,13 +44,14 @@ class DetectorLabel(qt.QLabel):
 
     _MANUFACTURER_TEMPLATE = "<span style=\"vertical-align:sub;\">%s</span>"
 
-    _TOOLTIP_TEMPLATE = ("<html>"
-                         "<ul>"
-                         "<li><b>Model:</b> {model}</li>"
-                         "<li><b>Manufacturer:</b> {manufacturer}</li>"
-                         "<li><b>Type:</b> {kind}</li>"
-                         "</ul>"
-                         "</html>")
+    _TOOLTIP_TEMPLATE = """
+        <html>
+        <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0">
+        <li style="white-space:pre"><b>Model:</b> {model}</li>
+        <li style="white-space:pre"><b>Manufacturer:</b> {manufacturer}</li>
+        <li style="white-space:pre"><b>Type:</b> {kind}</li>
+        </ul>
+        </html>"""
 
     _MODEL_TEMPLATE = "%s"
 

--- a/pyFAI/gui/widgets/GeometryLabel.py
+++ b/pyFAI/gui/widgets/GeometryLabel.py
@@ -27,6 +27,7 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "17/11/2022"
 
+from typing import Optional
 from ..model.GeometryModel import GeometryModel
 from silx.gui.widgets.ElidedLabel import ElidedLabel
 
@@ -37,7 +38,7 @@ class GeometryLabel(ElidedLabel):
 
     def __init__(self, parent=None):
         super(GeometryLabel, self).__init__(parent)
-        self.__geometry = None
+        self.__geometry: Optional[GeometryModel] = None
         self.__updateDisplay()
         self.setTextAsToolTip(False)
 
@@ -78,7 +79,7 @@ class GeometryLabel(ElidedLabel):
         self.setText(labelTemplate.format(**args))
         self.setToolTip(tipTemplate.format(**args))
 
-    def setGeometryModel(self, geometryModel):
+    def setGeometryModel(self, geometryModel: Optional[GeometryModel]):
         """Set the geometry to display.
 
         :param ~pyFAI.gui.model.GeometryModel geometryModel: A geometry.
@@ -92,7 +93,7 @@ class GeometryLabel(ElidedLabel):
         if self.__geometry is not None:
             self.__geometry.changed.connect(self.__updateDisplay)
 
-    def geometryModel(self):
+    def geometryModel(self) -> Optional[GeometryModel]:
         """Returns the geometry model
 
         :rtype: Union[None,~pyFAI.gui.model.GeometryModel]

--- a/pyFAI/gui/widgets/GeometryLabel.py
+++ b/pyFAI/gui/widgets/GeometryLabel.py
@@ -33,7 +33,10 @@ from silx.gui.widgets.ElidedLabel import ElidedLabel
 
 
 class GeometryLabel(ElidedLabel):
-    """Label displaying a specific OpenCL device.
+    """Read-only widget to display a :class:`GeometryModel`.
+
+    - a detector holder (see :meth:`setDetector`, :meth:`detector`)
+    - a view on top of a model (see :meth:`setDetectorModel`, :meth:`detectorModel`)
     """
 
     def __init__(self, parent=None):

--- a/pyFAI/gui/widgets/GeometryLabel.py
+++ b/pyFAI/gui/widgets/GeometryLabel.py
@@ -63,13 +63,13 @@ class GeometryLabel(ElidedLabel):
             return
 
         tipTemplate = """<html>
-            <ul>
-            <li><b>Distance</b>: {distance} m</li>
-            <li><b>PONI1</b>: {poni1} m</li>
-            <li><b>PONI2</b>: {poni2} m</li>
-            <li><b>Rotation 1</b>: {rotation1} rad</li>
-            <li><b>Rotation 2</b>: {rotation2} rad</li>
-            <li><b>Rotation 3</b>: {rotation3} rad</li>
+            <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0">
+            <li style="white-space:pre"><b>Distance</b>: {distance} m</li>
+            <li style="white-space:pre"><b>PONI1</b>: {poni1} m</li>
+            <li style="white-space:pre"><b>PONI2</b>: {poni2} m</li>
+            <li style="white-space:pre"><b>Rotation 1</b>: {rotation1} rad</li>
+            <li style="white-space:pre"><b>Rotation 2</b>: {rotation2} rad</li>
+            <li style="white-space:pre"><b>Rotation 3</b>: {rotation3} rad</li>
             </ul>
         </html>"""
 

--- a/pyFAI/gui/widgets/MethodLabel.py
+++ b/pyFAI/gui/widgets/MethodLabel.py
@@ -54,11 +54,11 @@ class MethodLabel(qt.QLabel):
         "opencl": "OpenCL",
     }
 
-    _TOOLTIP_TEMPLATE = """<ul>
-    <li><b>Pixel splitting:</b> {split}</li>
-    <li><b>Implementation:</b> {impl}</li>
-    <li><b>Algorithm:</b> {algo}</li>
-    <li><b>Availability:</b> {availability}</li>
+    _TOOLTIP_TEMPLATE = """<ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0">
+    <li style="white-space:pre"><b>Pixel splitting:</b> {split}</li>
+    <li style="white-space:pre"><b>Implementation:</b> {impl}</li>
+    <li style="white-space:pre"><b>Algorithm:</b> {algo}</li>
+    <li style="white-space:pre"><b>Availability:</b> {availability}</li>
     </ul>"""
 
     def __init__(self, parent=None):

--- a/pyFAI/gui/widgets/OpenClDeviceLabel.py
+++ b/pyFAI/gui/widgets/OpenClDeviceLabel.py
@@ -82,19 +82,19 @@ class OpenClDeviceLabel(qt.QLabel):
             if deviceName is None:
                 labelTemplate = "{deviceId}, {platformId}"
                 tipTemplate = """
-                    <ul>
-                    <li><b>Platform index</b>: {platformId}</li>
-                    <li><b>Device index</b>: {deviceId}</li>
+                    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0">
+                    <li style="white-space:pre"><b>Platform index</b>: {platformId}</li>
+                    <li style="white-space:pre"><b>Device index</b>: {deviceId}</li>
                     </ul>
                 """
             else:
                 labelTemplate = "{deviceName} ({platformId}, {deviceId})"
                 tipTemplate = """
-                    <ul>
-                    <li><b>Platform name</b>: {platformName}</li>
-                    <li><b>Platform index</b>: {platformId}</li>
-                    <li><b>Device name</b>: {deviceName}</li>
-                    <li><b>Device index</b>: {deviceId}</li>
+                    <ul style="margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0">
+                    <li style="white-space:pre"><b>Platform name</b>: {platformName}</li>
+                    <li style="white-space:pre"><b>Platform index</b>: {platformId}</li>
+                    <li style="white-space:pre"><b>Device name</b>: {deviceName}</li>
+                    <li style="white-space:pre"><b>Device index</b>: {deviceId}</li>
                     </ul>
                 """
 

--- a/pyFAI/utils/ellipse.py
+++ b/pyFAI/utils/ellipse.py
@@ -38,14 +38,23 @@ __date__ = "26/02/2021"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
+from typing import NamedTuple
 import numpy
 import logging
 from math import sqrt, atan2, pi
-from collections import namedtuple
 
 _logger = logging.getLogger(__name__)
 
-Ellipse = namedtuple("Ellipse", ["center_1", "center_2", "angle", "half_long_axis", "half_short_axis"])
+
+class Ellipse(NamedTuple):
+    center_1: float
+    """Center position in the slow axis (pty)"""
+    center_2: float
+    """Center position in the fast axis (ptx)"""
+    angle: float
+    """Angle in radian"""
+    half_long_axis: float
+    half_short_axis: float
 
 
 def fit_ellipse(pty, ptx, _allow_delta=True):


### PR DESCRIPTION
This is a small PR with mostly fixes on doc and types, and small UI polish.

Feel free to tell me what you want to pick, i can create dedicated PR per commits if you prefer.

e78be61ad2d1421ff101900f4348ce5256f1875e is a commit that could in theory introduce a bug.
other commits are pretty safe.

# Tooltips

During the years i have rework my tooltips on Flint.

The patches on `<ul><li>` make the result a bit more compact and readable.

![image](https://github.com/silx-kit/pyFAI/assets/7579321/b45729c5-b7de-49e2-888f-cc8da48a2535)

# Calibrant selector

The proposal on the calibrant selector make the resulut smaller.

It's a trick to force Qt to use a pure Qt component instead of a widget from the system (or i misunderstand).

![image](https://github.com/silx-kit/pyFAI/assets/7579321/476e25c0-fea9-4861-962f-ddf4f84e69cf)

Instead of 

![image](https://github.com/silx-kit/pyFAI/assets/7579321/e18bc9e9-ef53-4fc4-8634-81cbad317873)
