### PR TITLE
Migrate Qt backend to PySide6 by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ The extra Ubuntu packages needed are:
 * ``python3-dev``
 * ``python3-fabio``
 * ``python3-pyopencl``
-* ``python3-pyqt5``
+* ``python3-qtpy``
 * ``python3-silx``
 * ``python3-numexpr``
 

--- a/README.rst
+++ b/README.rst
@@ -103,12 +103,12 @@ Python 3.9, ... 3.13 are well tested and officially supported.
 For full functionality of pyFAI the following modules need to be installed.
 
 * ``numpy``      - http://www.numpy.org
-* ``scipy`` 	 - http://www.scipy.org
+* ``scipy`` 	  - http://www.scipy.org
 * ``matplotlib`` - http://matplotlib.sourceforge.net/
-* ``fabio`` 	 - http://sourceforge.net/projects/fable/files/fabio/
+* ``fabio`` 	  - http://sourceforge.net/projects/fable/files/fabio/
 * ``h5py``	     - http://www.h5py.org/
-* ``pyopencl``	 - http://mathema.tician.de/software/pyopencl/
-* ``pyqt5``	     - http://www.riverbankcomputing.co.uk/software/pyqt/intro
+* ``pyopencl``	  - http://mathema.tician.de/software/pyopencl/
+* ``pyside6``	  - https://wiki.qt.io/Qt_for_Python
 * ``silx``       - http://www.silx.org
 * ``numexpr``    - https://github.com/pydata/numexpr
 

--- a/ci/requirements_appveyor.txt
+++ b/ci/requirements_appveyor.txt
@@ -14,5 +14,5 @@ numexpr != 2.8.6
 silx >= 2
 psutil
 importlib_resources; python_version < '3.9'
-pyqt5
+pyside6
 pyopengl

--- a/doc/source/operations/index.rst
+++ b/doc/source/operations/index.rst
@@ -36,7 +36,7 @@ by may impair performances or prevent tools from properly working:
 
 * pyopencl (for GPU computing)
 * fftw (for image analysis)
-* PyQt5, PyQt6, PySide2 or PySide6 (for the graphical user interface)
+* PyQt5, PyQt6 or PySide6 (for the graphical user interface)
 
 Build dependencies:
 -------------------

--- a/doc/source/project.rst
+++ b/doc/source/project.rst
@@ -97,7 +97,7 @@ Run dependencies
 * FabIO
 * h5py
 * pyopencl (optional)
-* PyQt5/6 or PySide2/6 (for the graphical user interface)
+* PyQt5/6 or PySide6 (for the graphical user interface)
 * Silx
 
 Build dependencies

--- a/package/debian13/control
+++ b/package/debian13/control
@@ -24,7 +24,7 @@ Build-Depends: bitshuffle <!nocheck>,
                python3-numpy,
                python3-pip,
                python3-pyopencl,
-               python3-pyqt5,
+               python3-pyside6,
                python3-scipy,
                python3-setuptools,
                python3-silx,
@@ -72,7 +72,7 @@ Description: Fast Azimuthal Integration scripts
 Package: python3-pyfai
 Architecture: any
 Section: python
-Depends: python3-pyqt5,
+Depends: python3-pyside6,
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends}

--- a/package/debian13/py3dist-overrides
+++ b/package/debian13/py3dist-overrides
@@ -1,1 +1,1 @@
-pyqt5 python3-pyqt5
+pyside6 python3-pyside6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ requires = [
 ]
 
 [project.optional-dependencies]
-gui = [ "PyQt5" ]
+gui = [ "PySide6" ]
 opencl = [ "pyopencl" ]
-all = ["PyQt5", "pyopencl", "hdf5plugin"]
+all = ["PySide6", "pyopencl", "hdf5plugin"]
 
 [project.urls]
 homepage = 'http://www.silx.org'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ numexpr != 2.8.6
 h5py
 silx >= 2
 PyOpenGL
-PyQt5
+PySide6
 hdf5plugin
 nbsphinx
 pydata-sphinx-theme

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "26/04/2023"
+__date__ = "13/05/2025"
 __license__ = "MIT"
 
 import sys
@@ -406,7 +406,7 @@ parser.add_argument("-v", "--verbose", default=0,
                          "INFO messages. Use -vv for full verbosity, " +
                          "including debug messages and test help strings.")
 parser.add_argument("--qt-binding", dest="qt_binding", default=None,
-                    help="Force using a Qt binding, from 'PyQt4', 'PyQt5', or 'PySide'")
+                    help="Force using a Qt binding, from 'PyQt5', 'PyQt6'or 'PySide6' (default)")
 
 options = parser.parse_args()
 sys.argv = [sys.argv[0]]
@@ -447,12 +447,18 @@ if options.qt_binding:
     elif binding == "pyqt5":
         logger.info("Force using PyQt5")
         import PyQt5.QtCore  # noqa
+    elif binding == "pyqt6":
+        logger.info("Force using PyQt6")
+        import PyQt6.QtCore  # noqa
     elif binding == "pyside":
         logger.info("Force using PySide")
         import PySide.QtCore  # noqa
     elif binding == "pyside2":
         logger.info("Force using PySide2")
         import PySide2.QtCore  # noqa
+    elif binding == "pyside6":
+        logger.info("Force using PySide6")
+        import PySide6.QtCore  # noqa
     else:
         raise ValueError("Qt binding '%s' is unknown" % options.qt_binding)
 

--- a/src/pyFAI/gui/matplotlib.py
+++ b/src/pyFAI/gui/matplotlib.py
@@ -33,7 +33,7 @@ to the used backend.
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "17/09/2024"
+__date__ = "13/05/2025"
 
 import sys
 import logging
@@ -61,17 +61,17 @@ def _configure(backend, backend_qt4=None, check=False):
         matplotlib.rcParams['backend.qt4'] = backend_qt4
 
 
-if qt.BINDING == 'PySide':
-    _configure('Qt4Agg', 'PySide', check=_check_matplotlib)
+if qt.BINDING in ('PySide', 'PyQt4'):
+    _configure('Qt4Agg', qt.BINDING, check=_check_matplotlib)
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg  # noqa
 
-elif qt.BINDING == 'PyQt4':
-    _configure('Qt4Agg', check=_check_matplotlib)
-    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg  # noqa
-
-elif qt.BINDING == 'PyQt5':
+elif qt.BINDING in ('PyQt5', 'PySide2'):
     _configure('Qt5Agg', check=_check_matplotlib)
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
+
+elif qt.BINDING in ('PyQt6', 'PySide6'):
+    _configure('QtAgg', check=_check_matplotlib)
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg  # noqa
 
 from matplotlib import pyplot  # noqa
 from matplotlib import pylab  # noqa


### PR DESCRIPTION
was PyQt5, but Qt5 is left unmaintained.