### PR TITLE
[pilx] new features

### DIFF
--- a/src/pyFAI/diffmap.py
+++ b/src/pyFAI/diffmap.py
@@ -293,6 +293,8 @@ If the number of files is too large, use double quotes like "*.edf" """
             mask = urlparse(options.mask).path
         elif config.get("do_mask", False) or config.get("mask_file", None):
             mask = urlparse(config.get("mask_file", None)).path
+        else:
+            mask = ""
         if os.path.isfile(mask):
             logger.info("Reading Mask file from: %s", mask)
             self.mask = os.path.abspath(mask)

--- a/src/pyFAI/diffmap.py
+++ b/src/pyFAI/diffmap.py
@@ -291,13 +291,15 @@ If the number of files is too large, use double quotes like "*.edf" """
 
         if options.mask:
             mask = urlparse(options.mask).path
-            if os.path.isfile(mask):
-                logger.info("Reading Mask file from: %s", mask)
-                self.mask = os.path.abspath(mask)
-                ai["mask_file"] = self.mask
-                ai["do_mask"] = True
-            else:
-                logger.warning("No such mask file %s", mask)
+        elif config.get("do_mask", False) or config.get("mask_file", None):
+            mask = urlparse(config.get("mask_file", None)).path
+        if os.path.isfile(mask):
+            logger.info("Reading Mask file from: %s", mask)
+            self.mask = os.path.abspath(mask)
+            ai["mask_file"] = self.mask
+            ai["do_mask"] = True
+        else:
+            logger.warning("No such mask file %s", mask)
         if options.poni:
             if os.path.isfile(options.poni):
                 logger.info("Reading PONI file from: %s", options.poni)

--- a/src/pyFAI/gui/pilx/MainWindow.py
+++ b/src/pyFAI/gui/pilx/MainWindow.py
@@ -194,7 +194,7 @@ class MainWindow(qt.QMainWindow):
                 maskfile = bytes.decode(h5file['entry_0000']['pyFAI']['maskfile'][()])
             else:
                 maskfile = None
-            
+
         if maskfile:
             mask_image = get_data(url=DataUrl(maskfile))
             if mask_image.shape != image.shape:

--- a/src/pyFAI/gui/pilx/MainWindow.py
+++ b/src/pyFAI/gui/pilx/MainWindow.py
@@ -143,7 +143,7 @@ class MainWindow(qt.QMainWindow):
     def getRoiRadialRange(self) -> Tuple[float | None, float | None]:
         return self._integrated_plot_widget.roi.getRange()
 
-    def displayPatternAtIndices(self, indices: ImageIndices, legend: str):
+    def displayPatternAtIndices(self, indices: ImageIndices, legend: str, color: str=None):
         if self._file_name is None:
             return
 
@@ -159,7 +159,6 @@ class MainWindow(qt.QMainWindow):
             y=curve,
             legend=legend,
             selectable=False,
-            color=self.getAvailableColor(legend),
             resetzoom=self._integrated_plot_widget.getGraphXLimits() == (0, 100),
         )
         self._integrated_plot_widget.setGraphXLabel(point._x_name)
@@ -228,17 +227,19 @@ class MainWindow(qt.QMainWindow):
         # Fix the point
         else:
             self._fixed_indices.add(indices)
+
+            legend = f"INTEGRATE_{indices.row}_{indices.col}"
             self.displayPatternAtIndices(
                 indices,
-                legend=f"INTEGRATE_{indices.row}_{indices.col}",
+                legend=legend,
             )
+            used_color = self._integrated_plot_widget.getCurve(legend=legend).getColor()
+
             self.displayImageAtIndices(indices)
             pixel_center_coords = self._map_plot_widget.findCenterOfNearestPixel(x, y)
             self._map_plot_widget.addMarker(
                 *pixel_center_coords,
-                color=self.getCurveColor(
-                    legend=f"INTEGRATE_{indices.row}_{indices.col}"
-                ),
+                color=used_color,
                 symbol="d",
                 legend=f"MAP_LOCATION_{indices.row}_{indices.col}",
             )
@@ -321,11 +322,6 @@ class MainWindow(qt.QMainWindow):
             color = self._integrated_plot_widget.getCurve(legend=legend).getColor()
         else:
             color, style = self._integrated_plot_widget._getColorAndStyle()
-            # index_color = 0
-            # color = rgba(self._integrated_plot_widget.getDefaultColors()[index_color])
-            # while color in [self._integrated_plot_widget.getCurve(legend=legend).getColor() for legend in self._integrated_plot_widget]:
-            #     index_color += 1
-            #     color = rgba(self._integrated_plot_widget.getDefaultColors()[index_color])
         return color
 
     def setNewBackgroundCurve(self, x: float, y: float):

--- a/src/pyFAI/gui/pilx/widgets/DiffractionImagePlotWidget.py
+++ b/src/pyFAI/gui/pilx/widgets/DiffractionImagePlotWidget.py
@@ -38,18 +38,20 @@ __status__ = "development"
 
 import numpy
 from silx.gui.plot.items import ImageData
+from silx.gui.colors import Colormap
 
 from .ImagePlotWidget import ImagePlotWidget
 from ..models import ROI_COLOR, ImageIndices
 
 _LEGEND = "IMAGE"
 
+DEFAULT_COLORMAP = Colormap(name="viridis")
 
 class DiffractionImagePlotWidget(ImagePlotWidget):
 
     def __init__(self, parent=None, backend=None):
         super().__init__(parent, backend)
-        image_item = self.addImage([[]], legend=_LEGEND)
+        image_item = self.addImage([[]], legend=_LEGEND, colormap=DEFAULT_COLORMAP)
         assert isinstance(image_item, ImageData)
         self._image_item = image_item
         self._first_plot = True


### PR DESCRIPTION
- [x] Plot with 10 available colors. Before, there was the period was 5 colors, because even if you provide the addCurve method with a color, if the curve is new, the silx method request a color again, so every time we plot a new curve, the index of the color advances 2 steps. So, at the time of adding a curve, I let the addCurve request the next color, then we retrieve manually that color and use it to plot the marker
- [x] Viridis as default colormap
- [x] Mask is applied on the pattern, only if pyFAI-diffmap saves the dataset 'maskfile', which is not happening on every situation (open another issue)
- [x] Re-wire pyFAI-diffmap to incorporate masks in the output file