### PR TITLE
Added convertion from tthrad to RecD2_NM

### DIFF
--- a/pyFAI/gui/utils/unitutils.py
+++ b/pyFAI/gui/utils/unitutils.py
@@ -112,5 +112,8 @@ def from2ThRad(twoTheta, unit, wavelength=None, directDist=None, ai=None):
         else:
             beamCentre = ai.getFit2D()["directDist"]  # in mm!!
         return beamCentre * numpy.tan(twoTheta) * 0.001
+    elif unit == units.RecD2_NM:
+        q = (4.e-9 * numpy.pi / wavelength) * numpy.sin(.5 * twoTheta)
+        return (q / (2.0 * numpy.pi)) ** 2
     else:
         raise ValueError("Converting from 2th to unit %s is not supported", unit)


### PR DESCRIPTION
Here is an update of the helper convertor to handle tth_rad to d^-2.

It's a rework of the info from `pyFAI.units`, but i would be happy to have a double check here.
Could you please check if the math is right?

BTW: I also have that code in Flint for now, to be sure it is working with previous pyFAI versions.