### PR TITLE
[GIWAXS] force split_pixel=no

### DIFF
--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1874,7 +1874,7 @@ class AzimuthalIntegrator(Geometry):
                                     correctSolidAngle=correctSolidAngle,
                                     mask=mask, dummy=dummy, delta_dummy=delta_dummy,
                                     polarization_factor=polarization_factor, dark=dark, flat=flat,
-                                    method=method, 
+                                    method=method,
                                     normalization_factor=normalization_factor)
 
     @deprecated(since_version="0.21", only_once=True, deprecated_since="0.21.0")

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1674,7 +1674,7 @@ class AzimuthalIntegrator(Geometry):
                 * True for using the former correction
         :param ndarray dark: dark noise image
         :param ndarray flat: flat field image
-        :param method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
+        :param IntegrationMethod method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
         :param float normalization_factor: Value of a normalization monitor
         :return: chi bins center positions and regrouped intensity
         :rtype: Integrate1dResult
@@ -1787,7 +1787,7 @@ class AzimuthalIntegrator(Geometry):
                 * True for using the former correction
         :param ndarray dark: dark noise image
         :param ndarray flat: flat field image
-        :param method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
+        :param IntegrationMethod method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
         :param float normalization_factor: Value of a normalization monitor
         :return: chi bins center positions and regrouped intensity
         :rtype: Integrate1dResult

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1651,7 +1651,7 @@ class AzimuthalIntegrator(Geometry):
                         correctSolidAngle=True,
                         mask=None, dummy=None, delta_dummy=None,
                         polarization_factor=None, dark=None, flat=None,
-                        method=("bbox", "csr", "cython"),
+                        method_algo="csr", method_impl="cython",
                         normalization_factor=1.0):
         """Calculate the integrated profile curve along a specific FiberUnit
 
@@ -1674,7 +1674,8 @@ class AzimuthalIntegrator(Geometry):
                 * True for using the former correction
         :param ndarray dark: dark noise image
         :param ndarray flat: flat field image
-        :param IntegrationMethod method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
+        :param method_algo: Algorithm of integration (default Compressed-Sparse Row)
+        :param method_impl: Integration implementation (default cython)
         :param float normalization_factor: Value of a normalization monitor
         :return: chi bins center positions and regrouped intensity
         :rtype: Integrate1dResult
@@ -1710,7 +1711,7 @@ class AzimuthalIntegrator(Geometry):
                                   correctSolidAngle=correctSolidAngle,
                                   mask=mask, dummy=dummy, delta_dummy=delta_dummy,
                                   polarization_factor=polarization_factor,
-                                  dark=dark, flat=flat, method=method,
+                                  dark=dark, flat=flat, method=("no", method_algo, method_impl),
                                   normalization_factor=normalization_factor,
                                   radial_range=integrated_unit_range,
                                   azimuth_range=output_unit_range,
@@ -1759,7 +1760,7 @@ class AzimuthalIntegrator(Geometry):
                         correctSolidAngle=True,
                         mask=None, dummy=None, delta_dummy=None,
                         polarization_factor=None, dark=None, flat=None,
-                        method=("bbox", "csr", "cython"),
+                        method_algo="csr", method_impl="cython",
                         normalization_factor=1.0):
         """Calculate the integrated profile curve along a specific FiberUnit, additional inputs for incident angle and tilt angle
 
@@ -1784,7 +1785,8 @@ class AzimuthalIntegrator(Geometry):
                 * True for using the former correction
         :param ndarray dark: dark noise image
         :param ndarray flat: flat field image
-        :param IntegrationMethod method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
+        :param method_algo: Algorithm of integration (default Compressed-Sparse Row)
+        :param method_impl: Integration implementation (default cython)
         :param float normalization_factor: Value of a normalization monitor
         :return: chi bins center positions and regrouped intensity
         :rtype: Integrate1dResult
@@ -1871,7 +1873,7 @@ class AzimuthalIntegrator(Geometry):
                                     correctSolidAngle=correctSolidAngle,
                                     mask=mask, dummy=dummy, delta_dummy=delta_dummy,
                                     polarization_factor=polarization_factor, dark=dark, flat=flat,
-                                    method=method,
+                                    method_algo=method_algo, method_impl=method_impl,
                                     normalization_factor=normalization_factor)
 
     @deprecated(since_version="0.21", only_once=True, deprecated_since="0.21.0")

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1874,7 +1874,8 @@ class AzimuthalIntegrator(Geometry):
                                     correctSolidAngle=correctSolidAngle,
                                     mask=mask, dummy=dummy, delta_dummy=delta_dummy,
                                     polarization_factor=polarization_factor, dark=dark, flat=flat,
-                                    method=method, normalization_factor=normalization_factor)
+                                    method=method, 
+                                    normalization_factor=normalization_factor)
 
     @deprecated(since_version="0.21", only_once=True, deprecated_since="0.21.0")
     def integrate2d_legacy(self, data, npt_rad, npt_azim=360,

--- a/src/pyFAI/azimuthalIntegrator.py
+++ b/src/pyFAI/azimuthalIntegrator.py
@@ -1651,7 +1651,7 @@ class AzimuthalIntegrator(Geometry):
                         correctSolidAngle=True,
                         mask=None, dummy=None, delta_dummy=None,
                         polarization_factor=None, dark=None, flat=None,
-                        method_algo="csr", method_impl="cython",
+                        method=("no", "histogram", "cython"),
                         normalization_factor=1.0):
         """Calculate the integrated profile curve along a specific FiberUnit
 
@@ -1674,8 +1674,7 @@ class AzimuthalIntegrator(Geometry):
                 * True for using the former correction
         :param ndarray dark: dark noise image
         :param ndarray flat: flat field image
-        :param method_algo: Algorithm of integration (default Compressed-Sparse Row)
-        :param method_impl: Integration implementation (default cython)
+        :param method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
         :param float normalization_factor: Value of a normalization monitor
         :return: chi bins center positions and regrouped intensity
         :rtype: Integrate1dResult
@@ -1707,11 +1706,14 @@ class AzimuthalIntegrator(Geometry):
         if reset:
             self.reset()
 
+        if (isinstance(method, (tuple, list)) and method[0] != "no") or (isinstance(method, IntegrationMethod) and method.split != "no"):
+            logger.warning(f"Method {method} is using a pixel-splitting scheme. GI integration should be use WITHOUT PIXEL-SPLITTING! The results could be wrong!")
+
         res = self.integrate2d_ng(data, npt_rad=npt_integrated, npt_azim=npt_output,
                                   correctSolidAngle=correctSolidAngle,
                                   mask=mask, dummy=dummy, delta_dummy=delta_dummy,
                                   polarization_factor=polarization_factor,
-                                  dark=dark, flat=flat, method=("no", method_algo, method_impl),
+                                  dark=dark, flat=flat, method=method,
                                   normalization_factor=normalization_factor,
                                   radial_range=integrated_unit_range,
                                   azimuth_range=output_unit_range,
@@ -1760,7 +1762,7 @@ class AzimuthalIntegrator(Geometry):
                         correctSolidAngle=True,
                         mask=None, dummy=None, delta_dummy=None,
                         polarization_factor=None, dark=None, flat=None,
-                        method_algo="csr", method_impl="cython",
+                        method=("no", "histogram", "cython"),
                         normalization_factor=1.0):
         """Calculate the integrated profile curve along a specific FiberUnit, additional inputs for incident angle and tilt angle
 
@@ -1785,8 +1787,7 @@ class AzimuthalIntegrator(Geometry):
                 * True for using the former correction
         :param ndarray dark: dark noise image
         :param ndarray flat: flat field image
-        :param method_algo: Algorithm of integration (default Compressed-Sparse Row)
-        :param method_impl: Integration implementation (default cython)
+        :param method: IntegrationMethod instance or 3-tuple with (splitting, algorithm, implementation)
         :param float normalization_factor: Value of a normalization monitor
         :return: chi bins center positions and regrouped intensity
         :rtype: Integrate1dResult
@@ -1873,8 +1874,7 @@ class AzimuthalIntegrator(Geometry):
                                     correctSolidAngle=correctSolidAngle,
                                     mask=mask, dummy=dummy, delta_dummy=delta_dummy,
                                     polarization_factor=polarization_factor, dark=dark, flat=flat,
-                                    method_algo=method_algo, method_impl=method_impl,
-                                    normalization_factor=normalization_factor)
+                                    method=method, normalization_factor=normalization_factor)
 
     @deprecated(since_version="0.21", only_once=True, deprecated_since="0.21.0")
     def integrate2d_legacy(self, data, npt_rad, npt_azim=360,


### PR DESCRIPTION
GIWAXS/fiber integration should be done without pixel splitting, to not fill any point within the missing wedge
```
from pyFAI.units import get_unit_fiber
import numpy as np
from pyFAI import load
from pyFAI.gui.jupyter import plot2d, plot1d
import  matplotlib.pyplot as plt
import time
qip = get_unit_fiber(name='qip_nm^-1') 
qoop = get_unit_fiber(name='qoop_nm^-1')

data = np.load('/data/scisoft/edgar/pyfai_files/data_eiger2m.npy')
poni = '/data/scisoft/edgar/pyfai_files/poni_eiger.poni'

ai = load(poni)
res2d = ai.integrate2d(data=data, npt_rad=1000, npt_azim=360, unit=(qip,qoop), method=("no", "csr", "cython"))
```
![image](https://github.com/user-attachments/assets/e0ef31c3-9a15-494c-a78e-72a3ba4fb4bc)

For a fiber integration, for example between qIP=[0,5] and qOOP=[0,30], this is the array to integrate (using split_pixel="no"):
```
res2d_limit = ai.integrate2d_ng(data=data,
                          npt_rad=100,
                          npt_azim=1000,
                          method=("no", "csr", "cython"),
                          radial_range=[0,5],
                          azimuth_range=[0,30],
                          unit=(qip, qoop),
                         )
```
![image](https://github.com/user-attachments/assets/dca6954a-402e-4772-aff6-4d2c4b908305)

Using "bbox", the missing wedge is filled:
```
res2d_limit = ai.integrate2d_ng(data=data,
                          npt_rad=100,
                          npt_azim=1000,
                          method=("bbox", "csr", "cython"),
                          radial_range=[0,5],
                          azimuth_range=[0,30],
                          unit=(qip, qoop),
                         )
```
![image](https://github.com/user-attachments/assets/f84377ab-84c4-4c01-8503-c7ac55e6a461)

Therefore, its integration is wrong:
![image](https://github.com/user-attachments/assets/5e46de59-f766-4d2e-994c-a54b89b80164)

If we force the method to not use pixel splitting, there is no integration within the missing wedge:
![image](https://github.com/user-attachments/assets/06e34d1a-7085-4a13-82ee-a07525d5c02b)

It's more clear if we include a background:
```
data = np.load('/data/scisoft/edgar/pyfai_files/data_eiger2m.npy') + 1e4
poni = '/data/scisoft/edgar/pyfai_files/poni_eiger.poni'
res1d = ai.integrate_grazing_incidence(data=data, npt_output=500, integrated_unit_range=[-2.5,2.5], output_unit_range=[0,50], method_algo="csr", method_impl="cython")
plt.plot(res1d.radial, res1d.intensity)
plt.show()


```
![image](https://github.com/user-attachments/assets/ab9ac9aa-100a-4e12-827c-d41a37ce7bd0)

