### PR TITLE
additional possibilities in diffmap

### DIFF
--- a/src/pyFAI/diffmap.py
+++ b/src/pyFAI/diffmap.py
@@ -230,11 +230,11 @@ If the number of files is too large, use double quotes like "*.edf" """
             ai = {}
 
         ai_keys = [
-            "wavelength", 
-            "dist", 
-            "poni1", "poni2", 
-            "rot1", "rot2", "rot3", 
-            "detector", "detector_config", 
+            "wavelength",
+            "dist",
+            "poni1", "poni2",
+            "rot1", "rot2", "rot3",
+            "detector", "detector_config",
             "nbpt_rad", "nbpt_azim",
         ]
         for poni_key in ai_keys:

--- a/src/pyFAI/diffmap.py
+++ b/src/pyFAI/diffmap.py
@@ -226,20 +226,10 @@ If the number of files is too large, use double quotes like "*.edf" """
         self.inputfiles = [i[0] for i in config.get("input_data", [])]
         if "ai" in config:
             ai = config["ai"]
+        elif config.get("application", None) == "pyfai-integrate":
+            ai = config.copy()
         else:
             ai = {}
-
-        ai_keys = [
-            "wavelength",
-            "dist",
-            "poni1", "poni2",
-            "rot1", "rot2", "rot3",
-            "detector", "detector_config",
-            "nbpt_rad", "nbpt_azim",
-        ]
-        for poni_key in ai_keys:
-            if not poni_key in ai.keys() and config.get(poni_key, None):
-                ai[poni_key] = config[poni_key]
 
         self.poni = config["ai"] = ai
         if "output_file" in config:
@@ -272,7 +262,7 @@ If the number of files is too large, use double quotes like "*.edf" """
             else:
                 raise RuntimeError("No such flat files")
 
-        if ocl and (options.gpu or 'opencl' in config.get("method", "")):
+        if ocl and options.gpu:
             ai["opencl_device"] = ocl.select_device(type="gpu")
             ai["method"] = ["full", "csr", "opencl"]
 
@@ -289,15 +279,6 @@ If the number of files is too large, use double quotes like "*.edf" """
 
         if options.mask:
             mask = urlparse(options.mask).path
-            if os.path.isfile(mask):
-                logger.info("Reading Mask file from: %s", mask)
-                self.mask = os.path.abspath(mask)
-                ai["mask_file"] = self.mask
-                ai["do_mask"] = True
-            else:
-                logger.warning("No such mask file %s", mask)
-        elif config.get("do_mask", None) and config.get("mask_file", None):
-            mask = urlparse(config["mask_file"]).path
             if os.path.isfile(mask):
                 logger.info("Reading Mask file from: %s", mask)
                 self.mask = os.path.abspath(mask)


### PR DESCRIPTION
Now, diffmap works by using a config file generated by pyFAI-integrate, + adding manually the additional needed parameters (output_file, input_file slow_points, fast_points:

```
pyFAI-diffmap ../pilx_test/RAW_DATA/scan0001/eiger/eiger_0000.h5 --config ../pilx_test/config.json -o /tmp/kk.h5 -r 6 -t 6 --no-gui
```
Before, even if the integration parameters are all there, it was not using them. Now it loads the poni parameters, nbpt_rad and nbpt_azim into the config["ai"] dictionary, takes the mask parameter from the .json file and if the method contains opencl, it takes it (before that, it only goes opencl if it's explicitly typed in CLI)

Json file:

```
{
    "application": "pyfai-integrate",
    "version": 3,
    "wavelength": 3.7380000000000004e-11,
    "dist": 0.18352000680503333,
    "poni1": 0.13032588094799352,
    "poni2": 0.11127533501437878,
    "rot1": 0.014561540164214496,
    "rot2": -0.010992447540998289,
    "rot3": 2.1944567622347524e-09,
    "detector": "Eiger2CdTe_9M",
    "detector_config": {
        "orientation": 3
    },
    "do_mask": true,
    "mask_file": "fabio:///users/edgar1993a/work/pilx_test/mask.npy",
    "do_dark": false,
    "dark_current": null,
    "do_flat": false,
    "flat_field": null,
    "do_polarization": false,
    "polarization_factor": 0.0,
    "do_dummy": false,
    "val_dummy": null,
    "delta_dummy": null,
    "do_2D": true,
    "nbpt_rad": 3000,
    "unit": "2th_deg",
    "do_radial_range": false,
    "radial_range_min": null,
    "radial_range_max": null,
    "do_azimuthal_range": false,
    "azimuth_range_min": null,
    "azimuth_range_max": null,
    "chi_discontinuity_at_0": false,
    "do_solid_angle": true,
    "error_model": null,
    "method": [
        "bbox",
        "csr",
        "opencl"
    ],
    "opencl_device": [
        0,
        0
    ]

```