### PR TITLE
improve pyFAI-average warning

### DIFF
--- a/src/pyFAI/app/average.py
+++ b/src/pyFAI/app/average.py
@@ -306,7 +306,13 @@ def main(args=None):
         process.set_writer(writer)
         process.process()
     else:
-        logger.warning("No input file specified.")
+        if options.args:
+            logger.warning(
+                "No valid input files found matching the specified pattern(s): %s",
+                ", ".join(options.args)
+            )
+        else:
+            logger.warning("No input files were specified. Please provide at least one file.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A beamline called me with an issue which was actually a typo in the argument and they did not understand from the stdout

```bash
pyFAI-average /path/to/file.h5
WARNING:pyFAI.app.average:No input file specified.
```