### PR TITLE
transform one dataset to list

### DIFF
--- a/src/pyFAI/io/spots.py
+++ b/src/pyFAI/io/spots.py
@@ -307,6 +307,8 @@ def save_spots_cxi(filename, spots, beamline="beamline", ai=None, source=None, e
                         logger.error(f"file {file_src} of type {type(fimg)} has not dataset attribute, skipping ({type(err)}: {err})")
                         datagrp.create_dataset("data", data=_stack_frames(fimg), **cmp).attrs["interpretation"] = "image"
                     else:
+                        if isinstance(lst_ds, h5py.Dataset):
+                            lst_ds = [lst_ds]
                         if len(lst_ds) == 1:
                             datagrp["data"] = h5py.ExternalLink(file_src, lst_ds[0].name)
                             # datagrp[f"data"].attrs["interpretation"] = "image"


### PR DESCRIPTION
f = fabio.open(file.h5)
if f is a LimaImage instance from fabio, f.dataset is a h5py.dataset, so len(f.dataset) is the number of frames inside the dataset

But if f is an EigerImage instance, f.dataset is a list, (with 1 or more items):

```
In [22]: f = fabio.open('/data/scisoft/edgar/collect_01_00001_data_000001.h5')

In [23]: type(f)
Out[23]: fabio.eigerimage.EigerImage

In [24]: f.dataset
Out[24]: [<HDF5 dataset "data": shape (100, 2167, 2070), type "<u4">]

In [25]: len(f.dataset)
Out[25]: 1

In [26]: f = fabio.open('/data/scisoft/edgar/lysozyme_100T-lysozyme_100T0000.h5')

In [27]: type(f)
Out[27]: fabio.limaimage.LimaImage

In [28]: f.dataset
Out[28]: <HDF5 dataset "data": shape (1000, 2164, 2068), type "<i4">

In [29]: len(f.dataset)
Out[29]: 1000


```