### PR TITLE
2631 segfault pixelsplitting

### DIFF
--- a/src/pyFAI/ext/regrid_common.pxi
+++ b/src/pyFAI/ext/regrid_common.pxi
@@ -32,7 +32,7 @@ Some are defined in the associated header file .pxd
 
 __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.kieffer@esrf.fr"
-__date__ = "18/11/2025"
+__date__ = "27/11/2025"
 __status__ = "stable"
 __license__ = "MIT"
 
@@ -512,6 +512,7 @@ def _sp_integrate1d(buffer_t[::1] buffer,
                     floating stop0, floating stop1):
     _integrate1d(buffer, start0, start1, stop0, stop1)
 
+
 cdef inline void _integrate2d(buffer_t[:, ::1] box,
                               floating start0, floating start1,
                               floating stop0, floating stop1) noexcept nogil:
@@ -545,7 +546,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                 abs_area = fabs(segment_area)
                 dA = (stop0 - start0)  # always positive
                 h = 0
-                while abs_area > 0:
+                while abs_area > 0 and h<box.shape[1]:
                     if dA > abs_area:
                         dA = abs_area
                         abs_area = -1
@@ -559,7 +560,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                     abs_area = fabs(segment_area)
                     h = 0
                     dA = dP
-                    while abs_area > 0:
+                    while abs_area > 0 and h<box.shape[1]:
                         if dA > abs_area:
                             dA = abs_area
                             abs_area = -1
@@ -573,7 +574,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                     abs_area = fabs(segment_area)
                     h = 0
                     dA = 1.0
-                    while abs_area > 0:
+                    while abs_area > 0 and h<box.shape[1]:
                         if dA > abs_area:
                             dA = abs_area
                             abs_area = -1
@@ -589,7 +590,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                     abs_area = fabs(segment_area)
                     h = 0
                     dA = fabs(dP)
-                    while abs_area > 0:
+                    while abs_area > 0 and h<box.shape[1]:
                         if dA > abs_area:
                             dA = abs_area
                             abs_area = -1
@@ -605,7 +606,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                 # sign = segment_area / abs_area
                 dA = (start0 - stop0)  # always positive
                 h = 0
-                while abs_area > 0:
+                while abs_area > 0 and h<box.shape[1]:
                     if dA > abs_area:
                         dA = abs_area
                         abs_area = -1
@@ -620,7 +621,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                     abs_area = fabs(segment_area)
                     h = 0
                     dA = fabs(dP)
-                    while abs_area > 0:
+                    while abs_area > 0 and h<box.shape[1]:
                         if dA > abs_area:
                             dA = abs_area
                             abs_area = -1
@@ -634,7 +635,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                     abs_area = fabs(segment_area)
                     h = 0
                     dA = 1
-                    while abs_area > 0:
+                    while abs_area > 0 and h<box.shape[1]:
                         if dA > abs_area:
                             dA = abs_area
                             abs_area = -1
@@ -650,7 +651,7 @@ cdef inline void _integrate2d(buffer_t[:, ::1] box,
                     abs_area = fabs(segment_area)
                     h = 0
                     dA = fabs(dP)
-                    while abs_area > 0:
+                    while abs_area > 0 and h<box.shape[1]:
                         if dA > abs_area:
                             dA = abs_area
                             abs_area = -1

--- a/src/pyFAI/test/test_azimuthal_integrator.py
+++ b/src/pyFAI/test/test_azimuthal_integrator.py
@@ -806,7 +806,6 @@ class TestFlexible2D(unittest.TestCase):
 
     def test_flexible(self):
         for m in IntegrationMethod.select_method(dim=2, impl="cython"):
-            print(m)
             res = self.ai.integrate2d(self.img, 50, 50, method=m, unit=("qxgi_nm^-1", "qygi_nm^-1"))
             img, rad, azim = res
             self.assertTrue(numpy.nanmax(img) > 0, f"image is non empty for {m}")
@@ -818,7 +817,6 @@ class TestFlexible2D(unittest.TestCase):
             azimin = azim.min()
             self.assertTrue(10 < azimax < 20, f"Upper bound azimuthal is  10<{azimax}<20 for {m} ")
             self.assertTrue(-20 < azimin < -15, f"Lower bound azimuthal is  -20<{azimin}<-15 for {m}")
-        raise RuntimeError("plop")
 
 
 class TestUnweighted(unittest.TestCase):


### PR DESCRIPTION
This modification ensures the pixel splitting does not write outside the bounding box, this could occur when there was an almost vertical edge for the pixel, where the accumulated area under the edge was negligible (1e-10) in comparison to everything else (1), especially when calculation are done in single precision.