### PR TITLE
create RingExtraction class 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,3 @@ PyOpenGL
 PyQt5
 hdf5plugin
 nbsphinx
-pytest
-pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ PyOpenGL
 PyQt5
 hdf5plugin
 nbsphinx
+pytest
+pytest-mock

--- a/src/pyFAI/meson.build
+++ b/src/pyFAI/meson.build
@@ -32,6 +32,7 @@ py.install_sources(
     'method_registry.py',
     'multi_geometry.py',
     'parallax.py',
+    'ring_extraction.py'
     'spline.py',
     'units.py',
     'worker.py'],

--- a/src/pyFAI/meson.build
+++ b/src/pyFAI/meson.build
@@ -32,7 +32,7 @@ py.install_sources(
     'method_registry.py',
     'multi_geometry.py',
     'parallax.py',
-    'ring_extraction.py'
+    'ring_extraction.py',
     'spline.py',
     'units.py',
     'worker.py'],

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -1,0 +1,349 @@
+"""
+Module used for extracting control points in a calibrant image to be used for geometry refinement.
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional
+
+import numpy as np
+from silx.image import marchingsquares
+
+from pyFAI.control_points import ControlPoints
+from pyFAI.goniometer import SingleGeometry
+from pyFAI.massif import Massif
+
+logger = logging.getLogger(__name__)
+
+
+class RingExtraction:
+    """Class to perform extraction of control points from a calibration image."""
+
+    def __init__(
+        self,
+        single_geometry: SingleGeometry,
+        massif: Optional[Massif] = None,
+    ):
+        """
+        Parameters
+        ----------
+        single_geometry : SingleGeometry
+            instance of pyFAI class
+        massif : Optional[Massif]
+            instance of Massif class, which defines an area around a peak; it is used to find
+            neighboring peaks, by default None
+        """
+
+        self.single_geometry = single_geometry
+        self.image = self.single_geometry.image
+        self.detector = self.single_geometry.detector
+        self.calibrant = self.single_geometry.calibrant
+
+        if massif:
+            self.massif = massif
+        else:
+            if self.detector:
+                mask = self.detector.dynamic_mask(self.image)
+            else:
+                mask = None
+            self.massif = Massif(self.image, mask)
+
+        self.two_theta_array = self.single_geometry.geometry_refinement.twoThetaArray()
+        self.two_theta_values = self._get_unique_two_theta_values_in_image()
+
+    def extract_control_points(
+        self,
+        max_number_of_rings: Optional[int] = None,
+        points_per_degree: int = 1,
+    ) -> ControlPoints:
+        """
+        Primary method of RingExtraction class. Runs extract_control_points_in_one_ring for all
+        rings in image, or for max_number_of_rings, if not None.
+
+        Parameters
+        ----------
+        max_number_of_rings : Optional[int]
+            Maximum number of diffraction rings to extract points from, by default None
+        points_per_degree : int, optional
+            number of control points per azimuthal degree (increase for better precision), by
+            default 1
+
+        Returns
+        -------
+        ControlPoints
+            Instance of the pyFAI class with extracted peaks
+        """
+
+        control_points = ControlPoints(calibrant=self.calibrant)
+
+        if max_number_of_rings is None:
+            max_number_of_rings = self.two_theta_values.size
+
+        tasks = {}
+        with ThreadPoolExecutor() as executor:
+            for ring_index in range(
+                min(max_number_of_rings, self.two_theta_values.size)
+            ):
+                future = executor.submit(
+                    self.extract_list_of_peaks_in_one_ring,
+                    ring_index,
+                    points_per_degree,
+                )
+                tasks[future] = ring_index
+
+            for future in as_completed(tasks):
+                list_of_peaks_in_ring = future.result()
+                ring_index = tasks[future]
+                if list_of_peaks_in_ring:
+                    control_points.append(list_of_peaks_in_ring, ring_index)
+
+        return control_points
+
+    def extract_list_of_peaks_in_one_ring(
+        self,
+        ring_index: int,
+        points_per_degree: int = 1,
+    ) -> Optional[list[tuple[float, float]]]:
+        """
+        Using massif.peaks_from_area, get all pixel coordinates inside a mask of pixels around a
+        diffraction ring above a certain intensity, provided the desired number of points to keep,
+        and the minimum distance between peaks.
+
+        Parameters
+        ----------
+        ring_index : int
+            ring number
+        points_per_degree : int, optional
+            number of control points per azimuthal degree (increase for better precision), by
+            default 1
+
+        Returns
+        -------
+        Optional[List[Tuple[float]]]
+            peaks at given ring index
+        """
+        marching_squares_algorithm = marchingsquares.MarchingSquaresMergeImpl(
+            self.two_theta_array,
+            mask=self.detector.mask,
+            use_minmax_cache=True,
+        )
+
+        initial_mask = self._create_mask_around_ring(ring_index)
+
+        mask_size = initial_mask.sum(dtype=int)
+        if mask_size > 0:
+            final_mask, upper_limit = self._remove_low_intensity_pixels_from_mask(
+                initial_mask
+            )
+
+            pixels_at_two_theta_level = marching_squares_algorithm.find_pixels(
+                self.two_theta_values[ring_index]
+            )
+            seeds = set(
+                (i[0], i[1])
+                for i in pixels_at_two_theta_level
+                if final_mask[i[0], i[1]]
+            )
+
+            num_points_to_keep = self._calculate_num_of_points_to_keep(
+                pixels_at_two_theta_level,
+                points_per_degree,
+            )
+            if num_points_to_keep > 0:
+                min_distance_between_control_points = (
+                    len(seeds) / 2.0 / num_points_to_keep
+                )
+                # original code has a comment here which seems outdates, but I also didn't
+                # understand where this calculation comes from, so I just left it as is
+
+                logger.info(
+                    "Extracting datapoints for ring %s (2theta = %.2f deg); searching for %i pts"
+                    " out of %i with I>%.1f, dmin=%.1f",
+                    ring_index,
+                    np.degrees(self.two_theta_values[ring_index]),
+                    num_points_to_keep,
+                    final_mask.sum(dtype=int),
+                    upper_limit,
+                    min_distance_between_control_points,
+                )
+
+                return self.massif.peaks_from_area(
+                    final_mask,
+                    keep=num_points_to_keep,
+                    dmin=min_distance_between_control_points,
+                    seed=seeds,
+                    ring=ring_index,
+                )
+            return None
+        return None
+
+    def _get_unique_two_theta_values_in_image(self) -> np.ndarray:
+        """
+        Calculates all two theta values covered by the image with the current detector and geometry
+
+        Returns
+        -------
+        np.ndarray
+            array containing all two theta values for calibrant at present wavelength
+        """
+        two_theta_values = np.unique(
+            np.array([i for i in self.calibrant.get_2th() if i is not None])
+        )
+        largest_two_theta_in_image = self.two_theta_array.max()
+        two_theta_values_in_image = np.array(
+            [
+                two_theta
+                for two_theta in two_theta_values
+                if two_theta <= largest_two_theta_in_image
+            ]
+        )
+        return two_theta_values_in_image
+
+    def _create_mask_around_ring(self, ring_index: int) -> np.ndarray:
+        """
+        Creates a mask of valid pixels around each ring, of thickness equal to 1/2 the distance
+        between the centre of two adjacent rings.
+
+
+        Parameters
+        ----------
+        ring_index : int
+            Ring number
+
+        Returns
+        -------
+        np.ndarray
+            Mask of valid pixels around each ring
+        """
+        two_theta_min_max = self._get_two_theta_min_max(ring_index)
+        two_theta_min, two_theta_max = (
+            two_theta_min_max["min"],
+            two_theta_min_max["max"],
+        )
+
+        initial_mask = np.logical_and(
+            self.two_theta_array >= two_theta_min,
+            self.two_theta_array < two_theta_max,
+        )
+        if self.detector.mask is not None:
+            detector_mask_bool = self.detector.mask.astype(bool)
+            initial_mask &= ~detector_mask_bool
+
+        return initial_mask
+
+    def _get_two_theta_min_max(self, ring_index: int) -> dict[str, float]:
+        """
+        Calculates the distance between 2 consecutive rings (in radians), and returns an
+        interval equal to +- 1/4 of this distance centred around the ring position, namely
+        a minimum and maximum values for the two theta of the ring.
+
+        Parameters
+        ----------
+        ring_index : int
+            ring number
+        Returns
+        -------
+        dict[str, np.ndarray]
+            dictionary containing minimum and maximum values for two theta
+        """
+        if ring_index == 0:
+            delta_two_theta = (self.two_theta_values[1] - self.two_theta_values[0]) / 4
+        else:
+            delta_two_theta = (
+                self.two_theta_values[ring_index]
+                - self.two_theta_values[ring_index - 1]
+            ) / 4
+
+        two_theta_min = self.two_theta_values[ring_index] - delta_two_theta
+        two_theta_max = self.two_theta_values[ring_index] + delta_two_theta
+
+        return {"min": two_theta_min, "max": two_theta_max}
+
+    def _remove_low_intensity_pixels_from_mask(
+        self, mask: np.ndarray
+    ) -> tuple[np.ndarray, float]:
+        """
+        Creates a final mask of valid pixels to be used in peak extraction, by removing low
+        intensity pixels from the initial mask
+
+        Parameters
+        ----------
+        mask : np.ndarray
+            mask of valid pixels
+
+        Returns
+        -------
+        uple[np.ndarray, float]
+            final mask of valid pixels, upper limit of intensity to mask
+        """
+        mean, std = self._calculate_mean_and_std_of_intensities_in_mask(mask)
+        upper_limit = mean + std
+        high_pixel_intensity_coords = self.image > upper_limit
+        final_mask = np.logical_and(high_pixel_intensity_coords, mask)
+        final_mask_size = final_mask.sum(dtype=int)
+        minimum_mask_size = (
+            1000  # copied this from original method, don't know why this number
+        )
+        if final_mask_size < minimum_mask_size:
+            upper_limit = mean
+            final_mask = np.logical_and(self.image > upper_limit, mask)
+            final_mask_size = final_mask.sum()
+        return final_mask, upper_limit
+
+    def _calculate_mean_and_std_of_intensities_in_mask(
+        self, mask: np.ndarray
+    ) -> tuple[float, float]:
+        """
+        Calculates mean and standard deviation of pixel intensities of image which are emcompassed
+        by mask.
+
+        Parameters
+        ----------
+        mask : np.ndarray
+            mask of valid pixels
+
+        Returns
+        -------
+        tuple[float, float]
+            mean and standard deviation of pixel intensities
+        """
+        flattened_mask = mask.flatten()
+        flattened_image = self.image.flatten()
+        pixel_intensities_in_mask = flattened_image[np.where(flattened_mask)]
+        mean = pixel_intensities_in_mask.mean()
+        std = pixel_intensities_in_mask.std()
+
+        return mean, std
+
+    def _calculate_num_of_points_to_keep(
+        self,
+        pixels_at_two_theta_level: np.ndrray,
+        points_per_degree,
+    ) -> int:
+        """
+        Calculate number of azimuthal degrees in ring, then multiply by self.points_per_degree
+
+        Parameters
+        ----------
+        pixels_at_two_theta_level : np.ndarray
+            Array of pixels in the image located in the ring at the current two theta value
+        points_per_degree : int, optional
+            number of control points per azimuthal degree (increase for better precision)
+
+        Returns
+        -------
+        int
+            Number of points to keep as control points
+        """
+        image_shape = self.image.shape
+        azimuthal_angles_array = self.single_geometry.geometry_refinement.chiArray(
+            image_shape
+        )
+        azimuthal_degrees_array_in_ring = azimuthal_angles_array[
+            pixels_at_two_theta_level[:, 0].clip(0, image_shape[0]),
+            pixels_at_two_theta_level[:, 1].clip(0, image_shape[1]),
+        ]
+        number_of_azimuthal_degrees = np.unique(
+            np.rad2deg(azimuthal_degrees_array_in_ring).round()
+        ).size
+        return int(number_of_azimuthal_degrees * points_per_degree)

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -139,8 +139,8 @@ class RingExtraction:
     def extract_list_of_peaks_in_one_ring(
         self,
         ring_index: int,
-        points_per_degree: int = 1,
-    ) -> Optional[list[tuple[float, float]]]:
+        points_per_degree: float = 1.0
+        ):
         """
         Using massif.peaks_from_area, get all pixel coordinates inside a mask of pixels around a
         diffraction ring above a certain intensity, provided the desired number of points to keep,
@@ -150,9 +150,9 @@ class RingExtraction:
         ----------
         ring_index : int
             ring number
-        points_per_degree : int, optional
+        points_per_degree : float, optional
             number of control points per azimuthal degree (increase for better precision), by
-            default 1
+            default 1.0
 
         Returns
         -------

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -93,7 +93,7 @@ class RingExtraction:
     def extract_control_points(
         self,
         max_number_of_rings: Optional[int] = None,
-        points_per_degree: int = 1,
+        points_per_degree: float = 1,
     ) -> ControlPoints:
         """
         Primary method of RingExtraction class. Runs extract_control_points_in_one_ring for all
@@ -103,9 +103,9 @@ class RingExtraction:
         ----------
         max_number_of_rings : Optional[int]
             Maximum number of diffraction rings to extract points from, by default None
-        points_per_degree : int, optional
+        points_per_degree : float, optional
             number of control points per azimuthal degree (increase for better precision), by
-            default 1
+            default 1.0
 
         Returns
         -------
@@ -357,7 +357,7 @@ class RingExtraction:
     def _calculate_num_of_points_to_keep(
         self,
         pixels_at_two_theta_level: np.ndarray,
-        points_per_degree,
+        points_per_degree: float,
     ) -> int:
         """
         Calculate number of azimuthal degrees in ring, then multiply by self.points_per_degree
@@ -366,7 +366,7 @@ class RingExtraction:
         ----------
         pixels_at_two_theta_level : np.ndarray
             Array of pixels in the image located in the ring at the current two theta value
-        points_per_degree : int, optional
+        points_per_degree : float
             number of control points per azimuthal degree (increase for better precision)
 
         Returns

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -352,7 +352,7 @@ class RingExtraction:
 
     def _calculate_num_of_points_to_keep(
         self,
-        pixels_at_two_theta_level: np.ndrray,
+        pixels_at_two_theta_level: np.ndarray,
         points_per_degree,
     ) -> int:
         """

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -3,9 +3,11 @@
 #    Project: Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2012-2022 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2024-2024 Australian Synchrotron
+#                  2024-2024 European Synchrotron Radiation Facility, Grenoble, France
 #
-#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#    Principal author:       Emily Massahud
+#                            Jerome Kieffer
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -9,9 +9,9 @@ from typing import Optional
 import numpy as np
 from silx.image import marchingsquares
 
-from pyFAI.control_points import ControlPoints
-from pyFAI.goniometer import SingleGeometry
-from pyFAI.massif import Massif
+from .control_points import ControlPoints
+from .goniometer import SingleGeometry
+from .massif import Massif
 
 logger = logging.getLogger(__name__)
 

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -142,7 +142,7 @@ class RingExtraction:
         self,
         ring_index: int,
         points_per_degree: float = 1.0
-        ):
+    ) -> Optional[list[tuple[float, float]]]:
         """
         Using massif.peaks_from_area, get all pixel coordinates inside a mask of pixels around a
         diffraction ring above a certain intensity, provided the desired number of points to keep,

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -1,6 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2012-2022 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 """
 Module used for extracting control points in a calibrant image to be used for geometry refinement.
 """
+
+__authors__ = ["Emily Massahud", "Jérôme Kieffer"]
+__contact__ = "Jerome.Kieffer@ESRF.eu"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "28/02/2024"
+__status__ = "development"
+
 
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -38,7 +38,7 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 __date__ = "28/02/2024"
 __status__ = "development"
 
-
+from __future__ import annotations
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -31,6 +31,8 @@
 Module used for extracting control points in a calibrant image to be used for geometry refinement.
 """
 
+from __future__ import annotations
+
 __authors__ = ["Emily Massahud", "Jérôme Kieffer"]
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
@@ -38,7 +40,7 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 __date__ = "28/02/2024"
 __status__ = "development"
 
-from __future__ import annotations
+
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional

--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -308,7 +308,7 @@ class RingExtraction:
 
         Returns
         -------
-        uple[np.ndarray, float]
+        tuple[np.ndarray, float]
             final mask of valid pixels, upper limit of intensity to mask
         """
         mean, std = self._calculate_mean_and_std_of_intensities_in_mask(mask)

--- a/src/pyFAI/test/meson.build
+++ b/src/pyFAI/test/meson.build
@@ -38,6 +38,7 @@ py.install_sources(
     'test_preproc.py',
     'test_pyfai_api.py',
     'test_rectangle.py',
+    'test_ring_extraction.py',
     'test_saxs.py',
     'test_scripts.py',
     'test_sparse.py',

--- a/src/pyFAI/test/test_all.py
+++ b/src/pyFAI/test/test_all.py
@@ -37,7 +37,6 @@ __date__ = "26/01/2024"
 import sys
 import unittest
 import logging
-logger = logging.getLogger(__name__)
 
 from .utilstest import UtilsTest
 
@@ -95,6 +94,9 @@ from . import test_parallax
 from . import test_error_model
 from . import test_units
 from . import test_uncertainties
+from . import test_ring_extraction
+
+logger = logging.getLogger(__name__)
 
 
 def suite():
@@ -153,10 +155,12 @@ def suite():
     testsuite.addTest(test_parallax.suite())
     testsuite.addTest(test_error_model.suite())
     testsuite.addTest(test_uncertainties.suite())
+    testsuite.addTest(test_ring_extraction.suite())
+
     return testsuite
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner()
     if runner.run(suite()).wasSuccessful():
         UtilsTest.clean_up()

--- a/src/pyFAI/test/test_ring_extraction.py
+++ b/src/pyFAI/test/test_ring_extraction.py
@@ -1,0 +1,138 @@
+"""Test suite for RingExtraction class."""
+
+# from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from .. import ring_extraction
+from ..ring_extraction import RingExtraction
+
+
+@pytest.fixture
+def ring_extraction_instance(mocker):
+    single_geometry = mocker.MagicMock()
+    massif = mocker.MagicMock()
+    ring_extraction_inst = RingExtraction(single_geometry, massif)
+    two_theta_values = np.array([1, 2, 3, 4, 5])
+    ring_extraction_inst.two_theta_values = two_theta_values
+    return ring_extraction_inst
+
+
+@pytest.fixture
+def mock_numpy(mocker):
+    return mocker.patch(ring_extraction.__name__ + ".np")
+
+
+ring_extraction_attributes = [
+    "single_geometry",
+    "image",
+    "detector",
+    "calibrant",
+    "massif",
+    "two_theta_array",
+    "two_theta_values",
+]
+
+
+@pytest.mark.parametrize("attribute_name", ring_extraction_attributes)
+def test_calib(attribute_name, ring_extraction_instance):
+    assert hasattr(ring_extraction_instance, attribute_name)
+
+
+def test_extract_control_points(mocker, ring_extraction_instance):
+    # arrange
+    mock_control_points = mocker.patch(ring_extraction.__name__ + ".ControlPoints")
+    mock_extract_peaks_in_one_ring = mocker.patch.object(
+        ring_extraction_instance, "extract_list_of_peaks_in_one_ring"
+    )
+
+    # act
+    ring_extraction_instance.extract_control_points(max_number_of_rings=3)
+
+    # assert
+    mock_control_points.assert_called_once_with(
+        calibrant=ring_extraction_instance.calibrant
+    )
+
+    assert mock_extract_peaks_in_one_ring.call_count == 3
+    assert mock_extract_peaks_in_one_ring.call_args_list[0][0] == (
+        0,
+        1,
+    )
+    assert mock_extract_peaks_in_one_ring.call_args_list[1][0] == (
+        1,
+        1,
+    )
+    assert mock_extract_peaks_in_one_ring.call_args_list[2][0] == (
+        2,
+        1,
+    )
+
+
+def test_extract_list_of_peaks_in_one_ring(mocker, ring_extraction_instance):
+    # arrange
+    ones_array = np.ones((5, 5))
+
+    ring_extraction_instance.two_theta_array = ones_array
+    mock_marching_squares = mocker.patch(
+        ring_extraction.__name__ + ".marchingsquares.MarchingSquaresMergeImpl"
+    )
+    mock_create_mask_around_ring = mocker.patch.object(
+        ring_extraction_instance,
+        "_create_mask_around_ring",
+        return_value=ones_array,
+    )
+    mock_remove_low_intensity_pixels_from_mask = mocker.patch.object(
+        ring_extraction_instance,
+        "_remove_low_intensity_pixels_from_mask",
+        return_value=(ones_array, 0),
+    )
+    mock_calculate_num_of_points_to_keep = mocker.patch.object(
+        ring_extraction_instance,
+        "_calculate_num_of_points_to_keep",
+        return_value=5,
+    )
+
+    ring_extraction_instance.image = ones_array
+    ring_extraction_instance.detector.mask = "detector_mask_string"
+
+    # act
+    ring_extraction_instance.extract_list_of_peaks_in_one_ring(ring_index=1)
+
+    # assert
+    mock_marching_squares.assert_called_once()
+    assert np.array_equal(mock_marching_squares.call_args_list[0][0][0], ones_array)
+    assert mock_marching_squares.call_args_list[0][1]["mask"] == "detector_mask_string"
+    assert mock_marching_squares.call_args_list[0][1]["use_minmax_cache"]
+    mock_create_mask_around_ring.assert_called_once()
+    assert mock_create_mask_around_ring.call_args_list[0][0][0] == 1
+
+    mock_remove_low_intensity_pixels_from_mask.assert_called_once()
+    assert np.array_equal(
+        mock_remove_low_intensity_pixels_from_mask.call_args_list[0][0][0], ones_array
+    )
+
+    mock_calculate_num_of_points_to_keep.assert_called_once()
+
+    ring_extraction_instance.massif.peaks_from_area.assert_called_once()
+    assert np.array_equal(
+        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][0][0],
+        ones_array,
+    )
+    assert (
+        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["keep"]
+        == 5
+    )
+    assert (
+        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["dmin"]
+        == 0
+    )
+    assert (
+        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["seed"]
+        == set()
+    )
+    assert (
+        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["ring"]
+        == 1
+    )

--- a/src/pyFAI/test/test_ring_extraction.py
+++ b/src/pyFAI/test/test_ring_extraction.py
@@ -1,6 +1,38 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+#    Project: Azimuthal integration
+#             https://github.com/silx-kit/pyFAI
+#
+#    Copyright (C) 2015-2018 European Synchrotron Radiation Facility, Grenoble, France
+#
+#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 """Test suite for RingExtraction class."""
 
-# from unittest.mock import MagicMock
+__authors__ = ["Emily Massahud", "Jérôme Kieffer"]
+__contact__ = "Jérôme.Kieffer@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "28/02/2024"
 
 import numpy as np
 import pytest

--- a/src/pyFAI/test/test_ring_extraction.py
+++ b/src/pyFAI/test/test_ring_extraction.py
@@ -34,137 +34,356 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 __date__ = "28/02/2024"
 
+import unittest
+from unittest import mock
+
 import numpy as np
-import pytest
 
 from .. import ring_extraction
 from ..ring_extraction import RingExtraction
 
 
-@pytest.fixture
-def ring_extraction_instance(mocker):
-    single_geometry = mocker.MagicMock()
-    massif = mocker.MagicMock()
-    ring_extraction_inst = RingExtraction(single_geometry, massif)
-    two_theta_values = np.array([1, 2, 3, 4, 5])
-    ring_extraction_inst.two_theta_values = two_theta_values
-    return ring_extraction_inst
+class RingExtractionTestBase(unittest.TestCase):
+    def setUp(self):
+        self.single_geometry = mock.MagicMock()
+        self.massif = mock.MagicMock()
+        self.ring_extraction = RingExtraction(self.single_geometry, self.massif)
+        two_theta_values = np.array([1, 2, 3, 4, 5])
+        self.ring_extraction.two_theta_values = two_theta_values
+        self.ones_array = np.ones((5, 5))
+        self.ring_extraction.two_theta_array = self.ones_array
+        self.expected_two_theta_dictionary = {
+            "min": 0.75,
+            "max": 1.25,
+        }
+
+        self.mock_np = mock.patch(
+            ring_extraction.__name__ + ".np", autospec=True
+        ).start()
+
+    def tearDown(self):
+        mock.patch.stopall()
 
 
-@pytest.fixture
-def mock_numpy(mocker):
-    return mocker.patch(ring_extraction.__name__ + ".np")
+class TestCalibAttributes(RingExtractionTestBase):
+    def test_calib_attributes(self):
+        ring_extraction_attributes = [
+            "single_geometry",
+            "image",
+            "detector",
+            "calibrant",
+            "massif",
+            "two_theta_array",
+            "two_theta_values",
+        ]
+
+        for attribute_name in ring_extraction_attributes:
+            with self.subTest(attribute_name=attribute_name):
+                self.assertTrue(
+                    hasattr(self.ring_extraction, attribute_name),
+                    f"{attribute_name} is missing",
+                )
 
 
-ring_extraction_attributes = [
-    "single_geometry",
-    "image",
-    "detector",
-    "calibrant",
-    "massif",
-    "two_theta_array",
-    "two_theta_values",
-]
+class TestExtractControlPoints(RingExtractionTestBase):
+    def setUp(self):
+        super().setUp()
+        self.mock_control_points = mock.patch(
+            (ring_extraction.__name__ + ".ControlPoints")
+        ).start()
+        self.mock_extract_peaks_in_one_ring = mock.patch.object(
+            self.ring_extraction, "extract_list_of_peaks_in_one_ring"
+        ).start()
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def test_extract_control_points(self):
+        # Act
+        self.ring_extraction.extract_control_points(max_number_of_rings=3)
+
+        # Assert
+        self.mock_control_points.assert_called_once_with(
+            calibrant=self.ring_extraction.calibrant
+        )
+
+        self.assertEqual(self.mock_extract_peaks_in_one_ring.call_count, 3)
+        self.mock_extract_peaks_in_one_ring.assert_has_calls(
+            [
+                mock.call(0, 1),
+                mock.call(1, 1),
+                mock.call(2, 1),
+            ],
+            any_order=False,
+        )
 
 
-@pytest.mark.parametrize("attribute_name", ring_extraction_attributes)
-def test_calib(attribute_name, ring_extraction_instance):
-    assert hasattr(ring_extraction_instance, attribute_name)
+class TestExtractOneRing(RingExtractionTestBase):
+    def setUp(self):
+        super().setUp()
+        self.ring_extraction.detector.mask = "detector_mask_string"
+
+        self.mock_calculate_num_of_points_to_keep = mock.patch.object(
+            RingExtraction, "_calculate_num_of_points_to_keep", return_value=5
+        ).start()
+        self.mock_remove_low_intensity_pixels = mock.patch.object(
+            RingExtraction,
+            "_remove_low_intensity_pixels_from_mask",
+            return_value=(np.ones((5, 5)), 0),
+        ).start()
+        self.mock_create_mask_around_ring = mock.patch.object(
+            RingExtraction, "_create_mask_around_ring", return_value=np.ones((5, 5))
+        ).start()
+        self.mock_marching_squares = mock.patch(
+            ring_extraction.__name__ + ".marchingsquares.MarchingSquaresMergeImpl"
+        ).start()
+
+        def tearDown(self):
+            mock.patch.stopall()
+
+    def test_extract_list_of_peaks_in_one_ring(
+        self,
+    ):
+        # Act
+        self.ring_extraction.extract_list_of_peaks_in_one_ring(ring_index=1)
+
+        # Assert
+        self.mock_marching_squares.assert_called_once()
+        self.assertTrue(
+            np.array_equal(
+                self.mock_marching_squares.call_args_list[0][0][0], self.ones_array
+            )
+        )
+        self.assertEqual(
+            self.mock_marching_squares.call_args_list[0][1]["mask"],
+            "detector_mask_string",
+        )
+        self.assertTrue(
+            self.mock_marching_squares.call_args_list[0][1]["use_minmax_cache"], True
+        )
+
+        self.mock_create_mask_around_ring.assert_called_once_with(1)
+        self.mock_remove_low_intensity_pixels.assert_called_once()
+        self.assertTrue(
+            np.array_equal(
+                self.mock_remove_low_intensity_pixels.call_args_list[0][0][0],
+                self.ones_array,
+            )
+        )
+        self.mock_calculate_num_of_points_to_keep.assert_called_once()
+
+        self.ring_extraction.massif.peaks_from_area.assert_called_once()
+        self.assertTrue(
+            np.array_equal(
+                self.ring_extraction.massif.peaks_from_area.call_args_list[0][0][0],
+                self.ones_array,
+            )
+        )
+        self.assertEqual(
+            self.ring_extraction.massif.peaks_from_area.call_args_list[0][1]["keep"],
+            5,
+        )
+        self.assertEqual(
+            self.ring_extraction.massif.peaks_from_area.call_args_list[0][1]["dmin"],
+            0,
+        )
+        self.assertEqual(
+            self.ring_extraction.massif.peaks_from_area.call_args_list[0][1]["seed"],
+            set(),
+        )
+        self.assertEqual(
+            self.ring_extraction.massif.peaks_from_area.call_args_list[0][1]["ring"],
+            1,
+        )
 
 
-def test_extract_control_points(mocker, ring_extraction_instance):
-    # arrange
-    mock_control_points = mocker.patch(ring_extraction.__name__ + ".ControlPoints")
-    mock_extract_peaks_in_one_ring = mocker.patch.object(
-        ring_extraction_instance, "extract_list_of_peaks_in_one_ring"
-    )
+class TestGetUniqueTwoThetaValuesInImage(RingExtractionTestBase):
+    def test_get_unique_two_theta_values_in_image(
+        self,
+    ):
+        two_theta_values = np.array([0.5, 1, 1.5, 2, 2.5, 1])
+        self.ring_extraction.calibrant = mock.MagicMock()
+        self.mock_np.array.return_value = two_theta_values
 
-    # act
-    ring_extraction_instance.extract_control_points(max_number_of_rings=3)
+        # Act
+        self.ring_extraction._get_unique_two_theta_values_in_image()
 
-    # assert
-    mock_control_points.assert_called_once_with(
-        calibrant=ring_extraction_instance.calibrant
-    )
-
-    assert mock_extract_peaks_in_one_ring.call_count == 3
-    assert mock_extract_peaks_in_one_ring.call_args_list[0][0] == (
-        0,
-        1,
-    )
-    assert mock_extract_peaks_in_one_ring.call_args_list[1][0] == (
-        1,
-        1,
-    )
-    assert mock_extract_peaks_in_one_ring.call_args_list[2][0] == (
-        2,
-        1,
-    )
+        # Assert
+        self.ring_extraction.calibrant.get_2th.assert_called_once_with()
+        self.mock_np.unique.assert_called_once_with(two_theta_values)
 
 
-def test_extract_list_of_peaks_in_one_ring(mocker, ring_extraction_instance):
-    # arrange
-    ones_array = np.ones((5, 5))
+class TestCreateMaskAroundRing(RingExtractionTestBase):
+    def setUp(self):
+        super().setUp()
+        zeros_array = np.zeros((3, 3))
+        self.ring_extraction.two_theta_array = zeros_array
+        self.mock_get_two_theta_min_max = mock.patch.object(
+            RingExtraction,
+            "_get_two_theta_min_max",
+            return_value=self.expected_two_theta_dictionary,
+        ).start()
 
-    ring_extraction_instance.two_theta_array = ones_array
-    mock_marching_squares = mocker.patch(
-        ring_extraction.__name__ + ".marchingsquares.MarchingSquaresMergeImpl"
-    )
-    mock_create_mask_around_ring = mocker.patch.object(
-        ring_extraction_instance,
-        "_create_mask_around_ring",
-        return_value=ones_array,
-    )
-    mock_remove_low_intensity_pixels_from_mask = mocker.patch.object(
-        ring_extraction_instance,
-        "_remove_low_intensity_pixels_from_mask",
-        return_value=(ones_array, 0),
-    )
-    mock_calculate_num_of_points_to_keep = mocker.patch.object(
-        ring_extraction_instance,
-        "_calculate_num_of_points_to_keep",
-        return_value=5,
-    )
+    def tearDown(self):
+        mock.patch.stopall()
 
-    ring_extraction_instance.image = ones_array
-    ring_extraction_instance.detector.mask = "detector_mask_string"
+    def test_create_mask_around_ring(self):
+        # Act
+        self.ring_extraction._create_mask_around_ring(ring_index=0)
 
-    # act
-    ring_extraction_instance.extract_list_of_peaks_in_one_ring(ring_index=1)
+        # Assert
+        self.mock_get_two_theta_min_max.assert_called_once_with(0)
+        self.mock_np.logical_and.assert_called_once()
+        first_call_logical_and = (
+            np.zeros((3, 3), dtype=bool),
+            np.ones((3, 3), dtype=bool),
+        )
+        self.assertTrue(
+            np.array_equal(
+                self.mock_np.logical_and.call_args_list[0][0], first_call_logical_and
+            )
+        )
 
-    # assert
-    mock_marching_squares.assert_called_once()
-    assert np.array_equal(mock_marching_squares.call_args_list[0][0][0], ones_array)
-    assert mock_marching_squares.call_args_list[0][1]["mask"] == "detector_mask_string"
-    assert mock_marching_squares.call_args_list[0][1]["use_minmax_cache"]
-    mock_create_mask_around_ring.assert_called_once()
-    assert mock_create_mask_around_ring.call_args_list[0][0][0] == 1
 
-    mock_remove_low_intensity_pixels_from_mask.assert_called_once()
-    assert np.array_equal(
-        mock_remove_low_intensity_pixels_from_mask.call_args_list[0][0][0], ones_array
-    )
+class TestGetTwoThetaMinMax(RingExtractionTestBase):
+    def test_get_two_theta_min_max(self):
+        # Act
+        two_theta_dictionary = self.ring_extraction._get_two_theta_min_max(0)
 
-    mock_calculate_num_of_points_to_keep.assert_called_once()
+        # Assert
+        self.assertEqual(
+            set(two_theta_dictionary.keys()),
+            set(self.expected_two_theta_dictionary.keys()),
+        )
 
-    ring_extraction_instance.massif.peaks_from_area.assert_called_once()
-    assert np.array_equal(
-        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][0][0],
-        ones_array,
-    )
-    assert (
-        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["keep"]
-        == 5
-    )
-    assert (
-        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["dmin"]
-        == 0
-    )
-    assert (
-        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["seed"]
-        == set()
-    )
-    assert (
-        ring_extraction_instance.massif.peaks_from_area.call_args_list[0][1]["ring"]
-        == 1
-    )
+
+class TestRemoveLowIntensityPixelsFromMask(RingExtractionTestBase):
+    def setUp(self):
+        super().setUp()
+        self.mock_np.logical_and.side_effect = [
+            np.ones((3, 3), dtype=bool),
+            np.ones((3, 3), dtype=bool),
+            np.ones((32, 32), dtype=bool),
+        ]
+        self.mock_calculate_mean_and_std_of_intensities_in_mask = mock.patch.object(
+            RingExtraction,
+            "_calculate_mean_and_std_of_intensities_in_mask",
+            return_value=(0.9, 0.1),
+        ).start()
+        self.ring_extraction.image = np.ones((3, 3))
+        self.mock_mask = np.ones((3, 3), dtype=bool)
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def test_remove_low_intensity_pixels_from_mask(self):
+        # Act
+        (
+            final_mask,
+            upper_limit,
+        ) = self.ring_extraction._remove_low_intensity_pixels_from_mask(self.mock_mask)
+
+        # Assert
+        self.assertIsInstance(final_mask, np.ndarray)
+        self.assertEqual(upper_limit, 0.9)
+        self.mock_calculate_mean_and_std_of_intensities_in_mask.assert_called_once_with(
+            self.mock_mask
+        )
+
+        expected_first_call = (np.zeros((3, 3)), np.ones((3, 3)))
+        expected_second_call = (np.ones((3, 3)), np.ones((3, 3)))
+        actual_calls = self.mock_np.logical_and.call_args_list
+        self.assertEqual(
+            len(actual_calls), 2, "np.logical_and was not called twice as expected"
+        )
+        self.assertTrue(np.array_equal(actual_calls[0][0][0], expected_first_call[0]))
+        self.assertTrue(np.array_equal(actual_calls[0][0][1], expected_first_call[1]))
+        self.assertTrue(np.array_equal(actual_calls[1][0][0], expected_second_call[0]))
+        self.assertTrue(np.array_equal(actual_calls[1][0][1], expected_second_call[1]))
+
+    def test_remove_low_intensity_pixels_from_mask_enough_points(self):
+        # Act
+        self.ring_extraction._remove_low_intensity_pixels_from_mask(self.mock_mask)
+
+        # Assert
+        self.mock_calculate_mean_and_std_of_intensities_in_mask.assert_called_once_with(
+            self.mock_mask
+        )
+
+        expected_call_args = (np.zeros((3, 3)), np.ones((3, 3)))
+        actual_call_args = self.mock_np.logical_and.call_args_list[0][0]
+        self.assertTrue(np.array_equal(actual_call_args[0], expected_call_args[0]))
+        self.assertTrue(np.array_equal(actual_call_args[1], expected_call_args[1]))
+
+
+class TestCalcMeanStdOfIntensitiesInMask(RingExtractionTestBase):
+    def test_calculate_mean_and_std_of_intensities_in_mask(self):
+        mock_mask = mock.MagicMock()
+        mock_flattened_mask = np.ones(9, dtype=bool)
+        mock_mask.flatten.return_value = mock_flattened_mask
+
+        mock_image = mock.MagicMock()
+        mock_flattened_image = mock.MagicMock()
+        mock_image.flatten.return_value = mock_flattened_image
+        mock_pixel_intensities_in_mask = mock_flattened_image[
+            np.where(mock_flattened_mask)
+        ]
+        mean = 1
+        std = 0.1
+        mock_pixel_intensities_in_mask.mean.return_value = mean
+        mock_pixel_intensities_in_mask.std.return_value = std
+
+        self.ring_extraction.image = mock_image
+
+        # Act
+        result = self.ring_extraction._calculate_mean_and_std_of_intensities_in_mask(
+            mock_mask
+        )
+
+        # Assert
+        self.assertEqual(result, (mean, std))
+        mock_mask.flatten.assert_called_once_with()
+        mock_image.flatten.assert_called_once_with()
+        self.mock_np.where.assert_called_once_with(mock_flattened_mask)
+
+
+class TestCalcPointsToKeep(RingExtractionTestBase):
+    def test_calculate_num_of_points_to_keep(self):
+        self.ring_extraction.image = np.zeros((10, 10))
+        pixel_list_at_two_theta_level = np.array([[2, 2], [3, 3], [4, 4]])
+        sample_array = np.array([[1, 2], [3, 4]])
+
+        self.mock_np.unique.return_value = np.array([1, 2, 3, 4])
+        self.mock_np.rad2deg.return_value = sample_array
+        # Act
+        points_to_keep = self.ring_extraction._calculate_num_of_points_to_keep(
+            pixel_list_at_two_theta_level, 1
+        )
+
+        # Assert
+        self.single_geometry.geometry_refinement.chiArray.assert_called_once_with(
+            (10, 10)
+        )
+        self.mock_np.unique.assert_called_once_with(sample_array)
+        self.assertEqual(points_to_keep, 4)
+
+
+def suite():
+    testsuite = unittest.TestSuite()
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite.addTest(loader(TestCalibAttributes))
+    testsuite.addTest(loader(TestExtractControlPoints))
+    testsuite.addTest(loader(TestExtractOneRing))
+    testsuite.addTest(loader(TestGetUniqueTwoThetaValuesInImage))
+    testsuite.addTest(loader(TestCreateMaskAroundRing))
+    testsuite.addTest(loader(TestGetTwoThetaMinMax))
+    testsuite.addTest(loader(TestRemoveLowIntensityPixelsFromMask))
+    testsuite.addTest(loader(TestCalcMeanStdOfIntensitiesInMask))
+    testsuite.addTest(loader(TestCalcPointsToKeep))
+
+    return testsuite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/src/pyFAI/test/test_ring_extraction.py
+++ b/src/pyFAI/test/test_ring_extraction.py
@@ -4,9 +4,11 @@
 #    Project: Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2015-2018 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2024-2024 Australian Synchrotron
+#                  2024-2024 European Synchrotron Radiation Facility, Grenoble, France
 #
-#    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
+#    Principal author:       Emily Massahud
+#                            Jerome Kieffer
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
resolves #2078 
This is my implementation of `extract_cp` as a RingExtraction class. The 2 main things I changed here were adding threading inside  `extract_control_points` which runs `extract_list_of_peaks_in_one_ring` concurrently; and `_get_unique_two_theta_values_in_image` which sets `two_theta_values` array to only go to the max two_theta_value encompassed in the calibration image.
As I was making this I did see that @kif created a PR already to speed things up using cython, but I thought I'd send in the PR anyway to see if we could combine them together, as I made a class for it as well. My idea was to make the class to separate the many things `extract_cp` was doing into smaller methods for clarity and making testing easier.

And speaking of tests, I'd like some help running with the unit tests I wrote. We work with pytest as our testing suite, but I couldn't set it up in the project to make them run. I can commit the test module here with all the tests I wrote as well to get help. (just to begin with I am having issues resolving relative imports of my `ring_extraction` module to the test module, and an absolute import throws the error `ModuleNotFoundError: No module named 'pyFAI'`).