### PR TITLE
Provide a more explicit exception

### DIFF
--- a/src/pyFAI/integrator/azimuthal.py
+++ b/src/pyFAI/integrator/azimuthal.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "19/02/2025"
+__date__ = "10/03/2025"
 __status__ = "stable"
 __docformat__ = 'restructuredtext'
 
@@ -1574,7 +1574,7 @@ class AzimuthalIntegrator(Integrator):
 
                 intpl = integr.medfilt(data, **kwargs)
         else:
-            raise RuntimeError("Not yet implemented. Sorry")
+            raise RuntimeError(f"Method {method} is not yet implemented. Please report an issue on https://github.com/silx-kit/pyFAI/issues/new")
         result = Integrate1dResult(intpl.position * unit.scale, intpl.intensity, intpl.sem)
         result._set_method_called("sigma_clip_ng")
         result._set_method(method)

--- a/src/pyFAI/test/test_azimuthal_integrator.py
+++ b/src/pyFAI/test/test_azimuthal_integrator.py
@@ -33,7 +33,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "29/01/2025"
+__date__ = "11/03/2025"
 
 import unittest
 import os
@@ -304,6 +304,7 @@ class TestAzimHalfFrelon(unittest.TestCase):
             self.assertLess(rwp, 0.1, "Rwp trimmed-mean Cython/OpenCL: %.3f" % rwp_ocl)
         ref = ocl = pyt = rwp = rwp_ocl = rwp_pyt = None
 
+    @unittest.skipIf(UtilsTest.low_mem, "test using >100Mb")
     def test_radial(self):
         "Non regression for #1602"
         res = self.ai.integrate_radial(self.data, npt=360, npt_rad=10,


### PR DESCRIPTION
@picca this is related to your email on the 
Fri, 28 Feb 2025 14:02:51 +0100 (CET)

Could you re-run the faulty test with this patch ? thanks.
```
======================================================================
ERROR: test_medfilt1d (pyFAI.test.test_azimuthal_integrator.TestAzimHalfFrelon.test_medfilt1d)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyFAI/test/test_azimuthal_integrator.py", line 290, in test_medfilt1d
    ocl = self.ai.medfilt1d_ng(self.data, N, method=("no", "csr", "opencl"), **param)
  File "/usr/lib/python3/dist-packages/pyFAI/integrator/azimuthal.py", line 1578, in medfilt1d_ng
    raise RuntimeError("Not yet implemented. Sorry")
RuntimeError: Not yet implemented. Sorry

----------------------------------------------------------------------
Ran 535 tests in 146.986s
```