### PR TITLE
This pull request addresses issue #2221

### DIFF
--- a/src/pyFAI/average.py
+++ b/src/pyFAI/average.py
@@ -589,6 +589,8 @@ class MultiFilesAverageWriter(AverageWriter):
                             image.write(file_name)
                             logger.info("Wrote %s", file_name)
         
+        if self._dry_run:
+            image = self._fabio_class.__class__(data=data, header=header)
         self._fabio_images[algorithm] = image
 
     def get_fabio_image(self, algorithm):

--- a/src/pyFAI/average.py
+++ b/src/pyFAI/average.py
@@ -588,7 +588,7 @@ class MultiFilesAverageWriter(AverageWriter):
                             file_name=f"{base_name}_channel_{i}{ext}"
                             image.write(file_name)
                             logger.info("Wrote %s", file_name)
-        
+
         if self._dry_run:
             image = self._fabio_class.__class__(data=data, header=header)
         self._fabio_images[algorithm] = image

--- a/src/pyFAI/average.py
+++ b/src/pyFAI/average.py
@@ -561,7 +561,7 @@ class MultiFilesAverageWriter(AverageWriter):
             header[name] = str(value)
 
         if not self._dry_run:
-        #####    
+       
             import os
             dim = len(data.shape)
 
@@ -588,7 +588,7 @@ class MultiFilesAverageWriter(AverageWriter):
                             file_name=f"{base_name}_channel_{i}{ext}"
                             image.write(file_name)
                             logger.info("Wrote %s", file_name)
-        #####
+        
         self._fabio_images[algorithm] = image
 
     def get_fabio_image(self, algorithm):

--- a/src/pyFAI/average.py
+++ b/src/pyFAI/average.py
@@ -36,6 +36,7 @@ import logging
 import numpy
 import fabio
 import weakref
+import os
 from scipy import ndimage
 from scipy.interpolate import interp1d
 from scipy.optimize import fmin
@@ -561,8 +562,6 @@ class MultiFilesAverageWriter(AverageWriter):
             header[name] = str(value)
 
         if not self._dry_run:
-
-            import os
             dim = len(data.shape)
 
             try:


### PR DESCRIPTION
Added option to save 4D data after reduction where the dimension is: N_frames x Channel x X_dim x Y_dim:

one file with 4D data,i.e., like NumPy format 
append frames to stack, i.e., like edf
create separate files for each channel, i.e., like  tif (Pilatus) 

