### PR TITLE
Replace `os.path.exists()`

### DIFF
--- a/src/pyFAI/app/saxs.py
+++ b/src/pyFAI/app/saxs.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer, Picca Frédéric-Emmanuel"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/09/2024"
+__date__ = "13/05/2025"
 __status__ = "production"
 
 import os
@@ -49,6 +49,7 @@ except ImportError:
     logger.debug("Unable to load hdf5plugin, backtrace:", exc_info=True)
 
 import fabio
+from fabio.fabioutils import exists as fabio_exists
 
 from .. import date as pyFAI_date, version as pyFAI_version, units, utils
 from ..method_registry import IntegrationMethod
@@ -130,12 +131,12 @@ def main(args=None):
             integrator.wavelength = options.wavelength * 1e-10
         elif options.energy:
             integrator.wavelength = hc / options.energy * 1e-10
-        if options.mask and os.path.exists(options.mask):  # override with the command line mask
+        if options.mask and fabio_exists(options.mask):  # override with the command line mask
             integrator.maskfile = options.mask
-        if options.dark and os.path.exists(options.dark):  # set dark current
+        if options.dark and fabio_exists(options.dark):  # set dark current
             with fabio.open(options.dark) as fimg:
                 integrator.darkcurrent = fimg.data
-        if options.flat and os.path.exists(options.flat):  # set Flat field
+        if options.flat and fabio_exists(options.flat):  # set Flat field
             with fabio.open(options.flat) as fimg:
                 integrator.flatfield = fimg.data
 

--- a/src/pyFAI/app/waxs.py
+++ b/src/pyFAI/app/waxs.py
@@ -33,7 +33,7 @@ __author__ = "Jerome Kieffer, Picca Frédéric-Emmanuel"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/09/2024"
+__date__ = "13/05/2025"
 __status__ = "production"
 
 import os
@@ -49,6 +49,7 @@ try:
 except ImportError:
     logger.debug("Unable to load hdf5plugin, backtrace:", exc_info=True)
 import fabio
+from fabio.fabioutils import exists as fabio_exists
 
 from .. import date as pyFAI_date, version as pyFAI_version, units, utils
 from ..average import average_dark
@@ -153,12 +154,12 @@ def main(args=None):
             integrator.wavelength = options.wavelength * 1e-10
         elif options.energy:
             integrator.wavelength = hc / options.energy * 1e-10
-        if options.mask and os.path.exists(options.mask):  # override with the command line mask
+        if options.mask and fabio_exists(options.mask):  # override with the command line mask
             integrator.maskfile = options.mask
-        if options.dark and os.path.exists(options.dark):  # set dark current
+        if options.dark and fabio_exists(options.dark):  # set dark current
             with fabio.open(options.dark) as fimg:
                 integrator.darkcurrent = fimg.data
-        if options.flat and os.path.exists(options.flat):  # set Flat field
+        if options.flat and fabio_exists(options.flat):  # set Flat field
             with fabio.open(options.flat) as fimg:
                 integrator.flatfield = fimg.data
 

--- a/src/pyFAI/benchmark/__init__.py
+++ b/src/pyFAI/benchmark/__init__.py
@@ -24,7 +24,7 @@
 "Benchmark for Azimuthal integration of PyFAI"
 
 __author__ = "Jérôme Kieffer"
-__date__ = "11/03/2025"
+__date__ = "13/05/2025"
 __license__ = "MIT"
 __copyright__ = "2012-2024 European Synchrotron Radiation Facility, Grenoble, France"
 
@@ -296,8 +296,9 @@ class Bench(object):
         Returns the occupied memory for memory-leak hunting in MByte
         """
         pid = os.getpid()
-        if os.path.exists("/proc/%i/status" % pid):
-            for l in open("/proc/%i/status" % pid):
+        status_file = f"/proc/{pid}/status
+        if os.path.exists(status_file):
+            for l in open(status_file):
                 if l.startswith("VmRSS"):
                     mem = int(l.split(":", 1)[1].split()[0]) / 1024.
         else:

--- a/src/pyFAI/benchmark/__init__.py
+++ b/src/pyFAI/benchmark/__init__.py
@@ -296,7 +296,7 @@ class Bench(object):
         Returns the occupied memory for memory-leak hunting in MByte
         """
         pid = os.getpid()
-        status_file = f"/proc/{pid}/status
+        status_file = f"/proc/{pid}/status"
         if os.path.exists(status_file):
             for l in open(status_file):
                 if l.startswith("VmRSS"):

--- a/src/pyFAI/gui/CalibrationContext.py
+++ b/src/pyFAI/gui/CalibrationContext.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "17/09/2024"
+__date__ = "13/05/2025"
 
 import logging
 import numpy
@@ -273,7 +273,7 @@ class CalibrationContext(ApplicationContext):
     def _getStyle(self, name):
         style = self.__cacheStyles.get(name, None)
         if style is None:
-            resource = "pyfai:/gui/styles/%s.json" % name
+            resource = f"pyfai:/gui/styles/{name}.json"
             path = silx.resources.resource_filename(resource)
             if os.path.exists(path):
                 try:

--- a/src/pyFAI/gui/cli_calibration.py
+++ b/src/pyFAI/gui/cli_calibration.py
@@ -37,7 +37,7 @@ __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/09/2024"
+__date__ = "13/05/2025"
 __status__ = "production"
 
 import os
@@ -51,6 +51,7 @@ import numpy
 from silx.image import marchingsquares
 from scipy.stats import linregress
 import fabio
+from fabio.fabioutils import exists as fabio_exists
 
 from argparse import ArgumentParser
 from urllib.parse import urlparse
@@ -106,7 +107,7 @@ def get_detector(detector, datafiles=None):
         res = detector
     else:
         res = Detector()
-    if datafiles and os.path.exists(datafiles[0]):
+    if datafiles and fabio_exists(datafiles[0]):
         with fabio.open(datafiles[0]) as fimg:
             shape = fimg.shape
         res.guess_binning(shape)
@@ -2363,10 +2364,10 @@ refinement process.
             for f in args[1:]:
                 with fabio.open(f) as fimg:
                     self.img += fimg.data
-        if options.dark and os.path.exists(options.dark):
+        if options.dark and fabio_exists(options.dark):
             with fabio.open(options.dark) as fimg:
                 self.img -= fimg.data
-        if options.flat and os.path.exists(options.flat):
+        if options.flat and fabio_exists(options.flat):
             with fabio.open(options.flat) as fimg:
                 self.img /= fimg.data
         if options.poni:

--- a/src/pyFAI/gui/diffmap_widget.py
+++ b/src/pyFAI/gui/diffmap_widget.py
@@ -31,7 +31,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/04/2025"
+__date__ = "13/05/2025"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
@@ -42,6 +42,7 @@ import threading
 import logging
 import numpy
 import fabio
+from fabio.fabioutils import exists as fabio_exists
 from silx.gui import qt
 from silx.gui import icons
 
@@ -393,7 +394,7 @@ class DiffMapWidget(qt.QWidget):
         shape = None
         for i in self.list_dataset:
             fn = i.path
-            if os.path.exists(fn):
+            if fabio_exists(fn):
                 try:
                     with fabio.open(fn) as fimg:
                         new_shape = fimg.shape

--- a/src/pyFAI/gui/tasks/MaskTask.py
+++ b/src/pyFAI/gui/tasks/MaskTask.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "19/01/2024"
+__date__ = "13/05/2025"
 
 import logging
 import os.path


### PR DESCRIPTION
Use `fabio.fabioutils.exists()` instead of `os.path.exists()` to accept '::' seprated HDF5 dataset descriptors
close #308 