### PR TITLE
numexpr work arround

### DIFF
--- a/pyFAI/geometry/core.py
+++ b/pyFAI/geometry/core.py
@@ -40,7 +40,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "31/05/2023"
+__date__ = "14/09/2023"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -63,7 +63,7 @@ from ..units import CONST_hc, to_unit
 logger = logging.getLogger(__name__)
 
 try:
-    import numexpr
+    from ..third_party import numexpr
 except ImportError:
     logger.debug("Backtrace", exc_info=True)
     numexpr = None

--- a/pyFAI/goniometer.py
+++ b/pyFAI/goniometer.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "25/04/2023"
+__date__ = "14/09/2023"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
@@ -58,10 +58,11 @@ from .units import CONST_hc, CONST_q
 logger = logging.getLogger(__name__)
 
 try:
-    import numexpr
+    from .third_party import numexpr
 except ImportError:
     logger.debug("Backtrace", exc_info=True)
     numexpr = None
+
 
 # Parameter set used in PyFAI:
 PoniParam = namedtuple("PoniParam", ["dist", "poni1", "poni2", "rot1", "rot2", "rot3"])

--- a/pyFAI/parallax.py
+++ b/pyFAI/parallax.py
@@ -37,7 +37,7 @@ import logging
 logger = logging.getLogger(__name__)
 import numpy
 try:
-    from ..third_party import numexpr
+    from .third_party import numexpr
 except ImportError:
     logger.debug("Backtrace", exc_info=True)
     numexpr = None

--- a/pyFAI/parallax.py
+++ b/pyFAI/parallax.py
@@ -29,14 +29,19 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "19/01/2022"
+__date__ = "14/09/2023"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
 import logging
 logger = logging.getLogger(__name__)
 import numpy
-import numexpr
+try:
+    from ..third_party import numexpr
+except ImportError:
+    logger.debug("Backtrace", exc_info=True)
+    numexpr = None
+
 import scipy.integrate, scipy.signal
 from math import sin, cos, pi, log, sqrt
 from .utils.decorators import timeit

--- a/pyFAI/third_party/meson.build
+++ b/pyFAI/third_party/meson.build
@@ -2,7 +2,8 @@ subdir('_local')
 
 py.install_sources(
    ['__init__.py',
-    'transformations.py'],
+    'transformations.py',
+    'numexpr.py'],
   pure: false,    # Will be installed next to binaries
   subdir: 'pyFAI/third_party'  # Folder relative to site-packages to install to
 )

--- a/pyFAI/third_party/numexp.py
+++ b/pyFAI/third_party/numexp.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2023-2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+
+__authors__ = ["Jérôme Kieffer"]
+__license__ = "MIT"
+__date__ = "14/09/2023"
+
+import logging
+logger = logging.getLogger(__name__)
+local = locals()
+try:
+    import numexpr as _numexpr
+except ImportError as error:
+    logger.errror("unable to import `numexp`")
+    raise error
+else:
+    _version = tuple(int(i) for i in _numexpr.__version__.split(".")[:3] if i.isdigit())
+    if _version < (2,8,6):
+        for key in dir(_numexpr):
+            local[key] = getattr(_numexpr, key)
+    else:
+        for key in dir(_numexpr):
+            if key not in ("evaluate", "NumExpr"):
+                local[key] = getattr(_numexpr, key)
+        # patch NumExpr and evaluate with  `sanitize=False`
+        class NumExpr(_numexpr.NumExpr):
+            def __init__(self, *args, **kwargs):
+                kwargs["sanitize"] = False
+                _numexpr.NumExpr.__init__(self, *args, **kwargs)
+
+        def evaluate(*args, **kwargs):
+            kwargs["sanitize"] = False
+            return _numexpr.evaluate(*args, **kwargs)

--- a/pyFAI/third_party/numexpr.py
+++ b/pyFAI/third_party/numexpr.py
@@ -26,9 +26,11 @@ __authors__ = ["Jérôme Kieffer"]
 __license__ = "MIT"
 __date__ = "14/09/2023"
 
+import os
 import logging
 logger = logging.getLogger(__name__)
 local = locals()
+os.environ['NUMEXPR_SANITIZE'] = "0"
 try:
     import numexpr as _numexpr
 except ImportError as error:
@@ -41,13 +43,9 @@ else:
             local[key] = getattr(_numexpr, key)
     else:
         for key in dir(_numexpr):
-            if key not in ("evaluate", "NumExpr"):
+            if key not in ("NumExpr",):
                 local[key] = getattr(_numexpr, key)
-        # patch NumExpr and evaluate with  `sanitize=False`
+        # patch NumExpr with  `sanitize=False`
         def NumExpr(*args, **kwargs):
             kwargs["sanitize"] = False
             return _numexpr.NumExpr(*args, **kwargs)
-
-        def evaluate(*args, **kwargs):
-            kwargs["sanitize"] = False
-            return _numexpr.evaluate(*args, **kwargs)

--- a/pyFAI/third_party/numexpr.py
+++ b/pyFAI/third_party/numexpr.py
@@ -44,10 +44,9 @@ else:
             if key not in ("evaluate", "NumExpr"):
                 local[key] = getattr(_numexpr, key)
         # patch NumExpr and evaluate with  `sanitize=False`
-        class NumExpr(_numexpr.NumExpr):
-            def __init__(self, *args, **kwargs):
-                kwargs["sanitize"] = False
-                _numexpr.NumExpr.__init__(self, *args, **kwargs)
+        def NumExpr(*args, **kwargs):
+            kwargs["sanitize"] = False
+            return _numexpr.NumExpr(*args, **kwargs)
 
         def evaluate(*args, **kwargs):
             kwargs["sanitize"] = False

--- a/pyFAI/units.py
+++ b/pyFAI/units.py
@@ -47,7 +47,7 @@ import numpy
 from numpy import pi
 import scipy.constants
 try:
-    from ..third_party import numexpr
+    from .third_party import numexpr
 except ImportError:
     logger.debug("Backtrace", exc_info=True)
     numexpr = None

--- a/pyFAI/units.py
+++ b/pyFAI/units.py
@@ -37,7 +37,7 @@ __authors__ = ["Picca Frédéric-Emmanuel", "Jérôme Kieffer"]
 __contact__ = "picca@synchrotron-soleil.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "24/02/2023"
+__date__ = "14/09/2023"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -47,9 +47,11 @@ import numpy
 from numpy import pi
 import scipy.constants
 try:
-    import numexpr
-except (ImportError, ModuleNotFoundError):
+    from ..third_party import numexpr
+except ImportError:
+    logger.debug("Backtrace", exc_info=True)
     numexpr = None
+
 
 ################################################################################
 # A few physical constants

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -107,10 +107,10 @@ from .engines.preproc import preproc as preproc_numpy
 from .utils.decorators import deprecated_warning
 
 try:
-    from ..third_party import numexpr
-except ImportError:
+    from .third_party import numexpr
+except ImportError as err:
     logger.debug("Backtrace", exc_info=True)
-    logger.warning("Unable to import Cython version of preproc: %s", err)
+    logger.warning("Unable to import NumExpr version of preproc: %s", err)
     numexpr = None
     USE_NUMEXPR = False
 else:

--- a/pyFAI/worker.py
+++ b/pyFAI/worker.py
@@ -82,7 +82,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "16/05/2023"
+__date__ = "14/09/2023"
 __status__ = "development"
 
 import threading
@@ -105,10 +105,13 @@ from .io import integration_config
 import pyFAI.io.image
 from .engines.preproc import preproc as preproc_numpy
 from .utils.decorators import deprecated_warning
+
 try:
-    import numexpr
-except ImportError as err:
+    from ..third_party import numexpr
+except ImportError:
+    logger.debug("Backtrace", exc_info=True)
     logger.warning("Unable to import Cython version of preproc: %s", err)
+    numexpr = None
     USE_NUMEXPR = False
 else:
     USE_NUMEXPR = True


### PR DESCRIPTION
I am not especially happy to put in place such work around, I find it pretty ugly but something is needed while waiting for the issue to be fixed upstream.

What I did, theer is a hook to import numexpr from third_party where numexpr is locally patch (or not) to tell it not to sanitize the input. Unfortunately, this has to be done in 2 different ways, using the environment variable for `numexpr.evaluate` and patching the class for `numexpr.NumExpr`. Apparently it works. If you have a better idea, I would be happy to hear it.
