### PR TITLE
remove reference to numpy.float

### DIFF
--- a/src/pyFAI/gui/dialog/Detector3dDialog.py
+++ b/src/pyFAI/gui/dialog/Detector3dDialog.py
@@ -129,8 +129,8 @@ class CreateSceneThread(qt.QThread):
         if self.__mask is not None:
             mask = self.__mask.reshape(-1)
             if pixelValues.dtype.kind in "ui":
-                pixelValues = pixelValues.astype(numpy.float)
-            pixelValues[mask != 0] = numpy.float("nan")
+                pixelValues = pixelValues.astype(float)
+            pixelValues[mask != 0] = float("nan")
 
         values = numpy.empty(shape=(vertices.shape[0]))
         values[0::4] = pixelValues


### PR DESCRIPTION
This was causing an issue when viewing calibration model in 3D - need to change numpy.float to just float due to deprecation of numpy.float