### PR TITLE
New calibrant widget

### DIFF
--- a/pyFAI/gui/CalibrationContext.py
+++ b/pyFAI/gui/CalibrationContext.py
@@ -286,7 +286,7 @@ class CalibrationContext(ApplicationContext):
     def getHtmlMarkerColor(self, index):
         colors = self.markerColorList()
         color = colors[index % len(colors)]
-        "#%02X%02X%02X" % (color.red(), color.green(), color.blue())
+        return "#%02X%02X%02X" % (color.red(), color.green(), color.blue())
 
     def disabledMarkerColor(self):
         style = self.getCurrentStyle()

--- a/pyFAI/gui/CalibrationContext.py
+++ b/pyFAI/gui/CalibrationContext.py
@@ -83,6 +83,8 @@ class CalibrationContext(ApplicationContext):
         self.__scatteringVectorUnit.setValue(units.Unit.INV_ANGSTROM)
         self.__markerColors = {}
         self.__cacheStyles = {}
+        self.__recentCalibrants = DataModel()
+        self.__recentCalibrants.setValue([])
 
         self.sigStyleChanged = self.__rawColormap.sigChanged
 
@@ -142,6 +144,9 @@ class CalibrationContext(ApplicationContext):
         self.__restoreUnit(self.__scatteringVectorUnit, settings, "scattering-vector-unit", units.Unit.INV_ANGSTROM)
         settings.endGroup()
 
+        recentCalibrants = settings.value("recent-calibrations", [], type=list)
+        self.__recentCalibrants.setValue(recentCalibrants)
+
     def saveSettings(self):
         """Save the settings of all the application"""
         settings = self.__settings
@@ -156,6 +161,8 @@ class CalibrationContext(ApplicationContext):
         settings.setValue("wavelength-unit", self.__wavelengthUnit.value().name)
         settings.setValue("scattering-vector-unit", self.__scatteringVectorUnit.value().name)
         settings.endGroup()
+
+        settings.setValue("recent-calibrations", self.__recentCalibrants.value())
 
         # Synchronize the file storage
         super(CalibrationContext, self).saveSettings()
@@ -287,6 +294,9 @@ class CalibrationContext(ApplicationContext):
         colors = self.markerColorList()
         color = colors[index % len(colors)]
         return "#%02X%02X%02X" % (color.red(), color.green(), color.blue())
+
+    def getRecentCalibrants(self) -> DataModel:
+        return self.__recentCalibrants
 
     def disabledMarkerColor(self):
         style = self.getCurrentStyle()

--- a/pyFAI/gui/dialog/DetectorSelectorDialog.py
+++ b/pyFAI/gui/dialog/DetectorSelectorDialog.py
@@ -34,8 +34,8 @@ from silx.gui import qt
 
 import pyFAI.utils
 import pyFAI.detectors
-from ..widgets.DetectorModel import AllDetectorModel
-from ..widgets.DetectorModel import DetectorFilter
+from ..widgets.model.AllDetectorItemModel import AllDetectorItemModel
+from ..widgets.model.DetectorFilterProxyModel import DetectorFilterProxyModel
 from ..model.DataModel import DataModel
 from ..utils import validators
 from ..ApplicationContext import ApplicationContext
@@ -62,8 +62,8 @@ class DetectorSelectorDrop(qt.QWidget):
         selection = self._manufacturerList.selectionModel()
         selection.selectionChanged.connect(self.__manufacturerChanged)
 
-        model = AllDetectorModel(self)
-        modelFilter = DetectorFilter(self)
+        model = AllDetectorItemModel(self)
+        modelFilter = DetectorFilterProxyModel(self)
         modelFilter.setSourceModel(model)
 
         self._detectorView.setModel(modelFilter)
@@ -512,7 +512,7 @@ class DetectorSelectorDrop(qt.QWidget):
             return None
         index = indexes[0]
         model = self._detectorView.model()
-        return model.data(index, role=AllDetectorModel.CLASS_ROLE)
+        return model.data(index, role=AllDetectorItemModel.CLASS_ROLE)
 
     def __modelChanged(self, selected, deselected):
         model = self.currentDetectorClass()

--- a/pyFAI/gui/tasks/ExperimentTask.py
+++ b/pyFAI/gui/tasks/ExperimentTask.py
@@ -141,7 +141,7 @@ class ExperimentTask(AbstractCalibrationTask):
 
         settings = model.experimentSettingsModel()
 
-        self._calibrant.setModel(settings.calibrantModel())
+        self._calibrant.setCalibrantModel(settings.calibrantModel())
         self._detectorLabel.setDetectorModel(settings.detectorModel())
         self._image.setModel(settings.image())
         self._imageLoader.setModel(settings.image())

--- a/pyFAI/gui/tasks/ExperimentTask.py
+++ b/pyFAI/gui/tasks/ExperimentTask.py
@@ -78,8 +78,10 @@ class ExperimentTask(AbstractCalibrationTask):
 
         self._detectorFileDescription.setElideMode(qt.Qt.ElideMiddle)
 
-        self._calibrant.setFileLoadable(True)
+        #self._calibrant.setFileLoadable(True)
         self._calibrant.sigLoadFileRequested.connect(self.loadCalibrant)
+        recentCalibrants = CalibrationContext.instance().getRecentCalibrants().value()
+        self._calibrant.setRecentCalibrants(recentCalibrants)
 
         self.__synchronizeRawView = SynchronizeRawView()
         self.__synchronizeRawView.registerTask(self)
@@ -92,6 +94,11 @@ class ExperimentTask(AbstractCalibrationTask):
         self._energy.setValidator(validator)
         self._wavelength.setValidator(validator)
         super()._initGui()
+
+    def aboutToClose(self):
+        super(ExperimentTask, self).aboutToClose()
+        recentCalibrants = self._calibrant.recentCalibrants()
+        CalibrationContext.instance().getRecentCalibrants().setValue(recentCalibrants)
 
     def __createPlot(self, parent):
         plot = silx.gui.plot.PlotWidget(parent=parent)

--- a/pyFAI/gui/widgets/CalibrantSelector.py
+++ b/pyFAI/gui/widgets/CalibrantSelector.py
@@ -35,12 +35,14 @@ from silx.gui import qt
 from silx.gui import icons
 import pyFAI.calibrant
 from ..model.CalibrantModel import CalibrantModel
+from ...utils.decorators import deprecated
 
 
 class CalibrantSelector(qt.QComboBox):
     """Dropdown widget to select a calibrant.
 
-    It is a view on top of a calibrant model (see :meth:`setModel`, :meth:`model`)
+    It is a view on top of a calibrant model (see :meth:`setCalibrantModel`,
+    :meth:`calibrantModel`)
 
     The calibrant can be selected from a list of calibrant known by pyFAI.
 
@@ -67,11 +69,11 @@ class CalibrantSelector(qt.QComboBox):
         self.__isFileLoadable = False
 
         self.__model: CalibrantModel = None
-        self.setModel(CalibrantModel())
+        self.setCalibrantModel(CalibrantModel())
         self.currentIndexChanged[int].connect(self.__currentIndexChanged)
 
     def __currentIndexChanged(self, index):
-        model = self.model()
+        model = self.calibrantModel()
         if model is None:
             return
         if self.__isFileLoadable:
@@ -108,13 +110,17 @@ class CalibrantSelector(qt.QComboBox):
     def __loadFileRequested(self):
         self.sigLoadFileRequested.emit()
 
-    def setModel(self, model: CalibrantModel):
+    def setCalibrantModel(self, model: CalibrantModel):
         if self.__model is not None:
             self.__model.changed.disconnect(self.__modelChanged)
         self.__model = model
         if self.__model is not None:
             self.__model.changed.connect(self.__modelChanged)
         self.__modelChanged()
+
+    @deprecated(replacement="setCalibrantModel")
+    def setModel(self, model: CalibrantModel):
+        self.setCalibrantModel(model)
 
     def findCalibrant(self, calibrant):
         """Returns the first index containing the requested calibrant.
@@ -154,5 +160,9 @@ class CalibrantSelector(qt.QComboBox):
                     self.__calibrantCount += 1
                 self.setCurrentIndex(index)
 
-    def model(self) -> CalibrantModel:
+    def calibrantModel(self) -> CalibrantModel:
         return self.__model
+
+    @deprecated(replacement="calibrantModel")
+    def model(self) -> CalibrantModel:
+        return self.model()

--- a/pyFAI/gui/widgets/CalibrantSelector2.py
+++ b/pyFAI/gui/widgets/CalibrantSelector2.py
@@ -1,0 +1,303 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "16/10/2020"
+
+import time
+import logging
+from typing import List
+
+from silx.gui import qt
+from pyFAI.calibrant import Calibrant
+from ..model.CalibrantModel import CalibrantModel
+from .model.CalibrantFilterProxyModel import CalibrantFilterProxyModel
+from .model.CalibrantItemModel import CalibrantItemModel
+from ...utils import get_ui_file
+
+
+_logger = logging.getLogger(__name__)
+
+
+class _CalibrantItemView(qt.QAbstractItemView):
+    """
+    Custom view  used as popup view for the main combobox.
+    """
+
+    sigLoadFileRequested = qt.Signal()
+
+    def __init__(self, parent=None):
+        super(_CalibrantItemView, self).__init__(parent=parent)
+        filename = get_ui_file("calibrant-selector2.ui")
+        layout = qt.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.__ui = qt.loadUi(filename)
+        self.__ui.setParent(self)
+        layout.addWidget(self.__ui)
+
+        self.__lastUsed = []
+        self.__dropTime = None
+
+        self.__filter = CalibrantFilterProxyModel(self)
+        self.__ui.listView.setModel(self.__filter)
+        self.__ui.allFilter.clicked.connect(self.__selectAll)
+        self.__ui.lastFilter.clicked.connect(self.__selectLast)
+        self.__ui.userFilter.clicked.connect(self.__selectUser)
+        self.__ui.defaultFilter.clicked.connect(self.__selectDefault)
+        self.__ui.loadButton.clicked.connect(self.__loadFileRequested)
+        self.__ui.listView.clicked.connect(self.__currentChanged)
+        self.__ui.listView.activated.connect(self.__currentChanged)
+
+        # self.setFocusProxy(self.__ui.listView)
+
+    def focusInEvent(self, event: qt.QEvent):
+        # Update the size when the model was initialized
+        self.adjustSize()
+        size = self.size()
+        h = self.__ui.listView.sizeHintForRow(0)
+        size.setHeight(h * 8)
+        self.setFixedSize(size)
+
+        if len(self.__lastUsed) > 0:
+            self.__selectLast()
+        else:
+            self.__selectAll()
+        self.__dropTime = time.time()
+        self.__ui.listView.setFocus()
+
+    def setRecentCalibrants(self, calibrants: List[str]):
+        self.__lastUsed = calibrants
+        self._syncLastUsed()
+
+    def recentCalibrants(self) -> List[str]:
+        return self.__lastUsed
+
+    def touchCalibrant(self, calibrant):
+        filename = calibrant.filename
+        if filename is not None:
+            try:
+                self.__lastUsed.remove(filename)
+            except ValueError:
+                pass
+            self.__lastUsed.insert(0, filename)
+            self.__lastUsed = self.__lastUsed[:8]
+
+    def __currentChanged(self, current: qt.QModelIndex):
+        if time.time() - self.__dropTime < 0.200:
+            # When a mouse press is performed on the combobox, directly followed
+            # a mouse release, if the first item was selected, the change is
+            # triggered
+            # Here is a mitigation
+            return
+        sourceIndex = self.__filter.mapToSource(current)
+        self.setCurrentIndex(sourceIndex)
+        calibrant = sourceIndex.data(CalibrantItemModel.CALIBRANT_ROLE)
+        self.touchCalibrant(calibrant)
+        self.accept()
+
+    def accept(self):
+        """Send event to close and accept the popup"""
+        event = qt.QKeyEvent(qt.QKeyEvent.KeyPress, qt.Qt.Key_Enter, qt.Qt.NoModifier, "x")
+        qt.QApplication.sendEvent(self, event);
+
+    def reject(self):
+        """Send event to close and reject the popup"""
+        event = qt.QKeyEvent(qt.QKeyEvent.KeyPress, qt.Qt.Key_Escape, qt.Qt.NoModifier, "x")
+        qt.QApplication.sendEvent(self, event);
+
+    def __loadFileRequested(self):
+        self.sigLoadFileRequested.emit()
+
+    def restoreState(self, state: qt.QByteArray) -> bool:
+        stream = qt.QDataStream(state, qt.QIODevice.ReadOnly)
+        version = stream.readUInt32()
+        if version != 0:
+            _logger.warning("Serial version mismatch. Found %d." % version)
+            return False
+
+        nb = stream.readUInt32()
+        names = []
+        for _ in range(nb):
+            name = stream.readQString()
+            names.append(name)
+        self.__lastUsed = names
+        self._syncLastUsed()
+        return True
+
+    def saveState(self) -> qt.QByteArray:
+        data = qt.QByteArray()
+        stream = qt.QDataStream(data, qt.QIODevice.WriteOnly)
+        stream.writeUInt32(0)
+        stream.writeUInt32(len(self.__lastUsed))
+        for c in self.__lastUsed:
+            stream.writeQString(c)
+        return data
+
+    def __clearAll(self):
+        self.__ui.allFilter.blockSignals(True)
+        self.__ui.allFilter.setChecked(False)
+        self.__ui.allFilter.blockSignals(False)
+
+        self.__ui.lastFilter.blockSignals(True)
+        self.__ui.lastFilter.setChecked(False)
+        self.__ui.lastFilter.blockSignals(False)
+
+        self.__ui.userFilter.blockSignals(True)
+        self.__ui.userFilter.setChecked(False)
+        self.__ui.userFilter.blockSignals(False)
+
+        self.__ui.defaultFilter.blockSignals(True)
+        self.__ui.defaultFilter.setChecked(False)
+        self.__ui.defaultFilter.blockSignals(False)
+
+    def __selectAll(self):
+        self.__clearAll()
+        self.__filter.setFilter(displayResource=True, displayUser=True)
+        self.__ui.allFilter.blockSignals(True)
+        self.__ui.allFilter.setChecked(True)
+        self.__ui.allFilter.blockSignals(False)
+
+    def __selectLast(self):
+        self.__clearAll()
+        self.__filter.setFilter(displayResource=False, displayUser=False, filenames=set(self.__lastUsed))
+        self.__ui.lastFilter.blockSignals(True)
+        self.__ui.lastFilter.setChecked(True)
+        self.__ui.lastFilter.blockSignals(False)
+
+    def __selectUser(self):
+        self.__clearAll()
+        self.__filter.setFilter(displayResource=False, displayUser=True)
+        self.__ui.userFilter.blockSignals(True)
+        self.__ui.userFilter.setChecked(True)
+        self.__ui.userFilter.blockSignals(False)
+
+    def __selectDefault(self):
+        self.__clearAll()
+        self.__filter.setFilter(displayResource=True, displayUser=False)
+        self.__ui.defaultFilter.blockSignals(True)
+        self.__ui.defaultFilter.setChecked(True)
+        self.__ui.defaultFilter.blockSignals(False)
+
+    def visualRegionForSelection(self, selection: qt.QItemSelection):
+        return qt.QRegion()
+
+    def visualRect(self, index: qt.QModelIndex):
+        return qt.QRect()
+
+    def moveCursor(self, cursorAction, modifiers) -> qt.QModelIndex:
+        return qt.QModelIndex()
+
+    def scrollTo(self, index, hint):
+        self.__ui.listView.scrollTo(index, hint)
+
+    def indexAt(self, point: qt.QPoint) -> qt.QModelIndex:
+        return self.__ui.listView.indexAt(point)
+
+    def setModel(self, model: qt.QStandardItemModel):
+        self.__filter.setSourceModel(model)
+        qt.QAbstractItemView.setModel(self, model)
+        self._syncLastUsed()
+
+    def _syncLastUsed(self):
+        model = self.model()
+        if model is None:
+            return
+        for f in self.__lastUsed:
+            calibrant = Calibrant(f)
+            index = model.indexFromCalibrant(calibrant)
+            if not index.isValid():
+                model.appendCalibrant(calibrant)
+
+    def horizontalOffset(self):
+        return 0
+
+    def verticalOffset(self):
+        return 0
+
+
+class CalibrantSelector2(qt.QComboBox):
+    """Dropdown widget to select a calibrant.
+
+    It is a view on top of a calibrant model (see :meth:`setCalibrantModel`,
+    :meth:`modelCalibrant`)
+
+    The calibrant can be selected from a list of calibrant known by pyFAI.
+    """
+
+    sigLoadFileRequested = qt.Signal()
+
+    def __init__(self, parent=None):
+        super(CalibrantSelector2, self).__init__(parent=parent)
+        model = CalibrantItemModel(self)
+        self.setModel(model)
+        self.setCurrentIndex(-1)
+
+        self.__calibrantModel: CalibrantModel = None
+        self.setCalibrantModel(CalibrantModel())
+
+        view = _CalibrantItemView(self)
+        view.sigLoadFileRequested.connect(self.__loadFileRequested)
+        self.setView(view)
+
+    def __modelChanged(self):
+        calibrant = self.__calibrantModel.calibrant()
+        model = self.model()
+        if calibrant is None or model is None:
+            self.setCurrentIndex(-1)
+        else:
+            index = model.indexFromCalibrant(calibrant)
+            if not index.isValid():
+                model.appendCalibrant(index)
+                index = model.indexFromCalibrant(calibrant)
+            if index.isValid():
+                self.view().touchCalibrant(calibrant)
+                self.setCurrentIndex(index.row())
+
+    def setCalibrantModel(self, model: CalibrantModel):
+        if self.__calibrantModel is not None:
+            self.__calibrantModel.changed.disconnect(self.__modelChanged)
+        self.__calibrantModel = model
+        if self.__calibrantModel is not None:
+            self.__calibrantModel.changed.connect(self.__modelChanged)
+        self.__modelChanged()
+
+    def calibrantModel(self) -> CalibrantModel:
+        return self.__calibrantModel
+
+    def recentCalibrants(self):
+        return self.view().recentCalibrants()
+
+    def setRecentCalibrants(self, recentCalibrants: List[str]):
+        return self.view().setRecentCalibrants(recentCalibrants)
+
+    def restoreState(self, state: qt.QByteArray) -> bool:
+        return self.view().restoreState(state)
+
+    def saveState(self) -> qt.QByteArray:
+        return self.view().saveState()
+
+    def __loadFileRequested(self):
+        self.sigLoadFileRequested.emit()

--- a/pyFAI/gui/widgets/DetectorSelector.py
+++ b/pyFAI/gui/widgets/DetectorSelector.py
@@ -29,8 +29,8 @@ __date__ = "16/10/2020"
 
 from silx.gui import qt
 from ..model.DetectorModel import DetectorModel
-from .DetectorModel import AllDetectorModel
-from .DetectorModel import DetectorFilter
+from .model.AllDetectorItemModel import AllDetectorItemModel
+from .model.DetectorFilterProxyModel import DetectorFilterProxyModel
 
 
 class DetectorSelector(qt.QComboBox):
@@ -39,8 +39,8 @@ class DetectorSelector(qt.QComboBox):
         super(DetectorSelector, self).__init__(parent)
 
         # feed the widget with default detectors
-        model = AllDetectorModel(self)
-        self.__filter = DetectorFilter(self)
+        model = AllDetectorItemModel(self)
+        self.__filter = DetectorFilterProxyModel(self)
         self.__filter.setSourceModel(model)
 
         super(DetectorSelector, self).setModel(self.__filter)

--- a/pyFAI/gui/widgets/meson.build
+++ b/pyFAI/gui/widgets/meson.build
@@ -1,4 +1,5 @@
 subdir('test')
+subdir('model')
 
 py.install_sources(
    ['AdvancedComboBox.py',

--- a/pyFAI/gui/widgets/meson.build
+++ b/pyFAI/gui/widgets/meson.build
@@ -6,6 +6,7 @@ py.install_sources(
     'AdvancedSpinBox.py',
     'CalibrantPreview.py',
     'CalibrantSelector.py',
+    'CalibrantSelector2.py',
     'ChoiceToolButton.py',
     'ColoredCheckBox.py',
     'DetectorLabel.py',

--- a/pyFAI/gui/widgets/model/AllDetectorItemModel.py
+++ b/pyFAI/gui/widgets/model/AllDetectorItemModel.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "16/10/2020"
+
+from silx.gui import qt
+import pyFAI.detectors
+
+
+class AllDetectorItemModel(qt.QStandardItemModel):
+
+    CLASS_ROLE = qt.Qt.UserRole
+    MODEL_ROLE = qt.Qt.UserRole + 1
+    MANUFACTURER_ROLE = qt.Qt.UserRole + 2
+
+    def __init__(self, parent):
+        qt.QStandardItemModel.__init__(self, parent)
+
+        detectorClasses = set(pyFAI.detectors.ALL_DETECTORS.values())
+
+        def getNameAndManufacturer(detectorClass):
+            modelName = None
+            result = []
+
+            if hasattr(detectorClass, "MANUFACTURER"):
+                manufacturer = detectorClass.MANUFACTURER
+            else:
+                manufacturer = None
+
+            if isinstance(manufacturer, list):
+                for index, m in enumerate(manufacturer):
+                    if m is None:
+                        continue
+                    modelName = detectorClass.aliases[index]
+                    result.append((modelName, m, detectorClass))
+            else:
+                if hasattr(detectorClass, "aliases"):
+                    if len(detectorClass.aliases) > 0:
+                        modelName = detectorClass.aliases[0]
+                if modelName is None:
+                    modelName = detectorClass.__name__
+                result.append((modelName, manufacturer, detectorClass))
+            return result
+
+        def sortingKey(item):
+            modelName, manufacturerName, _detector = item
+            if modelName:
+                modelName = modelName.lower()
+            if manufacturerName:
+                manufacturerName = manufacturerName.lower()
+            return modelName, manufacturerName
+
+        items = []
+        for c in detectorClasses:
+            items.extend(getNameAndManufacturer(c))
+        items = sorted(items, key=sortingKey)
+        for modelName, manufacturerName, detector in items:
+            if detector is pyFAI.detectors.Detector:
+                continue
+            item = qt.QStandardItem(modelName)
+            item.setData(detector, role=self.CLASS_ROLE)
+            item.setData(modelName, role=self.MODEL_ROLE)
+            item.setData(manufacturerName, role=self.MANUFACTURER_ROLE)
+            item2 = qt.QStandardItem(manufacturerName)
+            item2.setData(detector, role=self.CLASS_ROLE)
+            item2.setData(modelName, role=self.MODEL_ROLE)
+            item2.setData(manufacturerName, role=self.MANUFACTURER_ROLE)
+            self.appendRow([item, item2])
+
+    def indexFromDetector(self, detector, manufacturer):
+        for row in range(self.rowCount()):
+            index = self.index(row, 0)
+            manufacturerName = self.data(index, role=self.MANUFACTURER_ROLE)
+            if manufacturerName != manufacturer:
+                continue
+            detectorClass = self.data(index, role=self.CLASS_ROLE)
+            if detectorClass != detector:
+                continue
+            return index
+        return qt.QModelIndex()

--- a/pyFAI/gui/widgets/model/CalibrantFilterProxyModel.py
+++ b/pyFAI/gui/widgets/model/CalibrantFilterProxyModel.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "25/06/2023"
+
+from silx.gui import qt
+from silx.gui import icons
+import pyFAI.calibrant
+from pyFAI.calibrant import Calibrant
+from .CalibrantItemModel import CalibrantItemModel
+
+
+class CalibrantFilterProxyModel(qt.QSortFilterProxyModel):
+
+    def __init__(self, parent):
+        super(CalibrantFilterProxyModel, self).__init__(parent)
+        self.__displayUser: bool = True
+        self.__displayResource: bool = True
+        self.__filenames = None
+
+    def setFilter(self, displayResource: bool, displayUser: bool, filenames=None):
+        if (self.__displayResource == displayResource and self.__displayUser == displayUser):
+            return
+        self.__displayResource = displayResource
+        self.__displayUser = displayUser
+        self.__filenames = filenames
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, sourceRow, sourceParent):
+        sourceModel = self.sourceModel()
+        index = sourceModel.index(sourceRow, 0, sourceParent)
+        calibrant = index.data(CalibrantItemModel.CALIBRANT_ROLE)
+        if self.__filenames is not None:
+            return calibrant.filename in self.__filenames
+
+        is_user = not calibrant.filename.startswith("pyfai:")
+        return (self.__displayUser and is_user) or (self.__displayResource and not is_user)
+
+    def indexFromCalibrant(self, calibrant: Calibrant):
+        sourceModel = self.sourceModel()
+        index = sourceModel.indexFromCalibrant(calibrant)
+        index = self.mapFromSource(index)
+        return index

--- a/pyFAI/gui/widgets/model/CalibrantItemModel.py
+++ b/pyFAI/gui/widgets/model/CalibrantItemModel.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "25/06/2023"
+
+import os.path
+from silx.gui import qt
+from silx.gui import icons
+import pyFAI.calibrant
+from pyFAI.calibrant import Calibrant
+
+
+class CalibrantItemModel(qt.QStandardItemModel):
+
+    CALIBRANT_ROLE = qt.Qt.UserRole
+
+    def __init__(self, parent=None):
+        qt.QStandardItemModel.__init__(self, parent=parent)
+
+        calibrants = pyFAI.calibrant.CALIBRANT_FACTORY.items()
+        calibrants = sorted(calibrants, key=lambda x: x[0].lower())
+        for calibrantName, calibrant in calibrants:
+            item = self.createStandardItem(calibrant, calibrantName)
+            self.appendRow(item)
+
+    def createStandardItem(self, calibrant, calibrantName=None) -> qt.QStandardItem:
+        if calibrantName is None:
+            name = os.path.splitext(os.path.basename(calibrant.filename))[0]
+            calibrantName = name
+        item = qt.QStandardItem()
+        item.setText(calibrantName)
+        item.setToolTip(calibrant.filename)
+        item.setData(calibrant, role=self.CALIBRANT_ROLE)
+        if calibrant.filename is None or calibrant.filename.startswith("pyfai:"):
+            icon = icons.getQIcon("pyfai:gui/icons/calibrant")
+        else:
+            icon = icons.getQIcon("pyfai:gui/icons/calibrant-custom")
+
+        item.setIcon(icon)
+        item.setEditable(False)
+        return item
+
+    def indexFromCalibrant(self, calibrant: Calibrant):
+        for row in range(self.rowCount()):
+            index = self.index(row, 0)
+            calibrantObj = self.data(index, role=self.CALIBRANT_ROLE)
+            if calibrant.filename == calibrantObj.filename:
+                return index
+        return qt.QModelIndex()
+
+    def appendCalibrant(self, calibrant) -> qt.QModelIndex:
+        item = self.createStandardItem(calibrant)
+        self.appendRow(item)

--- a/pyFAI/gui/widgets/model/DetectorFilterProxyModel.py
+++ b/pyFAI/gui/widgets/model/DetectorFilterProxyModel.py
@@ -28,20 +28,31 @@ __license__ = "MIT"
 __date__ = "16/10/2020"
 
 from silx.gui import qt
-from .model.AllDetectorItemModel import AllDetectorItemModel
-from .model.DetectorFilterProxyModel import DetectorFilterProxyModel
-from ...utils.decorators import deprecated
+from .AllDetectorItemModel import AllDetectorItemModel
 
 
-class AllDetectorModel(AllDetectorItemModel):
+class DetectorFilterProxyModel(qt.QSortFilterProxyModel):
 
-    @deprecated(replacement="pyFAI.gui.widgets.model.AllDetectorItemModel.AllDetectorItemModel", since_version="2023.6")
     def __init__(self, parent):
-        AllDetectorItemModel.__init__(self, parent=parent)
+        super(DetectorFilterProxyModel, self).__init__(parent)
+        self.__manufacturerFilter = None
 
+    def setManufacturerFilter(self, manufacturer):
+        if self.__manufacturerFilter == manufacturer:
+            return
+        self.__manufacturerFilter = manufacturer
+        self.invalidateFilter()
 
-class DetectorFilter(DetectorFilterProxyModel):
+    def filterAcceptsRow(self, sourceRow, sourceParent):
+        if self.__manufacturerFilter == "*":
+            return True
+        sourceModel = self.sourceModel()
+        index = sourceModel.index(sourceRow, 0, sourceParent)
+        manufacturer = index.data(AllDetectorItemModel.MANUFACTURER_ROLE)
+        return manufacturer == self.__manufacturerFilter
 
-    @deprecated(replacement="pyFAI.gui.widgets.model.DetectorFilterProxyModel.DetectorFilterProxyModel", since_version="2023.6")
-    def __init__(self, parent):
-        DetectorFilterProxyModel.__init__(self, parent=parent)
+    def indexFromDetector(self, detector, manufacturer):
+        sourceModel = self.sourceModel()
+        index = sourceModel.indexFromDetector(detector, manufacturer)
+        index = self.mapFromSource(index)
+        return index

--- a/pyFAI/gui/widgets/model/__init__.py
+++ b/pyFAI/gui/widgets/model/__init__.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Module containing generic widgets"""
+
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__license__ = "MIT"
+__date__ = "25/06/2023"

--- a/pyFAI/gui/widgets/model/meson.build
+++ b/pyFAI/gui/widgets/model/meson.build
@@ -1,0 +1,8 @@
+
+py.install_sources(
+   ['CalibrantItemModel.py',
+    'CalibrantFilterProxyModel.py',
+    '__init__.py'],
+  pure: false,   # Will be installed next to binaries
+  subdir: 'pyFAI/gui/widgets/model'  # Folder relative to site-packages to install to
+)

--- a/pyFAI/gui/widgets/model/meson.build
+++ b/pyFAI/gui/widgets/model/meson.build
@@ -2,6 +2,8 @@
 py.install_sources(
    ['CalibrantItemModel.py',
     'CalibrantFilterProxyModel.py',
+    'AllDetectorItemModel.py',
+    'DetectorFilterProxyModel.py',
     '__init__.py'],
   pure: false,   # Will be installed next to binaries
   subdir: 'pyFAI/gui/widgets/model'  # Folder relative to site-packages to install to

--- a/pyFAI/resources/gui/calibrant-selector2.ui
+++ b/pyFAI/resources/gui/calibrant-selector2.ui
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>250</width>
+    <height>219</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,1">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>1</number>
+      </property>
+      <property name="topMargin">
+       <number>1</number>
+      </property>
+      <property name="rightMargin">
+       <number>1</number>
+      </property>
+      <property name="bottomMargin">
+       <number>1</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="allFilter">
+        <property name="toolTip">
+         <string>Display everything</string>
+        </property>
+        <property name="text">
+         <string>All</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="lastFilter">
+        <property name="toolTip">
+         <string>Recently used</string>
+        </property>
+        <property name="text">
+         <string>Recent</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="defaultFilter">
+        <property name="toolTip">
+         <string>Only calibrants from pyFAI</string>
+        </property>
+        <property name="text">
+         <string>Default</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="userFilter">
+        <property name="toolTip">
+         <string>Only user defined calibrants</string>
+        </property>
+        <property name="text">
+         <string>User</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="loadButton">
+        <property name="text">
+         <string>Load file...</string>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListView" name="listView">
+     <property name="styleSheet">
+      <string notr="true">QListView { background-color: transparent}</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
+     <property name="horizontalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
+     <property name="uniformItemSizes">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pyFAI/resources/gui/calibration-experiment.ui
+++ b/pyFAI/resources/gui/calibration-experiment.ui
@@ -120,7 +120,7 @@
            </widget>
           </item>
           <item row="5" column="1" colspan="2">
-           <widget class="CalibrantSelector" name="_calibrant"/>
+           <widget class="CalibrantSelector2" name="_calibrant"/>
           </item>
           <item row="0" column="1" colspan="2">
            <widget class="QuantityEdit" name="_energy">
@@ -435,9 +435,9 @@
    <header>pyFAI.gui.widgets.FileEdit</header>
   </customwidget>
   <customwidget>
-   <class>CalibrantSelector</class>
+   <class>CalibrantSelector2</class>
    <extends>QComboBox</extends>
-   <header>pyFAI.gui.widgets.CalibrantSelector</header>
+   <header>pyFAI.gui.widgets.CalibrantSelector2</header>
   </customwidget>
   <customwidget>
    <class>CalibrantPreview</class>

--- a/pyFAI/resources/gui/meson.build
+++ b/pyFAI/resources/gui/meson.build
@@ -3,7 +3,8 @@ subdir('images')
 subdir('styles')
 
 py.install_sources(
-   ['calibration-experiment.ui',
+   ['calibrant-selector2.ui',
+    'calibration-experiment.ui',
     'calibration-geometry.ui',
     'calibration-main.ui',
     'calibration-mask.ui',


### PR DESCRIPTION
Here is a test to provide a new popup for the calibrant widget.

Related to #1902 

I wanted to speed up the user selection.

First I have tried to provide a minimalistic periodic table of elements to group the calibrants, but it is probably not very convenient to use.

So my guess here is to provide the recently used calibrants.

The code provides:
- A calibrant widget with diffrent selectors
- The last 8 recently used calibrants are displayed
- This also store/restore user calibrants load from files (so no need to search for a file twice)
- A button to load a calibrant from file

![image](https://github.com/silx-kit/pyFAI/assets/7579321/4f5532c1-b60e-4712-8c47-b3d35ff40a96)
