### PR TITLE
Prevent the usage of the broken numexpr

### DIFF
--- a/ci/requirements_appveyor.txt
+++ b/ci/requirements_appveyor.txt
@@ -10,6 +10,6 @@ h5py
 fabio
 scipy
 matplotlib
-numexpr
+numexpr != 2.8.6
 silx
 psutil

--- a/ci/requirements_gh.txt
+++ b/ci/requirements_gh.txt
@@ -19,6 +19,6 @@ matplotlib
 #mako
 #pybind11
 #pyopencl
-numexpr
+numexpr != 2.8.6
 silx
 psutil

--- a/ci/requirements_travis.txt
+++ b/ci/requirements_travis.txt
@@ -16,5 +16,5 @@ matplotlib
 #mako
 #pybind11
 #pyopencl
-numexpr
+numexpr != 2.8.6
 silx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
    'h5py',
    'fabio',
    'silx',
-   'numexpr',
+   'numexpr != 2.8.6',
    'scipy',
    'matplotlib'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cython >=0.29.31
 fabio
 scipy
 matplotlib
-numexpr
+numexpr != 2.8.6
 h5py
 silx >=1.1
 PyOpenGL

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "14/11/2022"
+__date__ = "15/09/2023"
 __status__ = "stable"
 
 import io
@@ -985,7 +985,7 @@ def get_project_configuration(dry_run):
         "fabio>=0.5",
         "matplotlib",
         "scipy",
-        "numexpr",
+        "numexpr!=2.8.6",
         # for the use of pkg_resources on script launcher
         "setuptools<60.0.0",
         "silx>=1.1"]


### PR DESCRIPTION
Do you prefer this ?
How to ensure this gets propagated to debian/conda/ ... ?