### PR TITLE
new arg parser for 1d

### DIFF
--- a/src/pyFAI/app/benchmark.py
+++ b/src/pyFAI/app/benchmark.py
@@ -67,6 +67,9 @@ def main():
     parser.add_argument("-d", "--debug",
                         action="store_true", dest="debug", default=False,
                         help="switch to verbose/debug mode")
+    parser.add_argument("--no-proc",
+                        action="store_false", dest="processor", default=True,
+                        help="do not benchmark using the central processor")
     parser.add_argument("-c", "--cpu",
                         action="store_true", dest="opencl_cpu", default=False,
                         help="perform benchmark using OpenCL on the CPU")
@@ -95,25 +98,51 @@ def main():
     parser.add_argument("-r", "--repeat",
                         dest="repeat", default=1, type=int,
                         help="Repeat each measurement x times to take the best")
+    
+    parser.add_argument("-ps", "--pixelsplit",
+                        dest="pixelsplit", default=["bbox"], type=str, nargs="+",
+                        help="Benchmark using specific pixel splitting protocols: no, bbox, pseudo, full",)
+    parser.add_argument("-algo", "--algorithm",
+                        dest="algorithm", default=["histogram", "CSR"], type=str, nargs="+",
+                        help="Benchmark using specific algorithms: histogram, CSR, CSC, all")
+    parser.add_argument("-i", "--implementation",
+                        dest="implementation", default=["cython", "opencl"], type=str, nargs="+",
+                        help="Benchmark using specific algorithm implementations: python, cython, opencl, all")
+    
+    parser.add_argument("-f", "--function",
+                        dest="function", default="all", type=str,
+                        help="Benchmark legacy (legacy), engine function (ng), or both (all)")
+
+    parser.add_argument("--all",
+                        action="store_true", dest="all", default=False,
+                        help="Benchmark using all available methods and devices")
 
     options = parser.parse_args()
     if options.debug:
         pyFAI.logger.setLevel(logging.DEBUG)
-    devices = ""
-    if options.opencl_cpu:
-        devices += "cpu,"
-    if options.opencl_gpu:
-        devices += "gpu,"
-    if options.opencl_acc:
-        devices += "acc,"
 
+    devices = []
+    if options.opencl_cpu:
+        devices.append("cpu")
+    if options.opencl_gpu:
+        devices.append("gpu")
+    if options.opencl_acc:
+        devices.append("acc")
+    
     pyFAI.benchmark.run(number=options.number,
                         repeat=options.repeat,
                         memprof=options.memprof,
                         max_size=options.size,
                         do_1d=options.onedim,
                         do_2d=options.twodim,
-                        devices=devices)
+                        processor=options.processor,
+                        devices=devices,
+                        split_list=options.pixelsplit,
+                        algo_list=options.algorithm,
+                        impl_list=options.implementation,
+                        function=options.function,
+                        all=options.all,
+                        )
 
     if pyFAI.benchmark.pylab is not None:
         pyFAI.benchmark.pylab.ion()

--- a/src/pyFAI/app/benchmark.py
+++ b/src/pyFAI/app/benchmark.py
@@ -5,7 +5,7 @@
 #             https://github.com/silx-kit/pyFAI
 #
 #
-#    Copyright (C) 2012-2021 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2012-2023 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Authors: Jérôme Kieffer <Jerome.Kieffer@ESRF.eu>
 #
@@ -28,11 +28,11 @@
 #  THE SOFTWARE.
 
 """utility to run the benchmark for azimuthal integration on images of various sizes"""
-__author__ = "Jérôme Kieffer, Picca Frédéric-Emmanuel"
+__author__ = "Jérôme Kieffer, Picca Frédéric-Emmanuel, Edgar Gutierrez-Fernandez"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "20/10/2023"
+__date__ = "20/12/2023"
 __status__ = "development"
 
 import logging

--- a/src/pyFAI/app/benchmark.py
+++ b/src/pyFAI/app/benchmark.py
@@ -98,7 +98,7 @@ def main():
     parser.add_argument("-r", "--repeat",
                         dest="repeat", default=1, type=int,
                         help="Repeat each measurement x times to take the best")
-    
+
     parser.add_argument("-ps", "--pixelsplit",
                         dest="pixelsplit", default=["bbox"], type=str, nargs="+",
                         help="Benchmark using specific pixel splitting protocols: no, bbox, pseudo, full",)
@@ -108,7 +108,7 @@ def main():
     parser.add_argument("-i", "--implementation",
                         dest="implementation", default=["cython", "opencl"], type=str, nargs="+",
                         help="Benchmark using specific algorithm implementations: python, cython, opencl, all")
-    
+
     parser.add_argument("-f", "--function",
                         dest="function", default="all", type=str,
                         help="Benchmark legacy (legacy), engine function (ng), or both (all)")
@@ -128,7 +128,7 @@ def main():
         devices.append("gpu")
     if options.opencl_acc:
         devices.append("acc")
-    
+
     pyFAI.benchmark.run(number=options.number,
                         repeat=options.repeat,
                         memprof=options.memprof,

--- a/src/pyFAI/app/benchmark.py
+++ b/src/pyFAI/app/benchmark.py
@@ -101,7 +101,7 @@ def main():
 
     parser.add_argument("-ps", "--pixelsplit",
                         dest="pixelsplit", default=["bbox"], type=str, nargs="+",
-                        help="Benchmark using specific pixel splitting protocols: no, bbox, pseudo, full",)
+                        help="Benchmark using specific pixel splitting protocols: no, bbox, pseudo, full, all",)
     parser.add_argument("-algo", "--algorithm",
                         dest="algorithm", default=["histogram", "CSR"], type=str, nargs="+",
                         help="Benchmark using specific algorithms: histogram, CSR, CSC, all")

--- a/src/pyFAI/benchmark/__init__.py
+++ b/src/pyFAI/benchmark/__init__.py
@@ -24,7 +24,7 @@
 "Benchmark for Azimuthal integration of PyFAI"
 
 __author__ = "Jérôme Kieffer"
-__date__ = "20/10/2023"
+__date__ = "20/12/2023"
 __license__ = "MIT"
 __copyright__ = "2012-2017 European Synchrotron Radiation Facility, Grenoble, France"
 
@@ -457,15 +457,16 @@ class Bench(object):
                     print("No such OpenCL device: skipping benchmark")
                     return
                 platformid, deviceid = opencl["platformid"], opencl["deviceid"] = platdev
-            devicetype = opencl["devicetype"] = ocl.platforms[platformid].devices[deviceid].type
+            else:
+                platformid, deviceid = opencl["platformid"], opencl["deviceid"]
+            devicetype = ocl.platforms[platformid].devices[deviceid].type
             platform = str(ocl.platforms[platformid]).split()[0]
             if devicetype == "CPU":
                 device = (str(ocl.platforms[platformid].devices[deviceid]).split("@")[0]).split()[-1]
             else:
                 device = ' '.join(str(ocl.platforms[platformid].devices[deviceid]).split())
 
-            print("Working on device: %s platform: %s device: %s" % (devicetype, platform, device))
-            method += "_%i,%i" % (opencl["platformid"], opencl["deviceid"])
+            print(f"Working on device: {devicetype} platform: {platform} device: {device} method {method}")
             # label = ("2D %s %s %s %s" % (devicetype, self.LABELS[method[1:4]], platform, device)).replace(" ", "_")
             label = f'{devicetype}:{platform} / 2D: {method.split_lower}_{method.algo_lower}_{method.impl_lower}' #Edgar
             memory_error = (pyopencl.MemoryError, MemoryError, pyopencl.RuntimeError, RuntimeError)
@@ -491,7 +492,9 @@ class Bench(object):
             try:
                 t0 = time.perf_counter()
                 _res = bench_test.stmt()
-                self.print_init(time.perf_counter() - t0)
+                t2 = time.perf_counter()
+                self.print_init(t2 - t0)
+                loops = int(ceil(self.nbr / (t2 - t0)))
             except memory_error as error:
                 print(error)
                 break
@@ -522,7 +525,7 @@ class Bench(object):
             bench_test.clean()
             try:
                 t = timeit.Timer(bench_test.stmt, bench_test.setup_and_stmt)
-                tmin = min([i / self.nbr for i in t.repeat(repeat=self.repeat, number=self.nbr)])
+                tmin = min([i / loops for i in t.repeat(repeat=self.repeat, number=loops)])
             except memory_error as error:
                 print(error)
                 break
@@ -741,9 +744,10 @@ def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,
 
     ocl_devices = []
     if ocl:
-        if devices and isinstance(devices, (tuple, list)) and len(devices) == 2:
-            ocl_devices = devices
-        else:
+        try:
+            ocl_devices = [(int(i), int(j)) for i,j in devices]
+        except Exception as err:
+            # print(f"{type(err)}: {err}\ndevices is not a list of 2-tuple of integrers, parsing the list")
             ocl_devices = []
             for i in ocl.platforms:
                 if devices == "all":
@@ -755,11 +759,11 @@ def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,
                         ocl_devices += [(i.id, j.id) for j in i.devices if j.type == "GPU"]
                     if "acc" in devices:
                         ocl_devices += [(i.id, j.id) for j in i.devices if j.type == "ACC"]
-        print("Devices:", ocl_devices)
+        print(f"Devices: {devices} --> {ocl_devices}")
 
     # Gather available methods
     if all:
-        methods_available = IntegrationMethod.select_method(dim=1)
+        methods_available = IntegrationMethod.select_method()
     else:
         methods_available = []
 
@@ -774,14 +778,21 @@ def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,
         for split in split_list:
             for algo in algo_list:
                 for impl in impl_list:
-                    for method in IntegrationMethod.select_method(dim=1, split=split, algo=algo, impl=impl):
-                        print(method)
-                        if method not in methods_available:
-                            methods_available.append(method)
-
+                    if do_1d:
+                        for method in IntegrationMethod.select_method(dim=1, split=split, algo=algo, impl=impl):
+                            print(method)
+                            if method not in methods_available:
+                                methods_available.append(method)
+                    if do_2d:
+                        for method in IntegrationMethod.select_method(dim=2, split=split, algo=algo, impl=impl):
+                            print(method)
+                            if method not in methods_available:
+                                methods_available.append(method)
+    print(methods_available)
     # Separate non-opencl from opencl methods
     methods_non_ocl, methods_ocl = [], []
     for method in methods_available:
+        print(method, method.impl_lower, method.target, ocl_devices)
         if method.impl_lower == 'opencl':
             if method.target in ocl_devices:
                 methods_ocl.append(method)
@@ -789,6 +800,7 @@ def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,
             if processor:
                 methods_non_ocl.append(method)
 
+    print(methods_ocl, methods_non_ocl)
     # Benchmark 1d integration
     if do_1d:
         if function == "all":
@@ -800,49 +812,55 @@ def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,
 
         # Benchmark No OpenCL devices
         for method in methods_non_ocl:
-            for function in function_list:
-                bench.bench_1d(
-                    method=method,
-                    check=True,
-                    opencl=None,
-                    function=function,
-                )
+            if method.dimension == 1:
+                for function in function_list:
+                    bench.bench_1d(
+                        method=method,
+                        check=True,
+                        opencl=None,
+                        function=function,
+                    )
 
         # Benchmark OpenCL devices
         for method in methods_ocl:
-            print("Working on device: " + str(method.target_name))
-            for function in function_list:
-                bench.bench_1d(
-                    method=method,
-                    check=True,
-                    opencl={"platformid": method.target[0], "deviceid": method.target[1]},
-                    function=function,
-                )
+            if method.dimension == 1:
+                print("Working on device: " + str(method.target_name))
+                for function in function_list:
+                    bench.bench_1d(
+                        method=method,
+                        check=True,
+                        opencl={"platformid": method.target[0], "deviceid": method.target[1]},
+                        function=function,
+                    )
 
-    # Benchmark 2d integration (reshaping)
+    # Benchmark 2d integration
     if do_2d:
+        print(do_2d, methods_non_ocl, methods_ocl)
+        if function == "all":
+            function_list = ["integrate2d_legacy", "integrate2d_ng"]
+        elif function == "ng":
+            function_list = ["integrate2d_ng"]
+        elif function == "legacy":
+            function_list = ["integrate2d_legacy"]
 
         # Benchmark No OpenCL devices
         for method in methods_non_ocl:
-            bench.bench_2d(
-                method=method,
-                check=False,
-                opencl=False,
-            )
+            if method.dimension == 2:
+                bench.bench_2d(
+                    method=method,
+                    check=False,
+                    opencl=False,
+                    function=function,
+                )
 
         # Benchmark OpenCL devices
-        # CRASHES, NOT WORKING YET
         for method in methods_ocl:
-            bench.bench_2d(
-                method=method,
-                check=False,
-                opencl={"platformid": method.target[0], "deviceid": method.target[1]},
-            )
-#         bench.bench_2d("splitBBox")
-#         bench.bench_2d("lut", True)
-#         for device in ocl_devices:
-# #             bench.bench_1d("lut_ocl", True, {"platformid": device[0], "deviceid": device[1]})
-#             bench.bench_1d("csr_ocl", True, {"platformid": device[0], "deviceid": device[1]})
+            if method.dimension == 2:
+                bench.bench_2d(
+                    method=method,
+                    check=False,
+                    opencl={"platformid": method.target[0], "deviceid": method.target[1]},
+                )
 
     bench.save()
     bench.print_res()

--- a/src/pyFAI/benchmark/__init__.py
+++ b/src/pyFAI/benchmark/__init__.py
@@ -657,10 +657,10 @@ class Bench(object):
 
             # Display detector markers (vertical lines)
             self.ax.vlines(
-                x=data_sizes, 
-                ymin=self.ax.get_ylim()[0], 
-                ymax=self.ax.get_ylim()[1], 
-                linestyles='dashed', 
+                x=data_sizes,
+                ymin=self.ax.get_ylim()[0],
+                ymax=self.ax.get_ylim()[1],
+                linestyles='dashed',
                 alpha=0.4,
                 colors='black',
             )
@@ -692,7 +692,7 @@ class Bench(object):
             bbox_to_anchor=(1.05,0.5),
             fontsize=10,
         )
-        self.fig.subplots_adjust(right=0.5) 
+        self.fig.subplots_adjust(right=0.5)
         update_fig(self.fig)
 
     def new_point(self, size, exec_time):
@@ -723,7 +723,7 @@ class Bench(object):
 
     def display_detector_markers(self):
         if not self.fig:
-            return     
+            return
 
     def update_mp(self):
         """

--- a/src/pyFAI/benchmark/__init__.py
+++ b/src/pyFAI/benchmark/__init__.py
@@ -362,7 +362,7 @@ class Bench(object):
             memory_error = (pyopencl.MemoryError, MemoryError, pyopencl.RuntimeError, RuntimeError)
         else:
             print("Working on processor: %s" % self.get_cpu())
-            # label = function + " " + self.LABELS[method.method[1:4]] 
+            # label = function + " " + self.LABELS[method.method[1:4]]
             label = f'CPU / {function}: {method.split_lower}_{method.algo_lower}_{method.impl_lower}' #Edgar
             memory_error = (MemoryError, RuntimeError)
         results = OrderedDict()
@@ -762,7 +762,7 @@ def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,
         methods_available = IntegrationMethod.select_method(dim=1)
     else:
         methods_available = []
-        
+
         # Clear list if "all" to avoid redundances
         if "all" in split_list:
             split_list = [None]

--- a/src/pyFAI/method_registry.py
+++ b/src/pyFAI/method_registry.py
@@ -34,7 +34,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "17/03/2023"
+__date__ = "20/12/2023"
 __status__ = "development"
 
 import inspect
@@ -405,3 +405,19 @@ class IntegrationMethod:
     @property
     def algo_is_sparse(self):
         return self.algo_lower in self.AVAILABLE_ALGOS[1:]
+
+    @property
+    def dim(self):
+        return self.dimension
+
+    @property
+    def algo(self):
+        return self.algorithm
+
+    @property
+    def split(self):
+        return self.pixel_splitting
+
+    @property
+    def impl(self):
+        return self.implementation


### PR DESCRIPTION
- [x] New parser arguments: pixel split, algorithm, implementation...
- [x] Correct typos and prints
- [ ] Update documentation
- [x] Fix integrate2d benchmark


New attributes for "pyFAI-benchmark" tool (only 1d integration works fine so far)

New arguments for argument parser:
- Pixel splitting argument (-ps, --pixelsplit): no, bbox, pseudo, full, all (default=bbox)
- Algorithm argument: histogram (-algo, --algorithm), CSR, CSC, LUT, all (default=histogram, CSR)
- Implementation argument (-i, --impl): python, cython, opencl, all (default=cython, opencl)
- Function argument (-f, --function): legacy, ng, all (default=all)
- all argument (--all) (boolean): if True, benchmarks every available method (default=False)
- Not processor argument (--no-proc): if used, skips the benchmark using the central processor (useful if you want to benchmark only GPU devices using --gpu)
- Some changes in the figure legends to be consistent with the documentation of AzimuthalIntegrator

![image](https://github.com/silx-kit/pyFAI/assets/112327909/a41379d8-43d8-4c26-84c8-c4422382a978)
