### PR TITLE
Include fiber integrator into test suite

### DIFF
--- a/src/pyFAI/test/test_all.py
+++ b/src/pyFAI/test/test_all.py
@@ -32,7 +32,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "16/04/2024"
+__date__ = "30/10/2024"
 
 import sys
 import unittest
@@ -95,6 +95,7 @@ from . import test_error_model
 from . import test_units
 from . import test_uncertainties
 from . import test_ring_extraction
+from . import test_fiber_integrator
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +157,7 @@ def suite():
     testsuite.addTest(test_error_model.suite())
     testsuite.addTest(test_uncertainties.suite())
     testsuite.addTest(test_ring_extraction.suite())
-
+    testsuite.addTest(test_fiber_integrator.suite())
     return testsuite
 
 

--- a/src/pyFAI/test/test_fiber_integrator.py
+++ b/src/pyFAI/test/test_fiber_integrator.py
@@ -33,7 +33,7 @@ __author__ = "Edgar Gutiérrez Fernández"
 __contact__ = "edgar.gutierrez-fernandez@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "23/10/2024"
+__date__ = "30/10/2024"
 
 import unittest
 import logging
@@ -444,3 +444,15 @@ class TestFiberIntegrator(unittest.TestCase):
         )
 
         self.assertLess((abs(res_so_4.intensity) - abs(res_so_3.intensity)).max(), threshold)
+
+
+def suite():
+    testsuite = unittest.TestSuite()
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    testsuite.addTest(loader(TestFiberIntegrator))
+    return testsuite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
The number of tests increased from 433 to 450 (+2s runtime)