### PR TITLE
Update video format from MKV to MP4

### DIFF
--- a/doc/source/usage/tutorial/ThickDetector/synthetic_parallax.ipynb
+++ b/doc/source/usage/tutorial/ThickDetector/synthetic_parallax.ipynb
@@ -405,7 +405,7 @@
     {
      "data": {
       "text/html": [
-       "<video src=\"http://www.silx.org/pub/pyFAI/video/parallax.mkv\" controls  width=\"800\" >\n",
+       "<video src=\"http://www.silx.org/pub/pyFAI/video/parallax.mp4\" controls  width=\"800\" >\n",
        "      Your browser does not support the <code>video</code> element.\n",
        "    </video>"
       ],
@@ -422,7 +422,7 @@
     "#Video of the calibration of those \n",
     "from IPython.display import Video\n",
     "\n",
-    "Video(\"http://www.silx.org/pub/pyFAI/video/parallax.mkv\", width=800)"
+    "Video(\"http://www.silx.org/pub/pyFAI/video/parallax.mp4\", width=800)"
    ]
   },
   {


### PR DESCRIPTION
This is apparently better supported by browsers, especially Firefox.