### PR TITLE
Allow MultiGeometry to guess radial & azimuthal ranges when detectors are different shapes

### DIFF
--- a/src/pyFAI/multi_geometry.py
+++ b/src/pyFAI/multi_geometry.py
@@ -111,12 +111,12 @@ class MultiGeometry(object):
 
     def _guess_radial_range(self):
         logger.info(f"Calculating the radial range of MultiGeometry...")
-        radial = numpy.array([ai.array_from_unit(unit=self.radial_unit) for ai in self.ais])
+        radial = numpy.concatenate([ai.array_from_unit(unit=self.radial_unit).reshape(-1) for ai in self.ais])
         return (radial.min(), radial.max())
 
     def _guess_azimuth_range(self):
         logger.info(f"Calculating the azimuthal range of MultiGeometry...")
-        azimuthal = numpy.array([ai.array_from_unit(unit=self.azimuth_unit) for ai in self.ais])
+        azimuthal = numpy.concatenate([ai.array_from_unit(unit=self.azimuth_unit).reshape(-1) for ai in self.ais])
         return (azimuthal.min(), azimuthal.max())
 
     def integrate1d(self, lst_data, npt=1800,


### PR DESCRIPTION
Trying to combine two detectors with different pixel dimensions, I got an error like this:

```text

File /gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/lib/python3.11/site-packages/pyFAI/multi_geometry.py:169, in MultiGeometry.integrate1d(self, lst_data, npt, correctSolidAngle, lst_variance, error_model, polarization_factor, normalization_factor, lst_mask, lst_flat, method)
    167 variance = None
    168 if self.radial_range is None:
--> 169     self.radial_range = self._guess_radial_range()
    170 if self.azimuth_range is None:
    171     self.azimuth_range = self._guess_azimuth_range()

File /gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/lib/python3.11/site-packages/pyFAI/multi_geometry.py:113, in MultiGeometry._guess_radial_range(self)
    111 def _guess_radial_range(self):
    112     logger.info(f"Calculating the radial range of MultiGeometry...")
--> 113     radial = numpy.array([ai.array_from_unit(unit=self.radial_unit) for ai in self.ais])
    114     return (radial.min(), radial.max())

ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```

I think this change should fix this - flatten the arrays and concatenate them together, so their shape and number of values don't matter. I haven't tested this, however, although I'm doing basically the same thing in my own code as a workaround.