### PR TITLE
Add "absorption" kwarg to integrate1d_ng and sigmaclip_ng

### DIFF
--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -3261,6 +3261,7 @@ class AzimuthalIntegrator(Geometry):
                       normalization_factor=1.0,
                       metadata=None,
                       safe=True,
+                      absorption=None,
                        **kwargs):
         """Performs iteratively the 1D integration with variance propagation
         and performs a sigm-clipping at each iteration, i.e.
@@ -3302,6 +3303,7 @@ class AzimuthalIntegrator(Geometry):
         :param metadata: any other metadata,
         :type metadata: JSON serializable dict
         :param safe: set to False to skip some tests
+        :param ndarray absorption: Detector absorption (image)
         :return: Integrate1D like result like
 
         The difference with the previous `sigma_clip_legacy` implementation is that there is no 2D regrouping.
@@ -3508,7 +3510,7 @@ class AzimuthalIntegrator(Geometry):
                     integr = self.engines[method].engine
                 kwargs = {"dark":dark, "dummy":dummy, "delta_dummy":delta_dummy,
                           "variance":variance, "dark_variance":None,
-                          "flat":flat, "solidangle":solidangle, "polarization":polarization, "absorption":None,
+                          "flat":flat, "solidangle":solidangle, "polarization":polarization, "absorption":absorption,
                           "error_model":error_model, "normalization_factor":normalization_factor,
                           "cutoff":thres, "cycle":max_iter}
 

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1509,8 +1509,8 @@ class AzimuthalIntegrator(Geometry):
                                mask=mask,
                                pos0_range=radial_range,
                                pos1_range=azimuth_range,
-                               error_model=error_model,
-                               absorption=absorption)
+                               error_model=error_model)
+                               # absorption=absorption) # Not supported
             elif method.method[1] == "full":
                 pos = self.array_from_unit(shape, "corner", unit, scale=False)
                 intpl = integr(weights=data, variance=variance,
@@ -1524,8 +1524,8 @@ class AzimuthalIntegrator(Geometry):
                                mask=mask,
                                pos0_range=radial_range,
                                pos1_range=azimuth_range,
-                               error_model=error_model,
-                               absorption=absorption)
+                               error_model=error_model)
+                               # absorption=absorption) # Not supported
             else:
                 raise RuntimeError("Should not arrive here")
             if error_model.do_variance:

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1101,7 +1101,7 @@ class AzimuthalIntegrator(Geometry):
                        polarization_factor=None, dark=None, flat=None,
                        method=("bbox", "csr", "cython"), unit=units.Q, safe=True,
                        normalization_factor=1.0,
-                       metadata=None):
+                       metadata=None, absorption=None):
         """Calculate the azimuthal integration (1d) of a 2D image.
 
         Multi algorithm implementation (tries to be bullet proof), suitable for SAXS, WAXS, ... and much more
@@ -1131,6 +1131,7 @@ class AzimuthalIntegrator(Geometry):
         :param bool safe: Perform some extra checks to ensure LUT/CSR is still valid. False is faster.
         :param float normalization_factor: Value of a normalization monitor
         :param metadata: JSON serializable object containing the metadata, usually a dictionary.
+        :param ndarray absorption: detector absorption
         :return: Integrate1dResult namedtuple with (q,I,sigma) +extra informations in it.
         """
         method = self._normalize_method(method, dim=1, default=self.DEFAULT_METHOD_1D)
@@ -1266,7 +1267,8 @@ class AzimuthalIntegrator(Geometry):
                                             solidangle=solidangle,
                                             polarization=polarization,
                                             normalization_factor=normalization_factor,
-                                            weighted_average=method.weighted_average)
+                                            weighted_average=method.weighted_average,
+                                            absorption=absorption)
             else:  # method.impl_lower in ("opencl", "python"):
                 if method not in self.engines:
                     # instanciated the engine
@@ -1354,6 +1356,7 @@ class AzimuthalIntegrator(Geometry):
                                             polarization=polarization,
                                             normalization_factor=normalization_factor,
                                             weighted_average=method.weighted_average,
+                                            absorption=absorption,
                                             ** kwargs)
             # This section is common to all 3 CSR implementations...
             if error_model.do_variance:
@@ -1396,7 +1399,8 @@ class AzimuthalIntegrator(Geometry):
                            weighted_average=method.weighted_average,
                            mask=mask,
                            radial_range=radial_range,
-                           error_model=error_model)
+                           error_model=error_model,
+                           absorption=absorption)
 
             if error_model.do_variance:
                 result = Integrate1dResult(intpl.position * unit.scale,
@@ -1466,7 +1470,8 @@ class AzimuthalIntegrator(Geometry):
                                weighted_average=method.weighted_average,
                                radial_range=radial_range,
                                azimuth_range=azimuth_range,
-                               error_model=error_model)
+                               error_model=error_model,
+                               absorption=absorption)
 
             if error_model.do_variance:
                 result = Integrate1dResult(intpl.position * unit.scale,
@@ -1504,7 +1509,8 @@ class AzimuthalIntegrator(Geometry):
                                mask=mask,
                                pos0_range=radial_range,
                                pos1_range=azimuth_range,
-                               error_model=error_model)
+                               error_model=error_model,
+                               absorption=absorption)
             elif method.method[1] == "full":
                 pos = self.array_from_unit(shape, "corner", unit, scale=False)
                 intpl = integr(weights=data, variance=variance,
@@ -1518,7 +1524,8 @@ class AzimuthalIntegrator(Geometry):
                                mask=mask,
                                pos0_range=radial_range,
                                pos1_range=azimuth_range,
-                               error_model=error_model)
+                               error_model=error_model,
+                               absorption=absorption)
             else:
                 raise RuntimeError("Should not arrive here")
             if error_model.do_variance:

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1464,7 +1464,7 @@ class AzimuthalIntegrator(Geometry):
                                delta_dummy=delta_dummy,
                                variance=variance,
                                flat=flat, solidangle=solidangle,
-                               polarization=polarization, absorption=absorption
+                               polarization=polarization, absorption=absorption,
                                polarization_checksum=polarization_crc,
                                normalization_factor=normalization_factor,
                                weighted_average=method.weighted_average,

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "12/06/2024"
+__date__ = "18/06/2024"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 


### PR DESCRIPTION
This PR makes the `absorption` parameter usable from high-level functions `integrate1d_ng` and `sigmaclip_ng`. 

For `integrate1d_ng` there are lots of different class instantiations depending on the model/implementation/etc ; not sure all of them support the `absorption` parameter.

Also perhaps this parameter should be made visible to other functions.