### PR TITLE
Use unit.name as key cache

### DIFF
--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -767,9 +767,6 @@ class Geometry(object):
             # unit = to_unit("r_m")
         key = space + "_corner"
 
-        if isinstance(unit, UnitFiber):
-            key = f"{unit.name}_corner"
-
         if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:
             with self._sem:
                 if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:
@@ -924,11 +921,8 @@ class Geometry(object):
         """
 
         unit = to_unit(unit)
-        if isinstance(unit, UnitFiber):
-            key = f"{unit.name}_center"
-        else:
-            space = unit.name.split("_")[0]
-            key = space + "_center"
+        space = "_".join(unit.name.split("_")[:-1])
+        key = space + "_center"
         ary = self._cached_array.get(key)
 
         shape = self.get_shape(shape)
@@ -973,10 +967,7 @@ class Geometry(object):
         """
 
         unit = to_unit(unit)
-        if isinstance(unit, UnitFiber):
-            space = f"{unit.name}_delta"
-        else:
-            space = unit.name.split("_")[0] + "_delta"
+        space = "_".join(unit.name.split("_")[:-1]) + "_delta"
         ary = self._cached_array.get(space)
 
         shape = self.get_shape(shape)

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -920,8 +920,7 @@ class Geometry(object):
         """
 
         unit = to_unit(unit)
-        space = "_".join(unit.name.split("_")[:-1])
-        key = space + "_center"
+        key = f"{unit.space}_center"
         ary = self._cached_array.get(key)
 
         shape = self.get_shape(shape)
@@ -966,7 +965,7 @@ class Geometry(object):
         """
 
         unit = to_unit(unit)
-        space = "_".join(unit.name.split("_")[:-1]) + "_delta"
+        space = f"{unit.space}_delta"
         ary = self._cached_array.get(space)
 
         shape = self.get_shape(shape)

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -766,10 +766,10 @@ class Geometry(object):
             space = "r"
             # unit = to_unit("r_m")
         key = space + "_corner"
-        
+
         if isinstance(unit, UnitFiber):
-            key = f"{unit.name}_corner"        
-        
+            key = f"{unit.name}_corner"
+
         if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:
             with self._sem:
                 if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -766,6 +766,10 @@ class Geometry(object):
             space = "r"
             # unit = to_unit("r_m")
         key = space + "_corner"
+        
+        if isinstance(unit, UnitFiber):
+            key = f"{unit.name}_corner"        
+        
         if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:
             with self._sem:
                 if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:
@@ -920,8 +924,11 @@ class Geometry(object):
         """
 
         unit = to_unit(unit)
-        space = unit.name.split("_")[0]
-        key = space + "_center"
+        if isinstance(unit, UnitFiber):
+            key = f"{unit.name}_center"
+        else:
+            space = unit.name.split("_")[0]
+            key = space + "_center"
         ary = self._cached_array.get(key)
 
         shape = self.get_shape(shape)
@@ -966,7 +973,10 @@ class Geometry(object):
         """
 
         unit = to_unit(unit)
-        space = unit.name.split("_")[0] + "_delta"
+        if isinstance(unit, UnitFiber):
+            space = f"{unit.name}_delta"
+        else:
+            space = unit.name.split("_")[0] + "_delta"
         ary = self._cached_array.get(space)
 
         shape = self.get_shape(shape)

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -766,7 +766,6 @@ class Geometry(object):
             space = "r"
             # unit = to_unit("r_m")
         key = space + "_corner"
-
         if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:
             with self._sem:
                 if self._cached_array.get(key) is None or shape != self._cached_array.get(key).shape[:2]:

--- a/src/pyFAI/units.py
+++ b/src/pyFAI/units.py
@@ -95,7 +95,7 @@ class Unit(object):
         :param period: None or the periodicity of the unit (angles are periodic)
         """
         self.name = name
-        self.space = name.split("_")[0]  # used to idenfify compatible spaces.
+        self.space = "_".join(self.name.split("_")[:-1])  # used to idenfify compatible spaces.
         self.scale = scale
         self.label = label if label is not None else name
         self.corner = corner


### PR DESCRIPTION
For two units called `scattering_angle_horz` and `scattering_angle_vert` ; the key to cache the arrays is the same for both units (`scattering`). 
Can we change it and use just the full unit.name?