### PR TITLE
Calculate min dist between control points in RingExtraction #2094

### DIFF
--- a/src/pyFAI/ring_extraction.py
+++ b/src/pyFAI/ring_extraction.py
@@ -147,7 +147,7 @@ class RingExtraction:
 
         Returns
         -------
-        Optional[List[Tuple[float]]]
+        Optional[list[tuple[float, float]]]
             peaks at given ring index
         """
         marching_squares_algorithm = marchingsquares.MarchingSquaresMergeImpl(

--- a/src/pyFAI/test/test_ring_extraction.py
+++ b/src/pyFAI/test/test_ring_extraction.py
@@ -39,7 +39,7 @@ __date__ = "28/02/2024"
 import unittest
 from unittest import mock
 
-import numpy as np
+import numpy
 
 from .. import ring_extraction
 from ..ring_extraction import RingExtraction
@@ -50,18 +50,16 @@ class RingExtractionTestBase(unittest.TestCase):
         self.single_geometry = mock.MagicMock()
         self.massif = mock.MagicMock()
         self.ring_extraction = RingExtraction(self.single_geometry, self.massif)
-        two_theta_values = np.array([1, 2, 3, 4, 5])
+        two_theta_values = numpy.array([1, 2, 3, 4, 5])
         self.ring_extraction.two_theta_values = two_theta_values
-        self.ones_array = np.ones((5, 5))
+        self.ones_array = numpy.ones((5, 5))
         self.ring_extraction.two_theta_array = self.ones_array
         self.expected_two_theta_dictionary = {
             "min": 0.75,
             "max": 1.25,
         }
 
-        self.mock_np = mock.patch(
-            ring_extraction.__name__ + ".np", autospec=True
-        ).start()
+        self.mock_numpy = mock.patch(ring_extraction.__name__ + ".numpy", autospec=True).start()
 
     def tearDown(self):
         mock.patch.stopall()
@@ -90,9 +88,7 @@ class TestCalibAttributes(RingExtractionTestBase):
 class TestExtractControlPoints(RingExtractionTestBase):
     def setUp(self):
         super().setUp()
-        self.mock_control_points = mock.patch(
-            (ring_extraction.__name__ + ".ControlPoints")
-        ).start()
+        self.mock_control_points = mock.patch((ring_extraction.__name__ + ".ControlPoints")).start()
         self.mock_extract_peaks_in_one_ring = mock.patch.object(
             self.ring_extraction, "extract_list_of_peaks_in_one_ring"
         ).start()
@@ -105,9 +101,7 @@ class TestExtractControlPoints(RingExtractionTestBase):
         self.ring_extraction.extract_control_points(max_number_of_rings=3)
 
         # Assert
-        self.mock_control_points.assert_called_once_with(
-            calibrant=self.ring_extraction.calibrant
-        )
+        self.mock_control_points.assert_called_once_with(calibrant=self.ring_extraction.calibrant)
 
         self.assertEqual(self.mock_extract_peaks_in_one_ring.call_count, 3)
         self.mock_extract_peaks_in_one_ring.assert_has_calls(
@@ -131,10 +125,10 @@ class TestExtractOneRing(RingExtractionTestBase):
         self.mock_remove_low_intensity_pixels = mock.patch.object(
             RingExtraction,
             "_remove_low_intensity_pixels_from_mask",
-            return_value=(np.ones((5, 5)), 0),
+            return_value=(numpy.ones((5, 5)), 0),
         ).start()
         self.mock_create_mask_around_ring = mock.patch.object(
-            RingExtraction, "_create_mask_around_ring", return_value=np.ones((5, 5))
+            RingExtraction, "_create_mask_around_ring", return_value=numpy.ones((5, 5))
         ).start()
         self.mock_marching_squares = mock.patch(
             ring_extraction.__name__ + ".marchingsquares.MarchingSquaresMergeImpl"
@@ -152,22 +146,18 @@ class TestExtractOneRing(RingExtractionTestBase):
         # Assert
         self.mock_marching_squares.assert_called_once()
         self.assertTrue(
-            np.array_equal(
-                self.mock_marching_squares.call_args_list[0][0][0], self.ones_array
-            )
+            numpy.array_equal(self.mock_marching_squares.call_args_list[0][0][0], self.ones_array)
         )
         self.assertEqual(
             self.mock_marching_squares.call_args_list[0][1]["mask"],
             "detector_mask_string",
         )
-        self.assertTrue(
-            self.mock_marching_squares.call_args_list[0][1]["use_minmax_cache"], True
-        )
+        self.assertTrue(self.mock_marching_squares.call_args_list[0][1]["use_minmax_cache"], True)
 
         self.mock_create_mask_around_ring.assert_called_once_with(1)
         self.mock_remove_low_intensity_pixels.assert_called_once()
         self.assertTrue(
-            np.array_equal(
+            numpy.array_equal(
                 self.mock_remove_low_intensity_pixels.call_args_list[0][0][0],
                 self.ones_array,
             )
@@ -176,7 +166,7 @@ class TestExtractOneRing(RingExtractionTestBase):
 
         self.ring_extraction.massif.peaks_from_area.assert_called_once()
         self.assertTrue(
-            np.array_equal(
+            numpy.array_equal(
                 self.ring_extraction.massif.peaks_from_area.call_args_list[0][0][0],
                 self.ones_array,
             )
@@ -203,22 +193,22 @@ class TestGetUniqueTwoThetaValuesInImage(RingExtractionTestBase):
     def test_get_unique_two_theta_values_in_image(
         self,
     ):
-        two_theta_values = np.array([0.5, 1, 1.5, 2, 2.5, 1])
+        two_theta_values = numpy.array([0.5, 1, 1.5, 2, 2.5, 1])
         self.ring_extraction.calibrant = mock.MagicMock()
-        self.mock_np.array.return_value = two_theta_values
+        self.mock_numpy.array.return_value = two_theta_values
 
         # Act
         self.ring_extraction._get_unique_two_theta_values_in_image()
 
         # Assert
         self.ring_extraction.calibrant.get_2th.assert_called_once_with()
-        self.mock_np.unique.assert_called_once_with(two_theta_values)
+        self.mock_numpy.unique.assert_called_once_with(two_theta_values)
 
 
 class TestCreateMaskAroundRing(RingExtractionTestBase):
     def setUp(self):
         super().setUp()
-        zeros_array = np.zeros((3, 3))
+        zeros_array = numpy.zeros((3, 3))
         self.ring_extraction.two_theta_array = zeros_array
         self.mock_get_two_theta_min_max = mock.patch.object(
             RingExtraction,
@@ -235,14 +225,14 @@ class TestCreateMaskAroundRing(RingExtractionTestBase):
 
         # Assert
         self.mock_get_two_theta_min_max.assert_called_once_with(0)
-        self.mock_np.logical_and.assert_called_once()
+        self.mock_numpy.logical_and.assert_called_once()
         first_call_logical_and = (
-            np.zeros((3, 3), dtype=bool),
-            np.ones((3, 3), dtype=bool),
+            numpy.zeros((3, 3), dtype=bool),
+            numpy.ones((3, 3), dtype=bool),
         )
         self.assertTrue(
-            np.array_equal(
-                self.mock_np.logical_and.call_args_list[0][0], first_call_logical_and
+            numpy.array_equal(
+                self.mock_numpy.logical_and.call_args_list[0][0], first_call_logical_and
             )
         )
 
@@ -262,18 +252,18 @@ class TestGetTwoThetaMinMax(RingExtractionTestBase):
 class TestRemoveLowIntensityPixelsFromMask(RingExtractionTestBase):
     def setUp(self):
         super().setUp()
-        self.mock_np.logical_and.side_effect = [
-            np.ones((3, 3), dtype=bool),
-            np.ones((3, 3), dtype=bool),
-            np.ones((32, 32), dtype=bool),
+        self.mock_numpy.logical_and.side_effect = [
+            numpy.ones((3, 3), dtype=bool),
+            numpy.ones((3, 3), dtype=bool),
+            numpy.ones((32, 32), dtype=bool),
         ]
         self.mock_calculate_mean_and_std_of_intensities_in_mask = mock.patch.object(
             RingExtraction,
             "_calculate_mean_and_std_of_intensities_in_mask",
             return_value=(0.9, 0.1),
         ).start()
-        self.ring_extraction.image = np.ones((3, 3))
-        self.mock_mask = np.ones((3, 3), dtype=bool)
+        self.ring_extraction.image = numpy.ones((3, 3))
+        self.mock_mask = numpy.ones((3, 3), dtype=bool)
 
     def tearDown(self):
         mock.patch.stopall()
@@ -286,22 +276,20 @@ class TestRemoveLowIntensityPixelsFromMask(RingExtractionTestBase):
         ) = self.ring_extraction._remove_low_intensity_pixels_from_mask(self.mock_mask)
 
         # Assert
-        self.assertIsInstance(final_mask, np.ndarray)
+        self.assertIsInstance(final_mask, numpy.ndarray)
         self.assertEqual(upper_limit, 0.9)
         self.mock_calculate_mean_and_std_of_intensities_in_mask.assert_called_once_with(
             self.mock_mask
         )
 
-        expected_first_call = (np.zeros((3, 3)), np.ones((3, 3)))
-        expected_second_call = (np.ones((3, 3)), np.ones((3, 3)))
-        actual_calls = self.mock_np.logical_and.call_args_list
-        self.assertEqual(
-            len(actual_calls), 2, "np.logical_and was not called twice as expected"
-        )
-        self.assertTrue(np.array_equal(actual_calls[0][0][0], expected_first_call[0]))
-        self.assertTrue(np.array_equal(actual_calls[0][0][1], expected_first_call[1]))
-        self.assertTrue(np.array_equal(actual_calls[1][0][0], expected_second_call[0]))
-        self.assertTrue(np.array_equal(actual_calls[1][0][1], expected_second_call[1]))
+        expected_first_call = (numpy.zeros((3, 3)), numpy.ones((3, 3)))
+        expected_second_call = (numpy.ones((3, 3)), numpy.ones((3, 3)))
+        actual_calls = self.mock_numpy.logical_and.call_args_list
+        self.assertEqual(len(actual_calls), 2, "numpy.logical_and was not called twice as expected")
+        self.assertTrue(numpy.array_equal(actual_calls[0][0][0], expected_first_call[0]))
+        self.assertTrue(numpy.array_equal(actual_calls[0][0][1], expected_first_call[1]))
+        self.assertTrue(numpy.array_equal(actual_calls[1][0][0], expected_second_call[0]))
+        self.assertTrue(numpy.array_equal(actual_calls[1][0][1], expected_second_call[1]))
 
     def test_remove_low_intensity_pixels_from_mask_enough_points(self):
         # Act
@@ -312,24 +300,22 @@ class TestRemoveLowIntensityPixelsFromMask(RingExtractionTestBase):
             self.mock_mask
         )
 
-        expected_call_args = (np.zeros((3, 3)), np.ones((3, 3)))
-        actual_call_args = self.mock_np.logical_and.call_args_list[0][0]
-        self.assertTrue(np.array_equal(actual_call_args[0], expected_call_args[0]))
-        self.assertTrue(np.array_equal(actual_call_args[1], expected_call_args[1]))
+        expected_call_args = (numpy.zeros((3, 3)), numpy.ones((3, 3)))
+        actual_call_args = self.mock_numpy.logical_and.call_args_list[0][0]
+        self.assertTrue(numpy.array_equal(actual_call_args[0], expected_call_args[0]))
+        self.assertTrue(numpy.array_equal(actual_call_args[1], expected_call_args[1]))
 
 
 class TestCalcMeanStdOfIntensitiesInMask(RingExtractionTestBase):
     def test_calculate_mean_and_std_of_intensities_in_mask(self):
         mock_mask = mock.MagicMock()
-        mock_flattened_mask = np.ones(9, dtype=bool)
+        mock_flattened_mask = numpy.ones(9, dtype=bool)
         mock_mask.flatten.return_value = mock_flattened_mask
 
         mock_image = mock.MagicMock()
         mock_flattened_image = mock.MagicMock()
         mock_image.flatten.return_value = mock_flattened_image
-        mock_pixel_intensities_in_mask = mock_flattened_image[
-            np.where(mock_flattened_mask)
-        ]
+        mock_pixel_intensities_in_mask = mock_flattened_image[numpy.where(mock_flattened_mask)]
         mean = 1
         std = 0.1
         mock_pixel_intensities_in_mask.mean.return_value = mean
@@ -338,35 +324,31 @@ class TestCalcMeanStdOfIntensitiesInMask(RingExtractionTestBase):
         self.ring_extraction.image = mock_image
 
         # Act
-        result = self.ring_extraction._calculate_mean_and_std_of_intensities_in_mask(
-            mock_mask
-        )
+        result = self.ring_extraction._calculate_mean_and_std_of_intensities_in_mask(mock_mask)
 
         # Assert
         self.assertEqual(result, (mean, std))
         mock_mask.flatten.assert_called_once_with()
         mock_image.flatten.assert_called_once_with()
-        self.mock_np.where.assert_called_once_with(mock_flattened_mask)
+        self.mock_numpy.where.assert_called_once_with(mock_flattened_mask)
 
 
 class TestCalcPointsToKeep(RingExtractionTestBase):
     def test_calculate_num_of_points_to_keep(self):
-        self.ring_extraction.image = np.zeros((10, 10))
-        pixel_list_at_two_theta_level = np.array([[2, 2], [3, 3], [4, 4]])
-        sample_array = np.array([[1, 2], [3, 4]])
+        self.ring_extraction.image = numpy.zeros((10, 10))
+        pixel_list_at_two_theta_level = numpy.array([[2, 2], [3, 3], [4, 4]])
+        sample_array = numpy.array([[1, 2], [3, 4]])
 
-        self.mock_np.unique.return_value = np.array([1, 2, 3, 4])
-        self.mock_np.rad2deg.return_value = sample_array
+        self.mock_numpy.unique.return_value = numpy.array([1, 2, 3, 4])
+        self.mock_numpy.rad2deg.return_value = sample_array
         # Act
         points_to_keep = self.ring_extraction._calculate_num_of_points_to_keep(
             pixel_list_at_two_theta_level, 1
         )
 
         # Assert
-        self.single_geometry.geometry_refinement.chiArray.assert_called_once_with(
-            (10, 10)
-        )
-        self.mock_np.unique.assert_called_once_with(sample_array)
+        self.single_geometry.geometry_refinement.chiArray.assert_called_once_with((10, 10))
+        self.mock_numpy.unique.assert_called_once_with(sample_array)
         self.assertEqual(points_to_keep, 4)
 
 

--- a/src/pyFAI/test/test_ring_extraction.py
+++ b/src/pyFAI/test/test_ring_extraction.py
@@ -94,9 +94,6 @@ class TestExtractControlPoints(RingExtractionTestBase):
             self.ring_extraction, "extract_list_of_peaks_in_one_ring"
         ).start()
 
-    def tearDown(self):
-        mock.patch.stopall()
-
     def test_extract_control_points(self):
         # Act
         self.ring_extraction.extract_control_points(max_number_of_rings=3)
@@ -144,9 +141,6 @@ class TestExtractOneRing(RingExtractionTestBase):
             "_calculate_min_distance_between_control_points",
             return_value=0.1,
         ).start()
-
-    def tearDown(self):
-        mock.patch.stopall()
 
     def test_extract_list_of_peaks_in_one_ring(
         self,
@@ -232,9 +226,6 @@ class TestCreateMaskAroundRing(RingExtractionTestBase):
             return_value=self.expected_two_theta_dictionary,
         ).start()
 
-    def tearDown(self):
-        mock.patch.stopall()
-
     def test_create_mask_around_ring(self):
         # Act
         self.ring_extraction._create_mask_around_ring(ring_index=0)
@@ -280,9 +271,6 @@ class TestRemoveLowIntensityPixelsFromMask(RingExtractionTestBase):
         ).start()
         self.ring_extraction.image = numpy.ones((3, 3))
         self.mock_mask = numpy.ones((3, 3), dtype=bool)
-
-    def tearDown(self):
-        mock.patch.stopall()
 
     def test_remove_low_intensity_pixels_from_mask(self):
         # Act
@@ -379,9 +367,6 @@ class TestCalcMinDistBetweenControlPoints(RingExtractionTestBase):
             return_value=self.beam_centre_coords,
         ).start()
 
-    def tearDown(self):
-        mock.patch.stopall()
-
     def test_calculate_min_distance_between_control_points(self):
         # Arrange
         pixel_list_at_two_theta_level = [[5, 5]]
@@ -398,6 +383,22 @@ class TestCalcMinDistBetweenControlPoints(RingExtractionTestBase):
         self.assertAlmostEqual(min_dist_between_control_points, 0.0793309)
 
 
+class TestGetBeamCentreCoords(RingExtractionTestBase):
+    def setUp(self):
+        super().setUp()
+        self.numpy_patcher.stop()
+        self.mock_ai = self.single_geometry.get_ai.return_value
+        self.mock_ai.getFit2D.return_value = {"centerX": 1, "centerY": 2}
+
+    def test_get_beam_centre_coords(self):
+        # Act
+        beam_centre = self.ring_extraction._get_beam_centre_coords()
+
+        # Assert
+        self.single_geometry.get_ai().getFit2D.assert_called_once_with()
+        self.assertTrue(numpy.array_equal(beam_centre, numpy.array((2, 1))))
+
+
 def suite():
     testsuite = unittest.TestSuite()
     loader = unittest.defaultTestLoader.loadTestsFromTestCase
@@ -411,7 +412,7 @@ def suite():
     testsuite.addTest(loader(TestCalcMeanStdOfIntensitiesInMask))
     testsuite.addTest(loader(TestCalcPointsToKeep))
     testsuite.addTest(loader(TestCalcMinDistBetweenControlPoints))
-
+    testsuite.addTest(loader(TestGetBeamCentreCoords))
     return testsuite
 
 

--- a/src/pyFAI/test/test_ring_extraction.py
+++ b/src/pyFAI/test/test_ring_extraction.py
@@ -134,8 +134,8 @@ class TestExtractOneRing(RingExtractionTestBase):
             ring_extraction.__name__ + ".marchingsquares.MarchingSquaresMergeImpl"
         ).start()
 
-        def tearDown(self):
-            mock.patch.stopall()
+    def tearDown(self):
+        mock.patch.stopall()
 
     def test_extract_list_of_peaks_in_one_ring(
         self,


### PR DESCRIPTION
Apart from what I discussed in issue #2094, I also increased max line length of the formatter so the code looks less verbose (as jerome mentioned in a previous comment) and changed from `np` to `numpy`.
