### PR TITLE
Manage orientation of detector

### DIFF
--- a/src/pyFAI/_version.py
+++ b/src/pyFAI/_version.py
@@ -47,7 +47,7 @@ Thus 2.1.0a3 is hexversion 0x020100a3.
 __authors__ = ["Jérôme Kieffer", "V. Valls"]
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "06/10/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 __all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion",
@@ -61,7 +61,7 @@ RELEASE_LEVEL_VALUE = {"dev": 0,
                        "final": 15}
 
 MAJOR = 2023
-MINOR = 10
+MINOR = 11
 MICRO = 0
 RELEV = "dev"  # <16
 SERIAL = 0  # <16

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "04/10/2023"
+__date__ = "21/11/2023"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -118,7 +118,7 @@ class AzimuthalIntegrator(Geometry):
     def __init__(self, dist=1, poni1=0, poni2=0,
                  rot1=0, rot2=0, rot3=0,
                  pixel1=None, pixel2=None,
-                 splineFile=None, detector=None, wavelength=None):
+                 splineFile=None, detector=None, wavelength=None, orientation=0):
         """
         :param dist: distance sample - detector plan (orthogonal distance, not along the beam), in meter.
         :type dist: float
@@ -152,12 +152,12 @@ class AzimuthalIntegrator(Geometry):
             description is deprecated. Prefer using the result of the detector
             factory: ``pyFAI.detector_factory("eiger4m")``
         :type detector: str or pyFAI.Detector
-        :param wavelength: Wave length used in meter
-        :type wavelength: float
+        :param float wavelength: Wave length used in meter
+        :param int orientation: orientation of the detector, see pyFAI.detectors.orientation.Orientation
         """
         Geometry.__init__(self, dist, poni1, poni2,
                           rot1, rot2, rot3,
-                          pixel1, pixel2, splineFile, detector, wavelength)
+                          pixel1, pixel2, splineFile, detector, wavelength, orientation)
 
         # mask, maskfile, darkcurrent and flatfield are properties pointing to
         # self.detector now (16/06/2017)

--- a/src/pyFAI/detectors/_adsc.py
+++ b/src/pyFAI/detectors/_adsc.py
@@ -37,11 +37,10 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 
-from collections import OrderedDict
-from ._common import Detector
+from ._common import Detector, Orientation
 
 import logging
 logger = logging.getLogger(__name__)
@@ -63,7 +62,7 @@ class _ADSC(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class ADSC_Q315(_ADSC):

--- a/src/pyFAI/detectors/_adsc.py
+++ b/src/pyFAI/detectors/_adsc.py
@@ -33,11 +33,11 @@ The website is no longer available, but can be found throung the
 `web archive <https://web.archive.org/web/20150403133907/http://www.adsc-xray.com/>`_.
 """
 
-__author__ = "Jerome Kieffer"
+__author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "07/09/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 from collections import OrderedDict
@@ -53,16 +53,17 @@ class _ADSC(Detector):
     """
     MANUFACTURER = "ADSC"
 
-    def __init__(self, pixel1=51e-6, pixel2=51e-6, max_shape=None):
-        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=51e-6, pixel2=51e-6, max_shape=None, orientation=0):
+        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def get_config(self):
         """Return the configuration with arguments to the constructor
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class ADSC_Q315(_ADSC):
@@ -78,8 +79,8 @@ class ADSC_Q315(_ADSC):
     MAX_SHAPE = (6144, 6144)
     aliases = ["Quantum 315"]
 
-    def __init__(self, pixel1=51e-6, pixel2=51e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=51e-6, pixel2=51e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class ADSC_Q210(_ADSC):
@@ -95,8 +96,8 @@ class ADSC_Q210(_ADSC):
     MAX_SHAPE = (4096, 4096)
     aliases = ["Quantum 210"]
 
-    def __init__(self, pixel1=51e-6, pixel2=51e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=51e-6, pixel2=51e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class ADSC_Q270(_ADSC):
@@ -112,8 +113,8 @@ class ADSC_Q270(_ADSC):
     MAX_SHAPE = (4168, 4168)
     aliases = ["Quantum 270"]
 
-    def __init__(self, pixel1=64.8e-6, pixel2=64.8e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=64.8e-6, pixel2=64.8e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class ADSC_Q4(_ADSC):
@@ -129,8 +130,8 @@ class ADSC_Q4(_ADSC):
     MAX_SHAPE = (2304, 2304)
     aliases = ["Quantum 4"]
 
-    def __init__(self, pixel1=82e-6, pixel2=82e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=82e-6, pixel2=82e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class HF_130K(_ADSC):
@@ -145,8 +146,8 @@ class HF_130K(_ADSC):
     MAX_SHAPE = (256, 512)
     aliases = ["HF-130k"]
 
-    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class HF_262k(_ADSC):
@@ -162,8 +163,8 @@ class HF_262k(_ADSC):
     MAX_SHAPE = (512, 512)
     aliases = ["HF-262k"]
 
-    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class HF_1M(_ADSC):
@@ -179,8 +180,8 @@ class HF_1M(_ADSC):
     MAX_SHAPE = (1024, 1024)
     aliases = ["HF-1M"]
 
-    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class HF_2M(_ADSC):
@@ -196,8 +197,8 @@ class HF_2M(_ADSC):
     MAX_SHAPE = (1536, 1536)
     aliases = ["HF-2.4M"]
 
-    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class HF_4M(_ADSC):
@@ -211,8 +212,8 @@ class HF_4M(_ADSC):
     MAX_SHAPE = (2048, 2048)
     aliases = ["HF-4M"]
 
-    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class HF_9M(_ADSC):
@@ -227,5 +228,5 @@ class HF_9M(_ADSC):
     MAX_SHAPE = (3072, 3072)
     aliases = ["HF-9.4M"]
 
-    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None):
-        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None, orientation=0):
+        _ADSC.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "stable"
 
 import logging
@@ -358,7 +358,7 @@ class Detector(metaclass=DetectorMeta):
         dico = {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
                 'max_shape': self.max_shape,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
         if self._splineFile:
             dico["splineFile"] = self._splineFile
         return dico
@@ -1210,6 +1210,8 @@ class NexusDetector(Detector):
                 self.uniform_pixel = True
             if "orientation" in det_grp:
                 self.orientation = Orientation(det_grp["orientation"][()])
+            else:
+                self.orientation = Orientation(3)
         # Populate shape and max_shape if needed
         if self.max_shape is None:
             if self.shape is None:
@@ -1310,7 +1312,7 @@ class NexusDetector(Detector):
         return {"detector": self._filename or self.name,
                 "pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation
+                "orientation": self.orientation or 3
                 }
 
     def getFit2D(self):

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -117,7 +117,7 @@ class Detector(metaclass=DetectorMeta):
     _UNMUTABLE_ATTRS = ('_pixel1', '_pixel2', 'max_shape', 'shape', '_binning',
                         '_mask_crc', '_maskfile', "_splineFile", "_flatfield_crc",
                         "_darkcurrent_crc", "flatfiles", "darkfiles", "_dummy", "_delta_dummy",
-                        "orientation")
+                        "_orientation")
     _MUTABLE_ATTRS = ('_mask', '_flatfield', "_darkcurrent", "_pixel_corners")
 
 

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -256,7 +256,7 @@ class Detector(metaclass=DetectorMeta):
         else:
             txt += "\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation:
-            txt += "\t {self.orientation.name} (self.orientation.value)"
+            txt += "\t {self.orientation.name} ({self.orientation.value})"
         return txt
 
     def __copy__(self):

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -256,7 +256,7 @@ class Detector(metaclass=DetectorMeta):
         else:
             txt += "\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation:
-            txt += "\t {self.orientation.name}"
+            txt += "\t {self.orientation.name} (self.orientation.value)"
         return txt
 
     def __copy__(self):

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "stable"
 
 import logging
@@ -240,7 +240,7 @@ class Detector(metaclass=DetectorMeta):
         if splineFile:
             self.set_splineFile(splineFile)
 
-        orientation = Orientation(orientation or self.ORIENTATION)
+        orientation = Orientation(orientation or self.ORIENTATION or 3)
         if orientation<0 or orientation>4:
             raise RuntimeError("Unsuported orientation: "+orientation.__doc__)
         self.orientation = orientation

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -504,8 +504,8 @@ class Detector(metaclass=DetectorMeta):
                 "pixel1": self._pixel1,
                 "pixel2": self._pixel2,
                 'max_shape': self.max_shape}
-        if self.orientation:
-            dico['orientation'] = self.orientation
+        # if self.orientation:
+        #     dico['orientation'] = self.orientation
         if self._splineFile:
             dico["splineFile"] = self._splineFile
         return dico

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -731,7 +731,6 @@ class Detector(metaclass=DetectorMeta):
             with self._sem:
                 if self._pixel_corners is None:
                     r1, r2 = self._calc_pixel_index_from_orientation(True)
-
                     # like numpy.ogrid
                     d1 = expand2d(r1, self.shape[1] + 1, False)
                     d2 = expand2d(r2, self.shape[0] + 1, True)

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -567,7 +567,7 @@ class Detector(metaclass=DetectorMeta):
                 self.set_splineFile(kwarg[kw])
 
     def _calc_pixel_index_from_orientation(self, plus_one=False):
-        """Calculate the pixel index when considereing the different orientations"""
+        """Calculate the pixel index when considering the different orientations"""
         if plus_one: # used with corners
             m1 = self.shape[0] + 1
             m2 = self.shape[1] + 1

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -243,7 +243,7 @@ class Detector(metaclass=DetectorMeta):
         orientation = Orientation(orientation or self.ORIENTATION or 3)
         if orientation<0 or orientation>4:
             raise RuntimeError("Unsuported orientation: "+orientation.__doc__)
-        self.orientation = orientation
+        self._orientation = orientation
 
     def __repr__(self):
         """Nice representation of the instance
@@ -344,7 +344,7 @@ class Detector(metaclass=DetectorMeta):
                 self.set_splineFile(config.get("splineFile"))
             if "max_shape" in config:
                 self.max_shape = config.get("max_shape")
-        self.orientation = Orientation(config.get("orientation", 0))
+        self._orientation = Orientation(config.get("orientation", 0))
         return self
 
     def get_config(self):
@@ -1169,6 +1169,9 @@ class Detector(metaclass=DetectorMeta):
     def delta_dummy(self, value=None):
         self._delta_dummy = value
 
+    @property
+    def orientation(self):
+        return self._orientation
 
 class NexusDetector(Detector):
     """
@@ -1247,9 +1250,9 @@ class NexusDetector(Detector):
             else:
                 self.uniform_pixel = True
             if "orientation" in det_grp:
-                self.orientation = Orientation(det_grp["orientation"][()])
+                self._orientation = Orientation(det_grp["orientation"][()])
             else:
-                self.orientation = Orientation(3)
+                self._orientation = Orientation(3)
         # Populate shape and max_shape if needed
         if self.max_shape is None:
             if self.shape is None:

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -242,7 +242,7 @@ class Detector(metaclass=DetectorMeta):
 
         orientation = Orientation(orientation or self.ORIENTATION or 3)
         if orientation<0 or orientation>4:
-            raise RuntimeError("Unsuported orientation: "+orientation.__doc__)
+            raise RuntimeError("Unsupported orientation: "+orientation.__doc__)
         self._orientation = orientation
 
     def __repr__(self):

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -29,13 +29,12 @@
 
 """Description of all detectors with a factory to instantiate them"""
 
-from __future__ import annotations
 
 __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "29/06/2023"
+__date__ = "21/11/2023"
 __status__ = "stable"
 
 import logging
@@ -47,6 +46,7 @@ from collections import OrderedDict
 import json
 from typing import Dict, Any, Union
 
+from .orientation import Orientation
 from .. import io
 from .. import spline
 from .. import utils
@@ -113,13 +113,16 @@ class Detector(metaclass=DetectorMeta):
     """If true a spline file is mandatory to correct the geometry"""
     DUMMY = None
     DELTA_DUMMY = None
+    ORIENTATION = 0
     _UNMUTABLE_ATTRS = ('_pixel1', '_pixel2', 'max_shape', 'shape', '_binning',
                         '_mask_crc', '_maskfile', "_splineFile", "_flatfield_crc",
-                        "_darkcurrent_crc", "flatfiles", "darkfiles", "_dummy", "_delta_dummy")
+                        "_darkcurrent_crc", "flatfiles", "darkfiles", "_dummy", "_delta_dummy",
+                        "orientation")
     _MUTABLE_ATTRS = ('_mask', '_flatfield', "_darkcurrent", "_pixel_corners")
 
+
     @classmethod
-    def factory(cls, name: str, config: Union[None, str, Dict[str, Any]]=None) -> Detector:
+    def factory(cls, name: str, config: Union[None, str, Dict[str, Any]]=None):
         """
         Create a pyFAI detector from a name.
 
@@ -193,7 +196,7 @@ class Detector(metaclass=DetectorMeta):
 
         return detector
 
-    def __init__(self, pixel1=None, pixel2=None, splineFile=None, max_shape=None):
+    def __init__(self, pixel1=None, pixel2=None, splineFile=None, max_shape=None, orientation=0):
         """
         :param pixel1: size of the pixel in meter along the slow dimension (often Y)
         :type pixel1: float
@@ -203,6 +206,7 @@ class Detector(metaclass=DetectorMeta):
         :type splineFile: str
         :param max_shape: maximum size of the detector
         :type max_shape: 2-tuple of integrers
+        :param orientation: Orientation of the detector
         """
         self._pixel1 = None
         self._pixel2 = None
@@ -236,13 +240,24 @@ class Detector(metaclass=DetectorMeta):
         if splineFile:
             self.set_splineFile(splineFile)
 
+        orientation = Orientation(orientation or self.ORIENTATION)
+        if orientation<0 or orientation>4:
+            raise RuntimeError("Unsuported orientation: "+orientation.__doc__)
+        self.orientation = orientation
+
     def __repr__(self):
         """Nice representation of the instance
         """
+        txt = f"Detector {self.name}"
+        if self.splineFile:
+            txt += "\t Spline= {self.splineFile}"
         if (self._pixel1 is None) or (self._pixel2 is None):
             return "Undefined detector"
-        return "Detector %s\t Spline= %s\t PixelSize= %.3e, %.3e m" % \
-            (self.name, self.splineFile, self._pixel1, self._pixel2)
+        else:
+            txt += "\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
+        if self.orientation:
+            txt += "\t {self.orientation.name}"
+        return txt
 
     def __copy__(self):
         """
@@ -295,7 +310,7 @@ class Detector(metaclass=DetectorMeta):
         if other is None:
             return False
         res = True
-        for what in ["pixel1", "pixel2", "binning", "shape", "max_shape"]:
+        for what in ["pixel1", "pixel2", "binning", "shape", "max_shape", "orientation"]:
             res &= getattr(self, what) == getattr(other, what)
         return res
 
@@ -329,6 +344,7 @@ class Detector(metaclass=DetectorMeta):
                 self.set_splineFile(config.get("splineFile"))
             if "max_shape" in config:
                 self.max_shape = config.get("max_shape")
+        self.orientation = Orientation(config.get("orientation", 0))
         return self
 
     def get_config(self):
@@ -339,9 +355,10 @@ class Detector(metaclass=DetectorMeta):
 
         :return: dict with param for serialization
         """
-        dico = OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2),
-                            ('max_shape', self.max_shape)))
+        dico = {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                'max_shape': self.max_shape,
+                "orientation": self.orientation}
         if self._splineFile:
             dico["splineFile"] = self._splineFile
         return dico
@@ -483,13 +500,14 @@ class Detector(metaclass=DetectorMeta):
         :return: representation of the detector easy to serialize
         :rtype: dict
         """
-        dico = OrderedDict((("detector", self.name),
-                            ("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2),
-                            ('max_shape', self.max_shape)))
+        dico = {"detector": self.name,
+                "pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                'max_shape': self.max_shape}
+        if self.orientation:
+            dico['orientation'] = self.orientation
         if self._splineFile:
             dico["splineFile"] = self._splineFile
-
         return dico
 
     def getFit2D(self):
@@ -513,7 +531,7 @@ class Detector(metaclass=DetectorMeta):
         if "detector" in kwarg:
             import pyFAI.detectors
             config = {}
-            for key in ("pixel1", "pixel2", 'max_shape', "splineFile"):
+            for key in ("pixel1", "pixel2", 'max_shape', "splineFile", "orientation"):
                 if key in kwarg:
                     config[key] = kwarg[key]
             self = pyFAI.detectors.detector_factory(kwarg["detector"], config)
@@ -776,6 +794,10 @@ class Detector(metaclass=DetectorMeta):
                 det_grp["shape"] = numpy.array(self.shape, dtype=numpy.int32)
             if self.binning is not None:
                 det_grp["binning"] = numpy.array(self._binning, dtype=numpy.int32)
+            if self.orientation:
+                det_grp["orientation"] = numpy.array(self.orientation.value, dtype=numpy.int32)
+                det_grp["orientation"].attrs["value"] = self.orientation.name
+                det_grp["orientation"].attrs["doc"] = self.orientation.__doc__
             if self.flatfield is not None:
                 dset = det_grp.create_dataset("flatfield", data=self.flatfield,
                                               compression="gzip", compression_opts=9, shuffle=True)
@@ -1186,6 +1208,8 @@ class NexusDetector(Detector):
                     self.mask = numpy.logical_or(previous_mask, new_mask).astype(numpy.int8)
             else:
                 self.uniform_pixel = True
+            if "orientation" in det_grp:
+                self.orientation = Orientation(det_grp["orientation"][()])
         # Populate shape and max_shape if needed
         if self.max_shape is None:
             if self.shape is None:
@@ -1285,7 +1309,8 @@ class NexusDetector(Detector):
         """
         return {"detector": self._filename or self.name,
                 "pixel1": self._pixel1,
-                "pixel2": self._pixel2
+                "pixel2": self._pixel2,
+                "orientation": self.orientation
                 }
 
     def getFit2D(self):

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -30,11 +30,11 @@
 Description of the `Dectris <https://www.dectris.com/>`_ detectors.
 """
 
-__author__ = "Jerome Kieffer"
+__author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "production"
 
 import os
@@ -64,7 +64,7 @@ class _Dectris(Detector):
     force_pixel = True
     DUMMY = -2
     DELTA_DUMMY = 1.5
-    ORIENTATION = 2 # Personal communication from Dectris: origin top-left looking from the sample to the detector, thus flip-rl
+    ORIENTATION = 3#2 # Personal communication from Dectris: origin top-left looking from the sample to the detector, thus flip-rl
 
     def calc_mask(self):
         """

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -133,10 +133,23 @@ class Eiger(_Dectris):
                 r1, r2 = self._calc_pixel_index_from_orientation(False)
                 d1 = expand2d(r1, self.shape[1], False)
                 d2 = expand2d(r2, self.shape[0], True)
+            else:
+                if self.orientation in (0,3):
+                    pass
+                elif self.orientation==1:
+                    d1 = self.shape[0] - 1 - d1
+                    d2 = self.shape[1] - 1 - d2
+                elif self.orientation==2:
+                    d1 = self.shape[0] - 1 - d1
+                elif self.orientation == 4:
+                    d2 = self.shape[1] - 1 - d2
+                else:
+                    raise RuntimeError(f"Unsuported orientation: {self.orientation.name} ({self.orientation.value})")
 
         if self.offset1 is None or self.offset2 is None:
             delta1 = delta2 = 0.
         else:
+            #TODO: this does not take into account the orientation of the detector !
             if d2.ndim == 1:
                 d1n = d1.astype(numpy.int32)
                 d2n = d2.astype(numpy.int32)
@@ -520,10 +533,23 @@ class Pilatus(_Dectris):
         d1 and d2 must have the same shape, returned array will have
         the same shape.
         """
-        if self.shape and ((d1 is None) or (d2 is None)):
-            r1, r2 = self._calc_pixel_index_from_orientation(False)
-            d1 = expand2d(r1, self.shape[1], False)
-            d2 = expand2d(r2, self.shape[0], True)
+        if self.shape:
+            if ((d1 is None) or (d2 is None)):
+                r1, r2 = self._calc_pixel_index_from_orientation(False)
+                d1 = expand2d(r1, self.shape[1], False)
+                d2 = expand2d(r2, self.shape[0], True)
+            else:
+                if self.orientation in (0,3):
+                    pass
+                elif self.orientation==1:
+                    d1 = self.shape[0] - 1 - d1
+                    d2 = self.shape[1] - 1 - d2
+                elif self.orientation==2:
+                    d1 = self.shape[0] - 1 - d1
+                elif self.orientation == 4:
+                    d2 = self.shape[1] - 1 - d2
+                else:
+                    raise RuntimeError(f"Unsuported orientation: {self.orientation.name} ({self.orientation.value})")
 
         if (self.offset1 is None) or (self.offset2 is None):
             delta1 = delta2 = 0.

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -459,7 +459,7 @@ class Pilatus(_Dectris):
 
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
-        if self.orientation>1:
+        if self.orientation > 0:
             txt += f"\t {self.orientation.name} ({self.orientation.value})"
         if self.x_offset_file:
             txt += f"\t delta_x= {self.x_offset_file}"

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -226,7 +226,7 @@ class Eiger(_Dectris):
         module_size = config.get("module_size")
         if module_size is not None:
             self.module_size = tuple(module_size)
-        self.orientation = Orientation(config.get("orientation", 3))
+        self._orientation = Orientation(config.get("orientation", 3))
         return self
 
 
@@ -630,7 +630,7 @@ class Pilatus(_Dectris):
                 raise err
 
         # pixel size is enforced by the detector itself
-        self.orientation = Orientation(config.get("orientation", 0))
+        self._orientation = Orientation(config.get("orientation", 0))
         if "max_shape" in config:
             self.max_shape = tuple(config["max_shape"])
         module_size = config.get("module_size")

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -108,7 +108,7 @@ class Eiger(_Dectris):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation:
-            txt += f"\t {self.orientation.name} (self.orientation.value)"
+            txt += f"\t {self.orientation.name} ({self.orientation.value})"
         return txt
 
     def calc_cartesian_positions(self, d1=None, d2=None, center=True, use_cython=True):
@@ -445,7 +445,7 @@ class Pilatus(_Dectris):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation>1:
-            txt += f"\t {self.orientation.name} (self.orientation.value)"
+            txt += f"\t {self.orientation.name} ({self.orientation.value})"
         if self.x_offset_file:
             txt += f"\t delta_x= {self.x_offset_file}"
         if self.y_offset_file:
@@ -758,7 +758,7 @@ class Pilatus4(_Dectris):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation>1:
-            txt += f"\t {self.orientation.name} (self.orientation.value)"
+            txt += f"\t {self.orientation.name} ({self.orientation.value})"
 
 
 class Pilatus4_1M(Pilatus4):

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -64,7 +64,7 @@ class _Dectris(Detector):
     force_pixel = True
     DUMMY = -2
     DELTA_DUMMY = 1.5
-    ORIENTATION = 3#2 # Personal communication from Dectris: origin top-left looking from the sample to the detector, thus flip-rl
+    ORIENTATION = 2 # Personal communication from Dectris: origin top-left looking from the sample to the detector, thus flip-rl
 
     def calc_mask(self):
         """
@@ -130,7 +130,7 @@ class Eiger(_Dectris):
         """
         if self.shape:
             if (d1 is None) or (d2 is None):
-                r1, r2 = self._calc_pixel_index_from_orientation(True)
+                r1, r2 = self._calc_pixel_index_from_orientation(False)
                 d1 = expand2d(r1, self.shape[1], False)
                 d2 = expand2d(r2, self.shape[0], True)
 
@@ -521,7 +521,7 @@ class Pilatus(_Dectris):
         the same shape.
         """
         if self.shape and ((d1 is None) or (d2 is None)):
-            r1, r2 = self._calc_pixel_index_from_orientation(True)
+            r1, r2 = self._calc_pixel_index_from_orientation(False)
             d1 = expand2d(r1, self.shape[1], False)
             d2 = expand2d(r2, self.shape[0], True)
 

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -108,7 +108,7 @@ class Eiger(_Dectris):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation:
-            txt += f"\t {self.orientation.name}"
+            txt += f"\t {self.orientation.name} (self.orientation.value)"
         return txt
 
     def calc_cartesian_positions(self, d1=None, d2=None, center=True, use_cython=True):
@@ -445,7 +445,7 @@ class Pilatus(_Dectris):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation>1:
-            txt += f"\t {self.orientation.name}"
+            txt += f"\t {self.orientation.name} (self.orientation.value)"
         if self.x_offset_file:
             txt += f"\t delta_x= {self.x_offset_file}"
         if self.y_offset_file:
@@ -758,7 +758,7 @@ class Pilatus4(_Dectris):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation>1:
-            txt += f"\t {self.orientation.name}"
+            txt += f"\t {self.orientation.name} (self.orientation.value)"
 
 
 class Pilatus4_1M(Pilatus4):

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -64,7 +64,7 @@ class _Dectris(Detector):
     force_pixel = True
     DUMMY = -2
     DELTA_DUMMY = 1.5
-    ORIENTATION = 2 # Personal communication from Dectris: origin top-left looking from the sample to the detector, thus flip-rl
+    ORIENTATION = 3 # should be 2, Personal communication from Dectris: origin top-left looking from the sample to the detector, thus flip-rl
 
     def calc_mask(self):
         """

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 
 import os
@@ -180,7 +180,7 @@ class Eiger(_Dectris):
 
         :return: dict with param for serialization
         """
-        dico = {}
+        dico = {"orientation": self.orientation}
         if ((self.max_shape is not None) and
                 ("MAX_SHAPE" in dir(self.__class__)) and
                 (tuple(self.max_shape) != tuple(self.__class__.MAX_SHAPE))):
@@ -212,6 +212,7 @@ class Eiger(_Dectris):
         module_size = config.get("module_size")
         if module_size is not None:
             self.module_size = tuple(module_size)
+        self.orientation = Orientation(config.get("orientation", 3))
         return self
 
 
@@ -415,7 +416,7 @@ class Mythen(_Dectris):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
     def calc_mask(self):
         "Mythen have no masks"
@@ -570,7 +571,7 @@ class Pilatus(_Dectris):
 
         :return: dict with param for serialization
         """
-        dico = {"orientation": self.orientation}
+        dico = {"orientation": self.orientation or 3}
         if ((self.max_shape is not None) and
                 ("MAX_SHAPE" in dir(self.__class__)) and
                 (tuple(self.max_shape) != tuple(self.__class__.MAX_SHAPE))):

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -136,10 +136,10 @@ class Eiger(_Dectris):
             else:
                 if self.orientation in (0,3):
                     pass
-                elif self.orientation==1:
+                elif self.orientation == 1:
                     d1 = self.shape[0] - 1 - d1
                     d2 = self.shape[1] - 1 - d2
-                elif self.orientation==2:
+                elif self.orientation == 2:
                     d1 = self.shape[0] - 1 - d1
                 elif self.orientation == 4:
                     d2 = self.shape[1] - 1 - d2
@@ -786,7 +786,7 @@ class Pilatus4(_Dectris):
 
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
-        if self.orientation>1:
+        if self.orientation:
             txt += f"\t {self.orientation.name} ({self.orientation.value})"
 
 

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -4,7 +4,7 @@
 #    Project: Fast Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2017-2018 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2017-2023 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -64,7 +64,7 @@ class _Dectris(Detector):
     force_pixel = True
     DUMMY = -2
     DELTA_DUMMY = 1.5
-    ORIENTATION = 1
+    ORIENTATION = 2 # Personal communication from Dectris: origin top-left looking from the sample to the detector, thus flip-rl
 
     def calc_mask(self):
         """
@@ -107,7 +107,7 @@ class Eiger(_Dectris):
 
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
-        if self.orientation>1:
+        if self.orientation:
             txt += f"\t {self.orientation.name}"
         return txt
 

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "29/09/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 import os
@@ -42,7 +42,7 @@ import numpy
 import logging
 import json
 from collections import OrderedDict
-from ._common import Detector
+from ._common import Detector, Orientation
 from ..utils import expand2d
 logger = logging.getLogger(__name__)
 
@@ -64,6 +64,7 @@ class _Dectris(Detector):
     force_pixel = True
     DUMMY = -2
     DELTA_DUMMY = 1.5
+    ORIENTATION = 1
 
     def calc_mask(self):
         """
@@ -96,8 +97,8 @@ class Eiger(_Dectris):
     MODULE_GAP = (37, 10)
     force_pixel = True
 
-    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None):
-        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None, orientation=0):
+        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (module_size is None) and ("MODULE_SIZE" in dir(self.__class__)):
             self.module_size = tuple(self.MODULE_SIZE)
         else:
@@ -105,7 +106,10 @@ class Eiger(_Dectris):
         self.offset1 = self.offset2 = None
 
     def __repr__(self):
-        return f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
+        txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
+        if self.orientation>1:
+            txt += f"\t {self.orientation.name}"
+        return txt
 
     def calc_cartesian_positions(self, d1=None, d2=None, center=True, use_cython=True):
         """
@@ -401,16 +405,17 @@ class Mythen(_Dectris):
     force_pixel = True
     MAX_SHAPE = (1, 1280)
 
-    def __init__(self, pixel1=8e-3, pixel2=50e-6):
-        super(Mythen, self).__init__(pixel1=pixel1, pixel2=pixel2)
+    def __init__(self, pixel1=8e-3, pixel2=50e-6, orientation=0):
+        super(Mythen, self).__init__(pixel1=pixel1, pixel2=pixel2, orientation=orientation)
 
     def get_config(self):
         """Return the configuration with arguments to the constructor
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
     def calc_mask(self):
         "Mythen have no masks"
@@ -427,9 +432,10 @@ class Pilatus(_Dectris):
     MODULE_GAP = (17, 7)
     force_pixel = True
 
+
     def __init__(self, pixel1=172e-6, pixel2=172e-6, max_shape=None, module_size=None,
-                 x_offset_file=None, y_offset_file=None):
-        super(Pilatus, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+                 x_offset_file=None, y_offset_file=None, orientation=0):
+        super(Pilatus, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (module_size is None) and ("MODULE_SIZE" in dir(self.__class__)):
             self.module_size = tuple(self.MODULE_SIZE)
         else:
@@ -438,6 +444,8 @@ class Pilatus(_Dectris):
 
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
+        if self.orientation>1:
+            txt += f"\t {self.orientation.name}"
         if self.x_offset_file:
             txt += f"\t delta_x= {self.x_offset_file}"
         if self.y_offset_file:
@@ -562,7 +570,7 @@ class Pilatus(_Dectris):
 
         :return: dict with param for serialization
         """
-        dico = OrderedDict()
+        dico = {"orientation": self.orientation}
         if ((self.max_shape is not None) and
                 ("MAX_SHAPE" in dir(self.__class__)) and
                 (tuple(self.max_shape) != tuple(self.__class__.MAX_SHAPE))):
@@ -593,6 +601,7 @@ class Pilatus(_Dectris):
                 raise err
 
         # pixel size is enforced by the detector itself
+        self.orientation = Orientation(config.get("orientation", 0))
         if "max_shape" in config:
             self.max_shape = tuple(config["max_shape"])
         module_size = config.get("module_size")
@@ -742,12 +751,14 @@ class Pilatus4(_Dectris):
     MODULE_GAP = (20, 7)
     force_pixel = True
 
-    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None):
-        super(Pilatus4, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=150e-6, pixel2=150e-6, max_shape=None, orientation=0):
+        super(Pilatus4, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         self.module_size = tuple(self.MODULE_SIZE)
 
     def __repr__(self):
-        return f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
+        txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
+        if self.orientation>1:
+            txt += f"\t {self.orientation.name}"
 
 
 class Pilatus4_1M(Pilatus4):

--- a/src/pyFAI/detectors/_dectris.py
+++ b/src/pyFAI/detectors/_dectris.py
@@ -130,8 +130,9 @@ class Eiger(_Dectris):
         """
         if self.shape:
             if (d1 is None) or (d2 is None):
-                d1 = expand2d(numpy.arange(self.shape[0]).astype(numpy.float32), self.shape[1], False)
-                d2 = expand2d(numpy.arange(self.shape[1]).astype(numpy.float32), self.shape[0], True)
+                r1, r2 = self._calc_pixel_index_from_orientation(True)
+                d1 = expand2d(r1, self.shape[1], False)
+                d2 = expand2d(r2, self.shape[0], True)
 
         if self.offset1 is None or self.offset2 is None:
             delta1 = delta2 = 0.
@@ -520,8 +521,9 @@ class Pilatus(_Dectris):
         the same shape.
         """
         if self.shape and ((d1 is None) or (d2 is None)):
-            d1 = expand2d(numpy.arange(self.shape[0]).astype(numpy.float32), self.shape[1], False)
-            d2 = expand2d(numpy.arange(self.shape[1]).astype(numpy.float32), self.shape[0], True)
+            r1, r2 = self._calc_pixel_index_from_orientation(True)
+            d1 = expand2d(r1, self.shape[1], False)
+            d2 = expand2d(r2, self.shape[0], True)
 
         if (self.offset1 is None) or (self.offset2 is None):
             delta1 = delta2 = 0.

--- a/src/pyFAI/detectors/_esrf.py
+++ b/src/pyFAI/detectors/_esrf.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 
 
@@ -100,7 +100,7 @@ class FReLoN(Detector):
         :return: dict with param for serialization
         """
         return {"splineFile": self._splineFile,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class Maxipix(Detector):
@@ -152,7 +152,7 @@ class Maxipix(Detector):
 
         :return: dict with param for serialization
         """
-        dico = {"orientation": self.orientation}
+        dico = {"orientation": self.orientation or 3}
         if ((self.max_shape is not None) and
                 ("MAX_SHAPE" in dir(self.__class__)) and
                 (tuple(self.max_shape) != tuple(self.__class__.MAX_SHAPE))):
@@ -184,7 +184,7 @@ class Maxipix(Detector):
         module_size = config.get("module_size")
         if module_size is not None:
             self.module_size = tuple(module_size)
-        self.orientation = Orientation(config.get("orientation",0))
+        self.orientation = Orientation(config.get("orientation", 3))
         return self
 
 

--- a/src/pyFAI/detectors/_esrf.py
+++ b/src/pyFAI/detectors/_esrf.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "production"
 
 
@@ -184,7 +184,7 @@ class Maxipix(Detector):
         module_size = config.get("module_size")
         if module_size is not None:
             self.module_size = tuple(module_size)
-        self.orientation = Orientation(config.get("orientation", 3))
+        self._orientation = Orientation(config.get("orientation", 3))
         return self
 
 

--- a/src/pyFAI/detectors/_esrf.py
+++ b/src/pyFAI/detectors/_esrf.py
@@ -4,7 +4,7 @@
 #    Project: Fast Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2017-2018 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2017-2023 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -30,18 +30,18 @@
 Detectors manufactured by ESRF
 """
 
-__author__ = "Jerome Kieffer"
+__author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "18/06/2020"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 
 import numpy
 import logging
 import json
-from ._common import Detector
+from ._common import Detector, Orientation
 logger = logging.getLogger(__name__)
 
 try:
@@ -64,8 +64,8 @@ class FReLoN(Detector):
 
     HAVE_TAPER = True
 
-    def __init__(self, splineFile=None):
-        super(FReLoN, self).__init__(splineFile=splineFile)
+    def __init__(self, splineFile=None, orientation=0):
+        super(FReLoN, self).__init__(splineFile=splineFile, orientation=orientation)
         if splineFile:
             self.max_shape = (int(self.spline.ymax - self.spline.ymin),
                               int(self.spline.xmax - self.spline.xmin))
@@ -99,7 +99,8 @@ class FReLoN(Detector):
 
         :return: dict with param for serialization
         """
-        return {"splineFile": self._splineFile}
+        return {"splineFile": self._splineFile,
+                "orientation": self.orientation}
 
 
 class Maxipix(Detector):
@@ -116,8 +117,8 @@ class Maxipix(Detector):
     force_pixel = True
     aliases = ["Maxipix 1x1", "Maxipix1x1"]
 
-    def __init__(self, pixel1=55e-6, pixel2=55e-6, max_shape=None, module_size=None):
-        super(Maxipix, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=55e-6, pixel2=55e-6, max_shape=None, module_size=None, orientation=0):
+        super(Maxipix, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (module_size is None) and ("MODULE_SIZE" in dir(self.__class__)):
             self.module_size = tuple(self.MODULE_SIZE)
         else:
@@ -151,7 +152,7 @@ class Maxipix(Detector):
 
         :return: dict with param for serialization
         """
-        dico = {}
+        dico = {"orientation": self.orientation}
         if ((self.max_shape is not None) and
                 ("MAX_SHAPE" in dir(self.__class__)) and
                 (tuple(self.max_shape) != tuple(self.__class__.MAX_SHAPE))):
@@ -183,6 +184,7 @@ class Maxipix(Detector):
         module_size = config.get("module_size")
         if module_size is not None:
             self.module_size = tuple(module_size)
+        self.orientation = Orientation(config.get("orientation",0))
         return self
 
 

--- a/src/pyFAI/detectors/_hexagonal.py
+++ b/src/pyFAI/detectors/_hexagonal.py
@@ -3,7 +3,7 @@
 #    Project: Fast Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2022-2022 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2022-2023 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -33,14 +33,14 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "29/08/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 
 import numpy
 import logging
 from math import sqrt
-from ._common import Detector
+from ._common import Detector, Orientation
 logger = logging.getLogger(__name__)
 
 
@@ -85,14 +85,14 @@ class HexDetector(Detector):
         ary *= pitch
         return ary
 
-    def __init__(self, pitch=None, pixel1=None, pixel2=None, max_shape=None):
+    def __init__(self, pitch=None, pixel1=None, pixel2=None, max_shape=None, orientation=0):
         if pitch:
             pitch = float(pitch)
             h = 0.5*pitch*sqrt(3.0)
         else: #fallback on standard signature
             pitch = pixel2
             h = pixel1
-        Detector.__init__(self, pixel1=h, pixel2=pitch, max_shape=max_shape)
+        Detector.__init__(self, pixel1=h, pixel2=pitch, max_shape=max_shape, orientation=orientation)
         self.set_pixel_corners(self.build_pixel_coordinates(self.max_shape, self.pitch))
 
     @property
@@ -108,29 +108,33 @@ class Pixirad1(HexDetector):
     MAX_SHAPE = (476, 512)  # max size of the detector
     MANUFACTURER = "Pixirad"
     aliases = ["Pixirad-1"]
-    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None):
-        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None, orientation=0):
+        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2,
+                             max_shape=max_shape, orientation=orientation)
 
 
 class Pixirad2(HexDetector):
     MAX_SHAPE = (476, 1024)  # max size of the detector
     MANUFACTURER = "Pixirad"
     aliases = ["Pixirad-2"]
-    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None):
-        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None, orientation=0):
+        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2,
+                             max_shape=max_shape, orientation=orientation)
 
 
 class Pixirad4(HexDetector):
     MAX_SHAPE = (476, 2048)  # max size of the detector
     MANUFACTURER = "Pixirad"
     aliases = ["Pixirad-4"]
-    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None):
-        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None, orientation=0):
+        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2,
+                             max_shape=max_shape, orientation=orientation)
 
 
 class Pixirad8(HexDetector):
     MAX_SHAPE = (476, 4096)  # max size of the detector
     MANUFACTURER = "Pixirad"
     aliases = ["Pixirad-8"]
-    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None):
-        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pitch=60e-6, pixel1=None, pixel2=None, max_shape=None, orientation=0):
+        HexDetector.__init__(self, pitch=pitch, pixel1=pixel1, pixel2=pixel2,
+                             max_shape=max_shape, orientation=orientation)

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 
 import functools
@@ -226,7 +226,7 @@ class ImXPadS10(Detector):
 
         :return: dict with param for serialization
         """
-        dico = {}
+        dico = {"orientation": self.orientation or 3}
         if ((self.max_shape is not None) and
                 ("MAX_SHAPE" in dir(self.__class__)) and
                 (tuple(self.max_shape) != tuple(self.__class__.MAX_SHAPE))):
@@ -258,6 +258,7 @@ class ImXPadS10(Detector):
         module_size = config.get("module_size")
         if module_size is not None:
             self.module_size = tuple(module_size)
+        self.orientation = Orientation(config.get("orientation", 3))
         return self
 
 

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -329,7 +329,7 @@ class Xpad_flat(ImXPadS10):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self.pixel1:.3e}, {self.pixel2:.3e} m"
         if self.orientation:
-            txt += f"\t {self.orientation.name} (self.orientation.value)({self.orientation.value})"
+            txt += f"\t {self.orientation.name} ({self.orientation.value})({self.orientation.value})"
         return txt
 
     def calc_pixels_edges(self):

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -258,7 +258,7 @@ class ImXPadS10(Detector):
         module_size = config.get("module_size")
         if module_size is not None:
             self.module_size = tuple(module_size)
-        self.orientation = Orientation(config.get("orientation", 3))
+        self._orientation = Orientation(config.get("orientation", 3))
         return self
 
 

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -328,8 +328,8 @@ class Xpad_flat(ImXPadS10):
 
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self.pixel1:.3e}, {self.pixel2:.3e} m"
-        if orientation:
-            txt += f"\t {self.orientation.name}"
+        if self.orientation:
+            txt += f"\t {self.orientation.name} (self.orientation.value)({self.orientation.value})"
         return txt
 
     def calc_pixels_edges(self):

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -389,8 +389,9 @@ class Xpad_flat(ImXPadS10):
         """
         if self.shape:
             if (d1 is None) or (d2 is None):
-                d1 = mathutil.expand2d(numpy.arange(self.shape[0]).astype(numpy.float32), self.shape[1], False)
-                d2 = mathutil.expand2d(numpy.arange(self.shape[1]).astype(numpy.float32), self.shape[0], True)
+                r1, r2 = self._calc_pixel_index_from_orientation(True)
+                d1 = mathutil.expand2d(r1, self.shape[1], False)
+                d2 = mathutil.expand2d(r2, self.shape[0], True)
         corners = self.get_pixel_corners()
         if center:
             # note += would make an increment in place which is bad (segfault !)
@@ -616,8 +617,9 @@ class Cirpad(ImXPadS10):
     # TODO !!!
     def calc_cartesian_positions(self, d1=None, d2=None, center=True, use_cython=True):
         if (d1 is None) or d2 is None:
-            d1 = mathutil.expand2d(numpy.arange(self.MAX_SHAPE[0]).astype(numpy.float32), self.MAX_SHAPE[1], False)
-            d2 = mathutil.expand2d(numpy.arange(self.MAX_SHAPE[1]).astype(numpy.float32), self.MAX_SHAPE[0], True)
+            r1, r2 = self._calc_pixel_index_from_orientation(True)
+            d1 = mathutil.expand2d(r1, self.MAX_SHAPE[1], False)
+            d2 = mathutil.expand2d(r2, self.MAX_SHAPE[0], True)
         corners = self.get_pixel_corners()
         if center:
             # avoid += It modifies in place and segfaults

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -389,7 +389,7 @@ class Xpad_flat(ImXPadS10):
         """
         if self.shape:
             if (d1 is None) or (d2 is None):
-                r1, r2 = self._calc_pixel_index_from_orientation(True)
+                r1, r2 = self._calc_pixel_index_from_orientation(False)
                 d1 = mathutil.expand2d(r1, self.shape[1], False)
                 d2 = mathutil.expand2d(r2, self.shape[0], True)
         corners = self.get_pixel_corners()
@@ -553,7 +553,7 @@ class Cirpad(ImXPadS10):
         return pixel_size * size
 
     def _passage(self, corners, rot):
-        shape = corners.shape
+        # shape = corners.shape
         deltaX, deltaY = 0.0, 0.0
         nmd = self._rotation(corners, rot)
         # Size in mm of the chip in the Y direction (including 10px gap)
@@ -617,7 +617,7 @@ class Cirpad(ImXPadS10):
     # TODO !!!
     def calc_cartesian_positions(self, d1=None, d2=None, center=True, use_cython=True):
         if (d1 is None) or d2 is None:
-            r1, r2 = self._calc_pixel_index_from_orientation(True)
+            r1, r2 = self._calc_pixel_index_from_orientation(False)
             d1 = mathutil.expand2d(r1, self.MAX_SHAPE[1], False)
             d2 = mathutil.expand2d(r2, self.MAX_SHAPE[0], True)
         corners = self.get_pixel_corners()

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "production"
 
 import functools
@@ -541,8 +541,8 @@ class Cirpad(ImXPadS10):
     def _translation(md, u):
         return md + u
 
-    def __init__(self, pixel1=130e-6, pixel2=130e-6, max_shape=None, module_size=None):
-        ImXPadS10.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, module_size=module_size)
+    def __init__(self, pixel1=130e-6, pixel2=130e-6, max_shape=None, module_size=None, orientation=0):
+        ImXPadS10.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, module_size=module_size, orientation=orientation)
 
     def _calc_pixels_size(self, length, module_size, pixel_size):
         size = numpy.ones(length)

--- a/src/pyFAI/detectors/_non_flat.py
+++ b/src/pyFAI/detectors/_non_flat.py
@@ -179,8 +179,9 @@ class CylindricalDetector(Detector):
         the same shape.
         """
         if (d1 is None) or d2 is None:
-            d1 = mathutil.expand2d(numpy.arange(self.shape[0]).astype(numpy.float32), self.shape[1], False)
-            d2 = mathutil.expand2d(numpy.arange(self.shape[1]).astype(numpy.float32), self.shape[0], True)
+            r1, r2 = self._calc_pixel_index_from_orientation(True)
+            d1 = mathutil.expand2d(r1, self.shape[1], False)
+            d2 = mathutil.expand2d(r2, self.shape[0], True)
         corners = self.get_pixel_corners()
         if center:
             # avoid += It modifies in place and segfaults

--- a/src/pyFAI/detectors/_non_flat.py
+++ b/src/pyFAI/detectors/_non_flat.py
@@ -4,7 +4,7 @@
 #    Project: Fast Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2017-2020 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2017-2023 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -36,7 +36,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "05/01/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 
@@ -44,8 +44,7 @@ import numpy
 import logging
 logger = logging.getLogger(__name__)
 import json
-from collections import OrderedDict
-from ._common import Detector
+from ._common import Detector, Orientation
 from pyFAI.utils import mathutil
 try:
     from ..ext import bilinear
@@ -60,8 +59,8 @@ class CylindricalDetector(Detector):
     IS_FLAT = False
     force_pixel = True
 
-    def __init__(self, pixel1=24.893e-6, pixel2=24.893e-6, radius=0.29989):
-        Detector.__init__(self, pixel1, pixel2)
+    def __init__(self, pixel1=24.893e-6, pixel2=24.893e-6, radius=0.29989, orientation=0):
+        Detector.__init__(self, pixel1, pixel2, orientation=orientation)
         self.radius = radius
         self._pixel_corners = None
 
@@ -70,9 +69,10 @@ class CylindricalDetector(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2),
-                            ("radius", self.radius)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "radius": self.radius,
+                "orientation": self.orientation}
 
     def set_config(self, config):
         """Sets the configuration of the detector.
@@ -102,6 +102,7 @@ class CylindricalDetector(Detector):
         if radius:
             self.radius = radius
             self._pixel_corners = None
+        self.orientation = Orientation(config.get("orientation", 0))
         return self
 
     def _get_compact_pixel_corners(self):
@@ -268,8 +269,8 @@ class Aarhus(CylindricalDetector):
 
     MAX_SHAPE = (1000, 16000)
 
-    def __init__(self, pixel1=24.893e-6, pixel2=24.893e-6, radius=0.29989):
-        CylindricalDetector.__init__(self, pixel1, pixel2, radius)
+    def __init__(self, pixel1=24.893e-6, pixel2=24.893e-6, radius=0.29989, orientation=0):
+        CylindricalDetector.__init__(self, pixel1, pixel2, radius, orientation=orientation)
 
     def _get_compact_pixel_corners(self):
         "The core function which calculates the pixel corner coordinates"
@@ -304,8 +305,8 @@ class Rapid(CylindricalDetector):
     aliases = ["RapidII"]
     MAX_SHAPE = (2560, 4700)
 
-    def __init__(self, pixel1=0.1e-3, pixel2=0.1e-3, radius=0.12726):
-        CylindricalDetector.__init__(self, pixel1, pixel2, radius)
+    def __init__(self, pixel1=0.1e-3, pixel2=0.1e-3, radius=0.12726, orientation=0):
+        CylindricalDetector.__init__(self, pixel1, pixel2, radius, orientation=orientation)
 
     def _get_compact_pixel_corners(self):
         "The core function which calculates the pixel corner coordinates"

--- a/src/pyFAI/detectors/_non_flat.py
+++ b/src/pyFAI/detectors/_non_flat.py
@@ -36,7 +36,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 
 
@@ -72,7 +72,7 @@ class CylindricalDetector(Detector):
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
                 "radius": self.radius,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
     def set_config(self, config):
         """Sets the configuration of the detector.
@@ -102,7 +102,7 @@ class CylindricalDetector(Detector):
         if radius:
             self.radius = radius
             self._pixel_corners = None
-        self.orientation = Orientation(config.get("orientation", 0))
+        self.orientation = Orientation(config.get("orientation", 3))
         return self
 
     def _get_compact_pixel_corners(self):

--- a/src/pyFAI/detectors/_non_flat.py
+++ b/src/pyFAI/detectors/_non_flat.py
@@ -179,7 +179,7 @@ class CylindricalDetector(Detector):
         the same shape.
         """
         if (d1 is None) or d2 is None:
-            r1, r2 = self._calc_pixel_index_from_orientation(True)
+            r1, r2 = self._calc_pixel_index_from_orientation(False)
             d1 = mathutil.expand2d(r1, self.shape[1], False)
             d2 = mathutil.expand2d(r2, self.shape[0], True)
         corners = self.get_pixel_corners()

--- a/src/pyFAI/detectors/_non_flat.py
+++ b/src/pyFAI/detectors/_non_flat.py
@@ -36,7 +36,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "production"
 
 
@@ -102,7 +102,7 @@ class CylindricalDetector(Detector):
         if radius:
             self.radius = radius
             self._pixel_corners = None
-        self.orientation = Orientation(config.get("orientation", 3))
+        self._orientation = Orientation(config.get("orientation", 3))
         return self
 
     def _get_compact_pixel_corners(self):

--- a/src/pyFAI/detectors/_others.py
+++ b/src/pyFAI/detectors/_others.py
@@ -34,14 +34,13 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 
 import logging
 logger = logging.getLogger(__name__)
 import json
-from collections import OrderedDict
-from ._common import Detector
+from ._common import Detector, Orientation
 
 
 class Fairchild(Detector):
@@ -69,7 +68,7 @@ class Fairchild(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class Titan(Detector):
@@ -97,7 +96,7 @@ class Titan(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class Dexela2923(Detector):
@@ -122,7 +121,7 @@ class Dexela2923(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class Basler(Detector):
@@ -150,7 +149,7 @@ class Basler(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
     def set_config(self, config):
         """Sets the configuration of the detector.
@@ -175,6 +174,7 @@ class Basler(Detector):
         if pixel1 or pixel2:
             self.set_pixel1(pixel1 or pixel2)
             self.set_pixel2(pixel2 or pixel1)
+        self.orientation = Orientation(config.get("orientation", 3))
         return self
 
 
@@ -210,7 +210,7 @@ class Perkin(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class Pixium(Detector):
@@ -246,7 +246,7 @@ class Pixium(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class Apex2(Detector):
@@ -281,7 +281,7 @@ class Apex2(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class RaspberryPi5M(Detector):
@@ -302,7 +302,7 @@ class RaspberryPi5M(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}
 
 
 class RaspberryPi8M(Detector):
@@ -323,4 +323,4 @@ class RaspberryPi8M(Detector):
         """
         return {"pixel1": self._pixel1,
                 "pixel2": self._pixel2,
-                "orientation": self.orientation}
+                "orientation": self.orientation or 3}

--- a/src/pyFAI/detectors/_others.py
+++ b/src/pyFAI/detectors/_others.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "07/09/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 import logging
@@ -55,8 +55,8 @@ class Fairchild(Detector):
     aliases = ["Fairchild", "Condor", "Fairchild Condor 486:90"]
     MAX_SHAPE = (4096, 4096)
 
-    def __init__(self, pixel1=15e-6, pixel2=15e-6, max_shape=None):
-        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=15e-6, pixel2=15e-6, max_shape=None, orientation=0):
+        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def __repr__(self):
         return "Detector %s\t PixelSize= %.3e, %.3e m" % \
@@ -67,8 +67,9 @@ class Fairchild(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class Titan(Detector):
@@ -82,8 +83,8 @@ class Titan(Detector):
     aliases = ["Titan 2k x 2k", "Titan 2k x 2k", "OXD Titan", "Agilent Titan"]
     uniform_pixel = True
 
-    def __init__(self, pixel1=60e-6, pixel2=60e-6, max_shape=None):
-        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=60e-6, pixel2=60e-6, max_shape=None, orientation=0):
+        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def __repr__(self):
         return "Detector %s\t PixelSize= %.3e, %.3e m" % \
@@ -94,8 +95,9 @@ class Titan(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class Dexela2923(Detector):
@@ -106,8 +108,8 @@ class Dexela2923(Detector):
     aliases = ["Dexela 2923"]
     MAX_SHAPE = (3888, 3072)
 
-    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None):
-        super(Dexela2923, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, orientation=0):
+        super(Dexela2923, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def __repr__(self):
         return "Detector %s\t PixelSize= %.3e, %.3e m" % \
@@ -118,8 +120,9 @@ class Dexela2923(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class Basler(Detector):
@@ -133,8 +136,8 @@ class Basler(Detector):
     aliases = ["aca1300"]
     MAX_SHAPE = (966, 1296)
 
-    def __init__(self, pixel1=3.75e-6, pixel2=3.75e-6, max_shape=None):
-        super(Basler, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=3.75e-6, pixel2=3.75e-6, max_shape=None, orientation=0):
+        super(Basler, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def __repr__(self):
         return "Detector %s\t PixelSize= %.3e, %.3e m" % \
@@ -146,7 +149,8 @@ class Basler(Detector):
         :return: dict with param for serialization
         """
         return {"pixel1": self._pixel1,
-                "pixel2": self._pixel2}
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
     def set_config(self, config):
         """Sets the configuration of the detector.
@@ -186,8 +190,8 @@ class Perkin(Detector):
     MAX_SHAPE = (4096, 4096)
     DEFAULT_PIXEL1 = DEFAULT_PIXEL2 = 200e-6
 
-    def __init__(self, pixel1=200e-6, pixel2=200e-6, max_shape=None):
-        super(Perkin, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=200e-6, pixel2=200e-6, max_shape=None, orientation=0):
+        super(Perkin, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (pixel1 != self.DEFAULT_PIXEL1) or (pixel2 != self.DEFAULT_PIXEL2):
             self._binning = (int(2 * pixel1 / self.DEFAULT_PIXEL1), int(2 * pixel2 / self.DEFAULT_PIXEL2))
             self.shape = tuple(s // b for s, b in zip(self.max_shape, self._binning))
@@ -204,8 +208,9 @@ class Perkin(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class Pixium(Detector):
@@ -221,10 +226,10 @@ class Pixium(Detector):
     MAX_SHAPE = (1910, 2480)
     DEFAULT_PIXEL1 = DEFAULT_PIXEL2 = 154e-6
 
-    def __init__(self, pixel1=308e-6, pixel2=308e-6, max_shape=None):
+    def __init__(self, pixel1=308e-6, pixel2=308e-6, max_shape=None, orientation=0):
         """Defaults to 2x2 binning
         """
-        super(Pixium, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+        super(Pixium, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (pixel1 != self.DEFAULT_PIXEL1) or (pixel2 != self.DEFAULT_PIXEL2):
             self._binning = (int(round(pixel1 / self.DEFAULT_PIXEL1)),
                              int(round(pixel2 / self.DEFAULT_PIXEL2)))
@@ -239,8 +244,9 @@ class Pixium(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class Apex2(Detector):
@@ -255,10 +261,10 @@ class Apex2(Detector):
     MAX_SHAPE = (1024, 1024)
     DEFAULT_PIXEL1 = DEFAULT_PIXEL2 = 60e-6
 
-    def __init__(self, pixel1=120e-6, pixel2=120e-6, max_shape=None):
+    def __init__(self, pixel1=120e-6, pixel2=120e-6, max_shape=None, orientation=0):
         """Defaults to 2x2 binning
         """
-        super(Apex2, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+        super(Apex2, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (pixel1 != self.DEFAULT_PIXEL1) or (pixel2 != self.DEFAULT_PIXEL2):
             self._binning = (int(round(pixel1 / self.DEFAULT_PIXEL1)),
                              int(round(pixel2 / self.DEFAULT_PIXEL2)))
@@ -273,8 +279,9 @@ class Apex2(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class RaspberryPi5M(Detector):
@@ -285,16 +292,17 @@ class RaspberryPi5M(Detector):
     force_pixel = True
     MAX_SHAPE = (1944, 2592)
 
-    def __init__(self, pixel1=1.4e-6, pixel2=1.4e-6, max_shape=None):
-        super(RaspberryPi5M, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=1.4e-6, pixel2=1.4e-6, max_shape=None, orientation=0):
+        super(RaspberryPi5M, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def get_config(self):
         """Return the configuration with arguments to the constructor
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}
 
 
 class RaspberryPi8M(Detector):
@@ -305,13 +313,14 @@ class RaspberryPi8M(Detector):
     force_pixel = True
     MAX_SHAPE = (2464, 3280)
 
-    def __init__(self, pixel1=1.12e-6, pixel2=1.12e-6, max_shape=None):
-        super(RaspberryPi8M, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=1.12e-6, pixel2=1.12e-6, max_shape=None, orientation=0):
+        super(RaspberryPi8M, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def get_config(self):
         """Return the configuration with arguments to the constructor
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation}

--- a/src/pyFAI/detectors/_others.py
+++ b/src/pyFAI/detectors/_others.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "production"
 
 import logging
@@ -174,7 +174,7 @@ class Basler(Detector):
         if pixel1 or pixel2:
             self.set_pixel1(pixel1 or pixel2)
             self.set_pixel2(pixel2 or pixel1)
-        self.orientation = Orientation(config.get("orientation", 3))
+        self._orientation = Orientation(config.get("orientation", 3))
         return self
 
 

--- a/src/pyFAI/detectors/_psi.py
+++ b/src/pyFAI/detectors/_psi.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "2021 European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/03/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 import numpy
@@ -83,8 +83,8 @@ class Jungfrau(Detector):
             size[i * module_size] = cls.BORDER_SIZE_RELATIVE
         return pixel_size * size
 
-    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None):
-        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None, orientation=0):
+        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         self._pixel_edges = None  # array of size max_shape+1: pixels are contiguous
         if (module_size is None) and ("MODULE_SIZE" in dir(self.__class__)):
             self.module_size = tuple(self.MODULE_SIZE)
@@ -209,8 +209,8 @@ class Jungfrau4M(_Dectris):
     aliases = ["Jungfrau 4M"]
     uniform_pixel = True
 
-    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None):
-        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None, orientation=0):
+        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (module_size is None) and ("MODULE_SIZE" in dir(self.__class__)):
             self.module_size = tuple(self.MODULE_SIZE)
         else:
@@ -271,8 +271,8 @@ class Jungfrau8M(Jungfrau):
                         [3009, 538], [3009, 538+259], [3009, 1055], [3009, 1313],
                         [3078, 1577], [3078, 1836], [3078, 2094], [3078, 2352]]
 
-    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None):
-        Jungfrau.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, module_size=module_size)
+    def __init__(self, pixel1=75e-6, pixel2=75e-6, max_shape=None, module_size=None, orientation=0):
+        Jungfrau.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, module_size=module_size, orientation=orientation)
 
     def calc_mask(self):
         mask = numpy.ones(self.max_shape, dtype=numpy.int8)

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -98,7 +98,7 @@ class _Rayonix(Detector):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation:
-            txt+=f"\t {self.orientation.name} (self.orientation.value)"
+            txt+=f"\t {self.orientation.name} ({self.orientation.value})"
         return txt
 
     def guess_binning(self, data):

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -574,8 +574,8 @@ class Mar345(Detector):
 
         :return: dict with param for serialization
         """
-        dico = {"pixel1": self.pixel1
-                "pixel2": self.pixel3,
+        dico = {"pixel1": self.pixel1,
+                "pixel2": self.pixel2,
                 "orientation": self.orientation or 3}
         return dico
 

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -98,7 +98,7 @@ class _Rayonix(Detector):
     def __repr__(self):
         txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
         if self.orientation:
-            txt+=f"\t {self.orientation.name}"
+            txt+=f"\t {self.orientation.name} (self.orientation.value)"
         return txt
 
     def guess_binning(self, data):

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -35,13 +35,12 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 
 import numpy
 import json
-from collections import OrderedDict
-from ._common import Detector
+from ._common import Detector, Orientation
 
 import logging
 logger = logging.getLogger(__name__)
@@ -141,8 +140,9 @@ class _Rayonix(Detector):
 
         :return: dict with param for serialization
         """
-        return OrderedDict((("pixel1", self._pixel1),
-                            ("pixel2", self._pixel2)))
+        return {"pixel1": self._pixel1,
+                "pixel2": self._pixel2,
+                "orientation": self.orientation or 3}
 
 
 class Rayonix133(_Rayonix):
@@ -574,8 +574,9 @@ class Mar345(Detector):
 
         :return: dict with param for serialization
         """
-        dico = OrderedDict((("pixel1", self.pixel1),
-                            ("pixel2", self.pixel2)))
+        dico = {"pixel1": self.pixel1
+                "pixel2": self.pixel3,
+                "orientation": self.orientation or 3}
         return dico
 
     def set_config(self, config):
@@ -595,6 +596,7 @@ class Mar345(Detector):
                 raise err
         self.set_pixel1(config.get("pixel1"))
         self.set_pixel2(config.get("pixel2"))
+        self.oientation = Orientation(config.get("orientation", 3))
         return self
 
 
@@ -619,8 +621,9 @@ class Mar555(Detector):
 
         :return: dict with param for serialization
         """
-        dico = OrderedDict((("pixel1", self.pixel1),
-                            ("pixel2", self.pixel2)))
+        dico = {"pixel1": self.pixel1,
+                "pixel2": self.pixel2,
+                "orientation": self.orientation or 3
         return dico
 
     def set_config(self, config):
@@ -640,4 +643,5 @@ class Mar555(Detector):
                 raise err
         self.set_pixel1(config.get("pixel1"))
         self.set_pixel2(config.get("pixel2"))
+        self.orientation = Orientation(config.get("orientatio", 3))
         return self

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -643,5 +643,5 @@ class Mar555(Detector):
                 raise err
         self.set_pixel1(config.get("pixel1"))
         self.set_pixel2(config.get("pixel2"))
-        self._orientation = Orientation(config.get("orientatio", 3))
+        self._orientation = Orientation(config.get("orientation", 3))
         return self

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -35,7 +35,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "08/09/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 import numpy
@@ -55,8 +55,8 @@ class _Rayonix(Detector):
     BINNED_PIXEL_SIZE = {1: 32e-6}
     MAX_SHAPE = (4096, 4096)
 
-    def __init__(self, pixel1=32e-6, pixel2=32e-6, max_shape=None):
-        super(_Rayonix, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=32e-6, pixel2=32e-6, max_shape=None, orientation=0):
+        super(_Rayonix, self).__init__(pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         binning = [1, 1]
         for b, p in self.BINNED_PIXEL_SIZE.items():
             if p == pixel1:
@@ -96,8 +96,10 @@ class _Rayonix(Detector):
     binning = property(get_binning, set_binning)
 
     def __repr__(self):
-        return "Detector %s\t PixelSize= %.3e, %.3e m" % \
-            (self.name, self._pixel1, self._pixel2)
+        txt = f"Detector {self.name}\t PixelSize= {self._pixel1:.3e}, {self._pixel2:.3e} m"
+        if self.orientation:
+            txt+=f"\t {self.orientation.name}"
+        return txt
 
     def guess_binning(self, data):
         """
@@ -165,8 +167,8 @@ class Rayonix133(_Rayonix):
 
     aliases = ["Rayonix133", "MAR 133", "MAR133"]
 
-    def __init__(self, pixel1=64e-6, pixel2=64e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=64e-6, pixel2=64e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def calc_mask(self):
         """Circular mask"""
@@ -193,8 +195,8 @@ class RayonixSx165(_Rayonix):
     aliases = ["Rayonix SX165", "MAR 165", "MAR165"]
     force_pixel = True
 
-    def __init__(self, pixel1=39.5e-6, pixel2=39.5e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=39.5e-6, pixel2=39.5e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
     def calc_mask(self):
         """Circular mask"""
@@ -219,9 +221,8 @@ class RayonixSx200(_Rayonix):
     MAX_SHAPE = (4096, 4096)
     aliases = ["Rayonix SX200"]
 
-    def __init__(self, pixel1=48e-6, pixel2=48e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
-
+    def __init__(self, pixel1=48e-6, pixel2=48e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 class RayonixLx170(_Rayonix):
     """
@@ -242,9 +243,8 @@ class RayonixLx170(_Rayonix):
     force_pixel = True
     aliases = ["Rayonix LX170", "Rayonix LX170-HS", "Rayonix LX170 HS", "RayonixLX170HS"]
 
-    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
-
+    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 class RayonixMx170(_Rayonix):
     """
@@ -264,8 +264,8 @@ class RayonixMx170(_Rayonix):
     MAX_SHAPE = (3840, 3840)
     aliases = ["Rayonix MX170", "Rayonix MX170-HS", "RayonixMX170HS", "Rayonix MX170 HS"]
 
-    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixLx255(_Rayonix):
@@ -286,8 +286,8 @@ class RayonixLx255(_Rayonix):
     MAX_SHAPE = (1920, 5760)
     aliases = ["Rayonix LX255", "Rayonix LX255-HS", "Rayonix LX 255HS", "RayonixLX225HS"]
 
-    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixMx225(_Rayonix):
@@ -308,8 +308,8 @@ class RayonixMx225(_Rayonix):
     MANUFACTURER = ["Rayonix", "Mar Research"]
     aliases = ["Rayonix MX225", "MAR 225", "MAR225"]
 
-    def __init__(self, pixel1=73.242e-6, pixel2=73.242e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=73.242e-6, pixel2=73.242e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixMx225hs(_Rayonix):
@@ -331,8 +331,8 @@ class RayonixMx225hs(_Rayonix):
     MAX_SHAPE = (5760, 5760)
     aliases = ["Rayonix MX225HS", "Rayonix MX225 HS"]
 
-    def __init__(self, pixel1=78.125e-6, pixel2=78.125e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=78.125e-6, pixel2=78.125e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixMx300(_Rayonix):
@@ -352,8 +352,8 @@ class RayonixMx300(_Rayonix):
     MANUFACTURER = ["Rayonix", "Mar Research"]
     aliases = ["Rayonix MX300", "MAR 300", "MAR300"]
 
-    def __init__(self, pixel1=73.242e-6, pixel2=73.242e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=73.242e-6, pixel2=73.242e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixMx300hs(_Rayonix):
@@ -375,8 +375,8 @@ class RayonixMx300hs(_Rayonix):
     MAX_SHAPE = (7680, 7680)
     aliases = ["Rayonix MX300HS", "Rayonix MX300 HS"]
 
-    def __init__(self, pixel1=78.125e-6, pixel2=78.125e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=78.125e-6, pixel2=78.125e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixMx340hs(_Rayonix):
@@ -398,8 +398,8 @@ class RayonixMx340hs(_Rayonix):
     MAX_SHAPE = (7680, 7680)
     aliases = ["Rayonix MX340HS", "Rayonix MX340HS"]
 
-    def __init__(self, pixel1=88.5417e-6, pixel2=88.5417e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=88.5417e-6, pixel2=88.5417e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixSx30hs(_Rayonix):
@@ -420,8 +420,8 @@ class RayonixSx30hs(_Rayonix):
     MAX_SHAPE = (1920, 1920)
     aliases = ["Rayonix SX30HS", "Rayonix SX30 HS"]
 
-    def __init__(self, pixel1=15.625e-6, pixel2=15.625e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=15.625e-6, pixel2=15.625e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixSx85hs(_Rayonix):
@@ -442,8 +442,8 @@ class RayonixSx85hs(_Rayonix):
     MAX_SHAPE = (1920, 1920)
     aliases = ["Rayonix SX85HS", "Rayonix SX85 HS"]
 
-    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixMx425hs(_Rayonix):
@@ -464,8 +464,8 @@ class RayonixMx425hs(_Rayonix):
     MAX_SHAPE = (9600, 9600)
     aliases = ["Rayonix MX425HS", "Rayonix MX425 HS"]
 
-    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=44.2708e-6, pixel2=44.2708e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 
 class RayonixMx325(_Rayonix):
@@ -483,8 +483,8 @@ class RayonixMx325(_Rayonix):
     MAX_SHAPE = (8192, 8192)
     aliases = ["Rayonix MX325"]
 
-    def __init__(self, pixel1=79.346e-6, pixel2=79.346e-6, max_shape=None):
-        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=79.346e-6, pixel2=79.346e-6, max_shape=None, orientation=0):
+        _Rayonix.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
 
 ################################################################################
 # Because Rayonix and MAR-Research usedto be the same company
@@ -516,8 +516,8 @@ class Mar345(Detector):
 
     aliases = ["MAR 345", "Mar3450"]
 
-    def __init__(self, pixel1=100e-6, pixel2=100e-6, max_shape=None):
-        Detector.__init__(self, pixel1, pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=100e-6, pixel2=100e-6, max_shape=None, orientation=0):
+        Detector.__init__(self, pixel1, pixel2, max_shape=max_shape, orientation=orientation)
         self._default_pixel_size = pixel1, pixel2
         self.max_shape = (int(self.max_shape[0] * 100e-6 / self.pixel1),
                           int(self.max_shape[1] * 100e-6 / self.pixel2))
@@ -611,8 +611,8 @@ class Mar555(Detector):
     MAX_SHAPE = (3072, 2560)
     aliases = ["MAR 555"]
 
-    def __init__(self, pixel1=139e-6, pixel2=139e-6, max_shape=None):
-        Detector.__init__(self, pixel1, pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=139e-6, pixel2=139e-6, max_shape=None, orientation=0):
+        Detector.__init__(self, pixel1, pixel2, max_shape=max_shape, orientation=orientation)
 
     def get_config(self):
         """Return the configuration with arguments to the constructor

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -35,7 +35,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "production"
 
 import numpy
@@ -643,5 +643,5 @@ class Mar555(Detector):
                 raise err
         self.set_pixel1(config.get("pixel1"))
         self.set_pixel2(config.get("pixel2"))
-        self.orientation = Orientation(config.get("orientatio", 3))
+        self._orientation = Orientation(config.get("orientatio", 3))
         return self

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -596,7 +596,7 @@ class Mar345(Detector):
                 raise err
         self.set_pixel1(config.get("pixel1"))
         self.set_pixel2(config.get("pixel2"))
-        self.orientation = Orientation(config.get("orientation", 3))
+        self._orientation = Orientation(config.get("orientation", 3))
         return self
 
 

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -623,7 +623,7 @@ class Mar555(Detector):
         """
         dico = {"pixel1": self.pixel1,
                 "pixel2": self.pixel2,
-                "orientation": self.orientation or 3
+                "orientation": self.orientation or 3}
         return dico
 
     def set_config(self, config):

--- a/src/pyFAI/detectors/_rayonix.py
+++ b/src/pyFAI/detectors/_rayonix.py
@@ -596,7 +596,7 @@ class Mar345(Detector):
                 raise err
         self.set_pixel1(config.get("pixel1"))
         self.set_pixel2(config.get("pixel2"))
-        self.oientation = Orientation(config.get("orientation", 3))
+        self.orientation = Orientation(config.get("orientation", 3))
         return self
 
 

--- a/src/pyFAI/detectors/_xspectrum.py
+++ b/src/pyFAI/detectors/_xspectrum.py
@@ -4,7 +4,7 @@
 #    Project: Fast Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2022-2022 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2022-2024 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "09/12/2022"
+__date__ = "21/11/2023"
 __status__ = "production"
 
 import numpy
@@ -53,8 +53,8 @@ class _Lambda(Detector):
     MODULE_GAP = (4, 4)
     force_pixel = True
 
-    def __init__(self, pixel1=55e-6, pixel2=55e-6, max_shape=None, module_size=None):
-        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape)
+    def __init__(self, pixel1=55e-6, pixel2=55e-6, max_shape=None, module_size=None, orientation=0):
+        Detector.__init__(self, pixel1=pixel1, pixel2=pixel2, max_shape=max_shape, orientation=orientation)
         if (module_size is None) and ("MODULE_SIZE" in dir(self.__class__)):
             self.module_size = tuple(self.MODULE_SIZE)
         else:

--- a/src/pyFAI/detectors/meson.build
+++ b/src/pyFAI/detectors/meson.build
@@ -10,7 +10,8 @@ py.install_sources(
  '_others.py',
  '_psi.py',
  '_rayonix.py',
- '_xspectrum.py'],
+ '_xspectrum.py',
+ 'orientation.py'],
   pure: false,   # Will be installed next to binaries
   subdir: 'pyFAI/detectors'  # Folder relative to site-packages to install to
 )

--- a/src/pyFAI/detectors/orientation.py
+++ b/src/pyFAI/detectors/orientation.py
@@ -60,7 +60,7 @@ class Orientation(IntEnum):
 Orientation(0).__doc__ = "An orientation flag is not set."
 Orientation(1).__doc__ = "Camera default. Origin at the top left of the image when looking at the sample."
 Orientation(2).__doc__ = "Origin at the top left of the image when looking from the sample."
-Orientation(3).__doc__ = "Native orientation of pyFAI. Origin at the bottom left when looking from the sample"
+Orientation(3).__doc__ = "Native orientation of pyFAI. Origin at the bottom left when looking from the sample."
 Orientation(4).__doc__ = "Origin at the bottom left when looking at the sample."
 Orientation(5).__doc__ = "Rotate the photo counter-clockwise 270 degrees and then flip it horizontally. Unsupported for now."
 Orientation(6).__doc__ = "Rotate the photo counter-clockwise 270 degrees. Unsupported for now."

--- a/src/pyFAI/detectors/orientation.py
+++ b/src/pyFAI/detectors/orientation.py
@@ -1,0 +1,68 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2023-2023 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""Orientation of detectors:
+
+This module contains mostly an enum with the associated documentation
+For orientation description, see http://sylvana.net/jpegcrop/exif_orientation.html
+"""
+
+
+__author__ = "Jérôme Kieffer"
+__contact__ = "Jerome.Kieffer@ESRF.eu"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "21/11/2023"
+__status__ = "stable"
+
+from enum import IntEnum
+
+class Orientation(IntEnum):
+    """Names inspired from
+    https://learn.microsoft.com/en-us/uwp/api/windows.storage.fileproperties.photoorientation
+    """
+    Unspecified = 0
+    Normal = 1
+    FlipHorizontal = 2
+    Rotate180 = 3
+    FlipVertical = 4
+    Transpose = 5
+    Rotate270 = 6
+    Transverse = 7
+    Rotate90 = 8
+
+Orientation(0).__doc__ = "An orientation flag is not set."
+Orientation(1).__doc__ = "Camera default. Origin at the top left of the image when looking at the sample."
+Orientation(2).__doc__ = "Origin at the top left of the image when looking from the sample."
+Orientation(3).__doc__ = "Native orientation of pyFAI. Origin at the bottom left when looking from the sample"
+Orientation(4).__doc__ = "Origin at the bottom left when looking at the sample."
+Orientation(5).__doc__ = "Rotate the photo counter-clockwise 270 degrees and then flip it horizontally. Unsupported for now."
+Orientation(6).__doc__ = "Rotate the photo counter-clockwise 270 degrees. Unsupported for now."
+Orientation(7).__doc__ = "Rotate the photo counter-clockwise 90 degrees and then flip it horizontally. Unsupported for now."
+Orientation(8).__doc__ = "Rotate the photo counter-clockwise 90 degrees. Unsupported for now."

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -40,7 +40,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "20/11/2023"
+__date__ = "21/11/2023"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -115,7 +115,8 @@ class Geometry(object):
     _LAST_POLARIZATION = "last_polarization"
 
     def __init__(self, dist=1, poni1=0, poni2=0, rot1=0, rot2=0, rot3=0,
-                 pixel1=None, pixel2=None, splineFile=None, detector=None, wavelength=None):
+                 pixel1=None, pixel2=None, splineFile=None, detector=None, wavelength=None,
+                 orientation=0):
         """
         :param dist: distance sample - detector plan (orthogonal distance, not along the beam), in meter.
         :param poni1: coordinate of the point of normal incidence along the detector's first dimension, in meter
@@ -145,6 +146,7 @@ class Geometry(object):
         :type detector: str or pyFAI.Detector
         :param wavelength: Wave length used in meter
         :type wavelength: float
+        :param int orientation: orientation of the detector, see pyFAI.detectors.orientation.Orientation
         """
         self._dist = dist
         self._poni1 = poni1

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -40,7 +40,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -179,7 +179,7 @@ class Geometry(object):
             self.detector.pixel1 = pixel1
             self.detector.pixel2 = pixel2
         if orientation:
-            self.detector.orientation = detectors.orientation.Orientation(orientation or detector.ORIENTATION)
+            self.detector._orientation = detectors.orientation.Orientation(orientation or detector.ORIENTATION)
 
     def __repr__(self, dist_unit="m", ang_unit="rad", wl_unit="m"):
         """Nice representation of the class

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -40,7 +40,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -178,6 +178,8 @@ class Geometry(object):
         elif pixel1 and pixel2:
             self.detector.pixel1 = pixel1
             self.detector.pixel2 = pixel2
+        if orientation:
+            self.detector.orientation = detectors.orientation.Orientation(orientation or detector.ORIENTATION)
 
     def __repr__(self, dist_unit="m", ang_unit="rad", wl_unit="m"):
         """Nice representation of the class

--- a/src/pyFAI/geometryRefinement.py
+++ b/src/pyFAI/geometryRefinement.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/02/2023"
+__date__ = "21/11/2023"
 __status__ = "development"
 
 import os
@@ -75,15 +75,18 @@ ROCA = "/opt/saxs/roca"
 class GeometryRefinement(AzimuthalIntegrator):
     PARAM_ORDER = ("dist", "poni1", "poni2", "rot1", "rot2", "rot3", "wavelength")
 
-    def __init__(self, data=None, dist=1, poni1=None, poni2=None,
+    def __init__(self, data=None, calibrant=None,
+                 dist=1, poni1=None, poni2=None,
                  rot1=0, rot2=0, rot3=0,
                  pixel1=None, pixel2=None, splineFile=None, detector=None,
-                 wavelength=None, calibrant=None):
+                 wavelength=None, **kwargs):
         """
         :param data: ndarray float64 shape = n, 3
             col0: pos in dim0 (in pixels)
             col1: pos in dim1 (in pixels)
             col2: ring index in calibrant object
+        :param calibrant: instance of pyFAI.calibrant.Calibrant containing the d-Spacing
+
         :param dist: guessed sample-detector distance (optional, in m)
         :param poni1: guessed PONI coordinate along the Y axis (optional, in m)
         :param poni2: guessed PONI coordinate along the X axis (optional, in m)
@@ -95,7 +98,7 @@ class GeometryRefinement(AzimuthalIntegrator):
         :param splineFile: file describing the detector as 2 cubic splines. Replaces pixel1 & pixel2
         :param detector: name of the detector or Detector instance. Replaces splineFile, pixel1 & pixel2
         :param wavelength: wavelength in m (1.54e-10)
-        :param calibrant: instance of pyFAI.calibrant.Calibrant containing the d-Spacing
+
 
         """
         if data is None:
@@ -110,7 +113,8 @@ class GeometryRefinement(AzimuthalIntegrator):
             raise RuntimeError("Setting up the geometry refinement without knowing the detector makes little sense")
         AzimuthalIntegrator.__init__(self, dist, 0, 0,
                                      rot1, rot2, rot3,
-                                     pixel1, pixel2, splineFile, detector, wavelength=wavelength)
+                                     pixel1, pixel2, splineFile, detector,
+                                     wavelength=wavelength, **kwargs)
 
         if calibrant is None:
             self.calibrant = Calibrant()

--- a/src/pyFAI/test/test_detector.py
+++ b/src/pyFAI/test/test_detector.py
@@ -199,6 +199,7 @@ class TestDetector(unittest.TestCase):
                 logger.warning("Test nexus_detector failed due to short memory on detector %s", det_name)
                 continue
             self.assertEqual(len(o), len(r), "data have same dimension")
+
             err1 = abs(r[0] - o[0]).max()
             err2 = abs(r[1] - o[1]).max()
             if det.name in known_fail:
@@ -378,11 +379,96 @@ class TestDetector(unittest.TestCase):
         self.assertEqual(det.shape, shape)
         self.assertEqual(abs(z-res).max(), 0)
 
+class TestOrientation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls)->None:
+        super(TestOrientation, cls).setUpClass()
+        cls.orient1 = detector_factory("Pilatus100k", config={"orientation":1})
+        cls.orient2 = detector_factory("Pilatus100k", config={"orientation":2})
+        cls.orient3 = detector_factory("Pilatus100k", config={"orientation":3})
+        cls.orient4 = detector_factory("Pilatus100k", config={"orientation":4})
+
+    @classmethod
+    def tearDownClass(cls)->None:
+        super(TestOrientation, cls).tearDownClass()
+        cls.orient1 = None
+        cls.orient2 = None
+        cls.orient3 = None
+        cls.orient4 = None
+
+    def test_centers(self):
+        p1, p2, _ = self.orient1.calc_cartesian_positions()
+        #orient2 -> flip rl
+        r1, r2, _ = self.orient2.calc_cartesian_positions()
+        self.assertTrue(numpy.allclose(p1, numpy.fliplr(r1)), "orient 2vs1 dim1,y center")
+        self.assertTrue(numpy.allclose(p2, numpy.fliplr(r2)), "orient 2vs1 dim2,x center")
+        #orient3 -< rotate180
+        r1, r2, _ = self.orient3.calc_cartesian_positions()
+        self.assertTrue(numpy.allclose(p1, numpy.flipud(numpy.fliplr(r1))), "orient 3vs1 dim1,y center")
+        self.assertTrue(numpy.allclose(p2, numpy.flipud(numpy.fliplr(r2))), "orient 3vs1 dim2,x center")
+        #orient3 -> flip u-d
+        r1, r2, _ = self.orient4.calc_cartesian_positions()
+        self.assertTrue(numpy.allclose(p1, numpy.flipud(r1)), "orient 4vs1 dim1,y center")
+        self.assertTrue(numpy.allclose(p2, numpy.flipud(r2)), "orient 4vs1 dim2,x center")
+
+    def test_corners(self):
+        p1, p2, _ = self.orient1.calc_cartesian_positions(center=False)
+        #orient2 -> flip rl
+        r1, r2, _ = self.orient2.calc_cartesian_positions(center=False)
+        self.assertTrue(numpy.allclose(p1, numpy.fliplr(r1)), "orient 2vs1 dim1,y corner")
+        self.assertTrue(numpy.allclose(p2, numpy.fliplr(r2)), "orient 2vs1 dim2,x corner")
+        #orient3 -< rotate180
+        r1, r2, _ = self.orient3.calc_cartesian_positions(center=False)
+        self.assertTrue(numpy.allclose(p1, numpy.flipud(numpy.fliplr(r1))), "orient 3vs1 dim1,y corner")
+        self.assertTrue(numpy.allclose(p2, numpy.flipud(numpy.fliplr(r2))), "orient 3vs1 dim2,x corner")
+        #orient3 -> flip u-d
+        r1, r2, _ = self.orient4.calc_cartesian_positions(center=False)
+        self.assertTrue(numpy.allclose(p1, numpy.flipud(r1)), "orient 4vs1 dim1,y corner")
+        self.assertTrue(numpy.allclose(p2, numpy.flipud(r2)), "orient 4vs1 dim2,x corner")
+
+    def test_points(self):
+        npt = 1000
+        rng = UtilsTest.get_rng()
+        Y = rng.integers(0, self.orient1.shape[0]-1, size=npt)
+        X = rng.integers(0, self.orient1.shape[1]-1, size=npt)
+        #orient1
+        r1, r2, _ = self.orient1.calc_cartesian_positions(Y, X)
+        ref1, ref2, _ = self.orient1.calc_cartesian_positions()
+        p1 = ref1[Y, X]
+        p2 = ref2[Y, X]
+        self.assertTrue(numpy.allclose(r1, p1), "orient 1 dim1,y points")
+        self.assertTrue(numpy.allclose(r2, p2), "orient 1 dim2,x points")
+
+        #orient2
+        r1, r2, _ = self.orient2.calc_cartesian_positions(Y, X)
+        ref1, ref2, _ = self.orient2.calc_cartesian_positions()
+        p1 = ref1[Y, X]
+        p2 = ref2[Y, X]
+        self.assertTrue(numpy.allclose(r1, p1), "orient 2 dim1,y points")
+        self.assertTrue(numpy.allclose(r2, p2), "orient 2 dim2,x points")
+
+        #orient3
+        r1, r2, _ = self.orient3.calc_cartesian_positions(Y, X)
+        ref1, ref2, _ = self.orient3.calc_cartesian_positions()
+        p1 = ref1[Y, X]
+        p2 = ref2[Y, X]
+        self.assertTrue(numpy.allclose(r1, p1), "orient 3 dim1,y points")
+        self.assertTrue(numpy.allclose(r2, p2), "orient 3 dim2,x points")
+
+        #orient1
+        r1, r2, _ = self.orient4.calc_cartesian_positions(Y, X)
+        ref1, ref2, _ = self.orient4.calc_cartesian_positions()
+        p1 = ref1[Y, X]
+        p2 = ref2[Y, X]
+        self.assertTrue(numpy.allclose(r1, p1), "orient 4 dim1,y points")
+        self.assertTrue(numpy.allclose(r2, p2), "orient 4 dim2,x points")
+
 
 def suite():
     loader = unittest.defaultTestLoader.loadTestsFromTestCase
     testsuite = unittest.TestSuite()
     testsuite.addTest(loader(TestDetector))
+    testsuite.addTest(loader(TestOrientation))
     return testsuite
 
 

--- a/src/pyFAI/test/test_detector.py
+++ b/src/pyFAI/test/test_detector.py
@@ -33,7 +33,7 @@ __author__ = "Picca Frédéric-Emmanuel, Jérôme Kieffer",
 __contact__ = "picca@synchrotron-soleil.fr"
 __license__ = "MIT+"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 
 import os
 import shutil

--- a/src/pyFAI/test/test_detector.py
+++ b/src/pyFAI/test/test_detector.py
@@ -421,7 +421,7 @@ class TestOrientation(unittest.TestCase):
         r1, r2, _ = self.orient3.calc_cartesian_positions(center=False)
         self.assertTrue(numpy.allclose(p1, numpy.flipud(numpy.fliplr(r1))), "orient 3vs1 dim1,y corner")
         self.assertTrue(numpy.allclose(p2, numpy.flipud(numpy.fliplr(r2))), "orient 3vs1 dim2,x corner")
-        #orient3 -> flip u-d
+        #orient4 -> flip u-d
         r1, r2, _ = self.orient4.calc_cartesian_positions(center=False)
         self.assertTrue(numpy.allclose(p1, numpy.flipud(r1)), "orient 4vs1 dim1,y corner")
         self.assertTrue(numpy.allclose(p2, numpy.flipud(r2)), "orient 4vs1 dim2,x corner")

--- a/src/pyFAI/test/test_detector.py
+++ b/src/pyFAI/test/test_detector.py
@@ -455,7 +455,7 @@ class TestOrientation(unittest.TestCase):
         self.assertTrue(numpy.allclose(r1, p1), "orient 3 dim1,y points")
         self.assertTrue(numpy.allclose(r2, p2), "orient 3 dim2,x points")
 
-        #orient1
+        #orient4
         r1, r2, _ = self.orient4.calc_cartesian_positions(Y, X)
         ref1, ref2, _ = self.orient4.calc_cartesian_positions()
         p1 = ref1[Y, X]

--- a/src/pyFAI/test/test_detector.py
+++ b/src/pyFAI/test/test_detector.py
@@ -33,7 +33,7 @@ __author__ = "Picca Frédéric-Emmanuel, Jérôme Kieffer",
 __contact__ = "picca@synchrotron-soleil.fr"
 __license__ = "MIT+"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 
 import os
 import shutil
@@ -71,7 +71,7 @@ class TestDetector(unittest.TestCase):
             self.assertEqual(res, True, name)
 
     def test_reading_non_default_args(self):
-        config = {"pixel1": 1, "pixel2": 2, "orientation":0}
+        config = {"pixel1": 1, "pixel2": 2, "orientation":3}
         detector = detector_factory("adsc_q315", config)
         self.assertEqual(detector.get_config(), config)
         self.assertEqual(detector.pixel1, config["pixel1"])

--- a/src/pyFAI/test/test_detector.py
+++ b/src/pyFAI/test/test_detector.py
@@ -406,7 +406,7 @@ class TestOrientation(unittest.TestCase):
         r1, r2, _ = self.orient3.calc_cartesian_positions()
         self.assertTrue(numpy.allclose(p1, numpy.flipud(numpy.fliplr(r1))), "orient 3vs1 dim1,y center")
         self.assertTrue(numpy.allclose(p2, numpy.flipud(numpy.fliplr(r2))), "orient 3vs1 dim2,x center")
-        #orient3 -> flip u-d
+        #orient4 -> flip u-d
         r1, r2, _ = self.orient4.calc_cartesian_positions()
         self.assertTrue(numpy.allclose(p1, numpy.flipud(r1)), "orient 4vs1 dim1,y center")
         self.assertTrue(numpy.allclose(p2, numpy.flipud(r2)), "orient 4vs1 dim2,x center")

--- a/src/pyFAI/test/test_detector.py
+++ b/src/pyFAI/test/test_detector.py
@@ -4,7 +4,7 @@
 #    Project: Fast Azimuthal Integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2013-2022 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2023 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -33,7 +33,7 @@ __author__ = "Picca Frédéric-Emmanuel, Jérôme Kieffer",
 __contact__ = "picca@synchrotron-soleil.fr"
 __license__ = "MIT+"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "26/09/2023"
+__date__ = "21/11/2023"
 
 import os
 import shutil
@@ -71,7 +71,7 @@ class TestDetector(unittest.TestCase):
             self.assertEqual(res, True, name)
 
     def test_reading_non_default_args(self):
-        config = {"pixel1": 1, "pixel2": 2}
+        config = {"pixel1": 1, "pixel2": 2, "orientation":0}
         detector = detector_factory("adsc_q315", config)
         self.assertEqual(detector.get_config(), config)
         self.assertEqual(detector.pixel1, config["pixel1"])

--- a/src/pyFAI/test/test_geometry.py
+++ b/src/pyFAI/test/test_geometry.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "06/10/2023"
+__date__ = "21/11/2023"
 
 import unittest
 import random
@@ -486,7 +486,7 @@ class TestGeometry(utilstest.ParametricTestCase):
                 logger.debug(msg)
 
     def test_ponifile_custom_detector(self):
-        config = {"pixel1": 1, "pixel2": 2}
+        config = {"pixel1": 1, "pixel2": 2, "orientation":0}
         detector = detector_factory("adsc_q315", config)
         geom = geometry.Geometry(detector=detector)
         ponifile = os.path.join(UtilsTest.tempdir, "%s.poni" % self.id())

--- a/src/pyFAI/test/test_geometry.py
+++ b/src/pyFAI/test/test_geometry.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2023"
+__date__ = "22/11/2023"
 
 import unittest
 import random
@@ -486,7 +486,7 @@ class TestGeometry(utilstest.ParametricTestCase):
                 logger.debug(msg)
 
     def test_ponifile_custom_detector(self):
-        config = {"pixel1": 1, "pixel2": 2, "orientation":0}
+        config = {"pixel1": 1, "pixel2": 2, "orientation":3}
         detector = detector_factory("adsc_q315", config)
         geom = geometry.Geometry(detector=detector)
         ponifile = os.path.join(UtilsTest.tempdir, "%s.poni" % self.id())

--- a/src/pyFAI/test/test_geometry.py
+++ b/src/pyFAI/test/test_geometry.py
@@ -281,16 +281,28 @@ class TestFastPath(utilstest.ParametricTestCase):
         # Here is a set of pathological cases ...
         geometries = [
             # Provides atol = 1.08e-5
-            {"dist": 0.037759112584709535, "poni1": 0.005490358659182459, "poni2": 0.06625690275821605, "rot1": 0.20918568578536278, "rot2": 0.42161920581114365, "rot3": 0.38784171093239983, "wavelength": 1e-10, 'detector': 'Pilatus100k'},
+            {"dist": 0.037759112584709535, "poni1": 0.005490358659182459, "poni2": 0.06625690275821605,
+             "rot1": 0.20918568578536278, "rot2": 0.42161920581114365, "rot3": 0.38784171093239983,
+             "wavelength": 1e-10, 'detector': 'Pilatus100k', "orientation":3},
             # Provides atol = 2.8e-5
-            {'dist': 0.48459003559204783, 'poni2':-0.15784154756282065, 'poni1': 0.02783657100374448, 'rot3':-0.2901541134116695, 'rot1':-0.3927992588689394, 'rot2': 0.148115949280184, "wavelength": 1e-10, 'detector': 'Pilatus100k'},
+            {'dist': 0.48459003559204783, 'poni2':-0.15784154756282065, 'poni1': 0.02783657100374448,
+             'rot3':-0.2901541134116695, 'rot1':-0.3927992588689394, 'rot2': 0.148115949280184,
+             "wavelength": 1e-10, 'detector': 'Pilatus100k', "orientation":3},
             # Provides atol = 3.67761e-05
-            {'poni1':-0.22055143279015976, 'poni2':-0.11124668733292842, 'rot1':-0.18105235367380956, 'wavelength': 1e-10, 'rot3': 0.2146474866836957, 'rot2': 0.36581323339171257, 'detector': 'Pilatus100k', 'dist': 0.7350926443000882},
+            {'poni1':-0.22055143279015976, 'poni2':-0.11124668733292842, 'rot1':-0.18105235367380956,
+             'wavelength': 1e-10, 'rot3': 0.2146474866836957, 'rot2': 0.36581323339171257,
+             'detector': 'Pilatus100k', 'dist': 0.7350926443000882, "orientation":3},
             # Provides atol = 4.94719e-05
-            {'poni2': 0.1010652698401574, 'rot3':-0.30578860159890153, 'rot1': 0.46240992613529186, 'wavelength': 1e-10, 'detector': 'Pilatus300k', 'rot2':-0.027476969196682077, 'dist': 0.04711960678381288, 'poni1': 0.012745759325719641},
+            {'poni2': 0.1010652698401574, 'rot3':-0.30578860159890153, 'rot1': 0.46240992613529186,
+             'wavelength': 1e-10, 'detector': 'Pilatus300k', 'rot2':-0.027476969196682077,
+             'dist': 0.04711960678381288, 'poni1': 0.012745759325719641, "orientation":3},
             # atol=2pi
-            {'poni1': 0.07803878450256929, 'poni2': 0.2601779472529494, 'rot1':-0.33177239820033455, 'wavelength': 1e-10, 'rot3': 0.2928945825578625, 'rot2': 0.2762729953307118, 'detector': 'Pilatus100k', 'dist': 0.43544642285972124},
-            {'wavelength': 1e-10, 'dist': 0.13655542730645986, 'rot1':-0.16145635108891077, 'poni1': 0.16271587645146157, 'rot2':-0.443426307059295, 'rot3': 0.40517456402269536, 'poni2': 0.05248001026597382, 'detector': 'Pilatus100k'}
+            {'poni1': 0.07803878450256929, 'poni2': 0.2601779472529494, 'rot1':-0.33177239820033455,
+             'wavelength': 1e-10, 'rot3': 0.2928945825578625, 'rot2': 0.2762729953307118,
+             'detector': 'Pilatus100k', 'dist': 0.43544642285972124, "orientation":3},
+            {'wavelength': 1e-10, 'dist': 0.13655542730645986, 'rot1':-0.16145635108891077,
+             'poni1': 0.16271587645146157, 'rot2':-0.443426307059295, 'rot3': 0.40517456402269536,
+             'poni2': 0.05248001026597382, 'detector': 'Pilatus100k', "orientation":3}
         ]
 
         matrices = [[[ 0.84465919, -0.29127499, -0.44912107], [ 0.34507215, 0.93768707, 0.04084325], [ 0.4092384 , -0.1894778 , 0.89253689]],
@@ -316,7 +328,8 @@ class TestFastPath(utilstest.ParametricTestCase):
                    "rot1": (random.random() - 0.5) * numpy.pi,
                    "rot2": (random.random() - 0.5) * numpy.pi,
                    "rot3": (random.random() - 0.5) * numpy.pi,
-                   "wavelength": 1e-10}
+                   "wavelength": 1e-10,
+                   "orientation":3}
 
             for det in detectors:
                 dico = geo.copy()
@@ -348,6 +361,8 @@ class TestFastPath(utilstest.ParametricTestCase):
         for data, space in params:
             with self.subTest(data=data, space=space):
                 geo = geometry.Geometry(**data)
+                print(data)
+                print(geo.detector.orientation)
                 t00 = time.perf_counter()
                 py_res = geo.corner_array(unit=space, use_cython=False, scale=False)
                 t01 = time.perf_counter()

--- a/src/pyFAI/test/test_geometry.py
+++ b/src/pyFAI/test/test_geometry.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "22/11/2023"
+__date__ = "23/11/2023"
 
 import unittest
 import random
@@ -361,8 +361,6 @@ class TestFastPath(utilstest.ParametricTestCase):
         for data, space in params:
             with self.subTest(data=data, space=space):
                 geo = geometry.Geometry(**data)
-                print(data)
-                print(geo.detector.orientation)
                 t00 = time.perf_counter()
                 py_res = geo.corner_array(unit=space, use_cython=False, scale=False)
                 t01 = time.perf_counter()


### PR DESCRIPTION
This is likely to be a beefy one ...

* [X] create the detector orientation tag: value 0 to be used for "do not care" else value [1..8]
* [x] Use this tag when calculating the pixel center coordinate
* [x] Use this tag when calculating the pixel corner coordinate
* [x] Use this tag when calculating the x,y,z of a list of pixels (used while calibrating)
* [X] Save / restore this attribute into the Nexus detector file
* [X] Save / restore into the PONI-file
* [X] Save / restore into the config
* [x] Add some tests specific to orientation change
* [ ] ~~Ensure~~ the Detector cache gets reset when changing the orientation (--> use a property)
* [ ] ~~Ensure~~ the geometry cache gets reset when changing the orientation ( what is the best way of doing this ?)

close #1994