### PR TITLE
NexusDetector: Fixed type on shape

### DIFF
--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -1293,7 +1293,7 @@ class NexusDetector(Detector):
                 self._delta_dummy = det_grp["delta_dummy"][()]
             for what in ("max_shape", "shape"):
                 if what in det_grp:
-                    self.__setattr__(what, tuple(i for i in det_grp[what][()]))
+                    self.__setattr__(what, tuple(int(i) for i in det_grp[what][()]))
             if "mask" in det_grp:
                 self.mask = det_grp["mask"][()]
             if "pixel_corners" in det_grp:


### PR DESCRIPTION
Not sure this is the right way to fix it, but this PR workaround #2351: by making sure the shape is a tuple of Python int, this PR fixes the export of the Worker config as a JSON file.

Related to #2351