### PR TITLE
calib2: Fixes calibrant selection

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -184,7 +184,12 @@ def find_executable(target):
     # search the executable in pyproject.toml
     with open(os.path.join(PROJECT_DIR, "pyproject.toml")) as f:
         pyproject = tomli.loads(f.read())
-    for script, entry_point in list(pyproject.get("console_scripts", {}).items()) + list(pyproject.get("gui_scripts", {}).items()):
+
+    scripts = {}
+    scripts.update(pyproject.get("project", {}).get("scripts", {}))
+    scripts.update(pyproject.get("project", {}).get("gui-scripts", {}))
+
+    for script, entry_point in scripts.items():
         if script == target:
             print(script, entry_point)
             return ("entry_point", target, entry_point)

--- a/pyFAI/gui/widgets/CalibrantSelector2.py
+++ b/pyFAI/gui/widgets/CalibrantSelector2.py
@@ -262,6 +262,16 @@ class CalibrantSelector2(qt.QComboBox):
         view.sigLoadFileRequested.connect(self.__loadFileRequested)
         self.setView(view)
 
+        self.activated.connect(self.__calibrantWasSelected)
+
+    def __calibrantWasSelected(self):
+        index = self.currentIndex()
+        if index == -1:
+            calibrant = None
+        else:
+            calibrant = self.itemData(index, role=CalibrantItemModel.CALIBRANT_ROLE)
+        self.__calibrantModel.setCalibrant(calibrant)
+
     def __modelChanged(self):
         calibrant = self.__calibrantModel.calibrant()
         model = self.model()


### PR DESCRIPTION
This PR fixes #1931.

The user selection was not propagated to the `calibrantModel`.

+ A fix on the `bootstrap.py` to allow to execute entry-points