### PR TITLE
Rework pyFAI calibrant as resource

### DIFF
--- a/pyFAI/calibrant.py
+++ b/pyFAI/calibrant.py
@@ -628,8 +628,9 @@ class Calibrant(object):
             return self._2th.index(angle)
         if delta:
             d2th = abs(numpy.array(self._2th) - angle)
-            if d2th.min() < delta:
-                return d2th.argmin()
+            i = d2th.argmin()
+            if d2th[i] < delta:
+                return i
         return None
 
     def get_max_wavelength(self, index: Optional[int]=None):

--- a/pyFAI/calibrant.py
+++ b/pyFAI/calibrant.py
@@ -624,7 +624,7 @@ class Calibrant(object):
         :param delta: precision on angle
         :return: 0-based index or None
         """
-        if angle and angle in self._2th:
+        if angle in self._2th:
             return self._2th.index(angle)
         if delta:
             d2th = abs(numpy.array(self._2th) - angle)

--- a/pyFAI/calibrant.py
+++ b/pyFAI/calibrant.py
@@ -630,6 +630,7 @@ class Calibrant(object):
             d2th = abs(numpy.array(self._2th) - angle)
             if d2th.min() < delta:
                 return d2th.argmin()
+        return None
 
     def get_max_wavelength(self, index: Optional[int]=None):
         """Calculate the maximum wavelength assuming the ring at index is visible.


### PR DESCRIPTION
This PR is a proposal to store the calibrant from pyFAI as a resource.

Plus some review of the code, documentation, typing.

Now a calibrant resource from pyfai is stored as `_filename = "pyfai:LaB6"`.
The file path is generated only when it have to be read.

This way it is easy to distinguish calibrant from resources, and other user calibrants.

If one try to change and save such calibrant, it raises an exception.