### PR TITLE
Enforce encoding to UTF-8 when saving text

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (C) 2015-2023 European Synchrotron Radiation Facility
+# Copyright (C) 2015-2026 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "13/05/2025"
+__date__ = "24/02/2026"
 __license__ = "MIT"
 
 import sys
@@ -515,7 +515,7 @@ else:
 if options.coverage:
     cov.stop()
     cov.save()
-    with open("coverage.rst", "w") as fn:
+    with open("coverage.rst", "w", encoding="utf-8") as fn:
         fn.write(report_rst(cov, PROJECT_NAME, PROJECT_VERSION, PROJECT_PATH))
     print(cov.report())
     print("")

--- a/src/pyFAI/benchmark/__init__.py
+++ b/src/pyFAI/benchmark/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 #
-#    Copyright (C) 2016-2025 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2016-2026 European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 "Benchmark for Azimuthal integration of PyFAI"
 
 __author__ = "Jérôme Kieffer"
-__date__ = "08/10/2025"
+__date__ = "24/02/2026"
 __license__ = "MIT"
 __copyright__ = "2012-2024 European Synchrotron Radiation Facility, Grenoble, France"
 
@@ -615,7 +615,8 @@ class Bench(object):
         if filename is None:
             filename = f"benchmark-{time.strftime('%Y%m%d-%H%M%S')}.json"
         self.update_mp()
-        json.dump(self.results, open(filename, "w"), indent=4)
+        with open(filename, "w", encoding="utf-8") as wd:
+            json.dump(self.results, wd, indent=4)
         if self.fig is not None:
             self.fig.savefig(filename[:-4] + "svg")
 
@@ -772,7 +773,7 @@ class Bench(object):
         return size
 
     # Deprecated compatibility layer
-    get_size = deprecated(size.fget, reason="use property", since_version="2025.09")    
+    get_size = deprecated(size.fget, reason="use property", since_version="2025.09")
 
 
 def run_benchmark(number=10, repeat=1, memprof=False, max_size=1000,

--- a/src/pyFAI/control_points.py
+++ b/src/pyFAI/control_points.py
@@ -36,7 +36,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "08/10/2025"
+__date__ = "24/02/2026"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
@@ -84,7 +84,7 @@ class ControlPoints(object):
             else:
                 logger.error("Unable to handle such calibrant: %s", calibrant)
         if not self.calibrant.wavelength:
-            self.calibrant.wavelength = wavelength 
+            self.calibrant.wavelength = wavelength
 
     def __repr__(self):
         self.check()
@@ -225,7 +225,7 @@ class ControlPoints(object):
                 lstout.append("ring: %s" % ring)
                 for point in gpt.points:
                     lstout.append("point: x=%s y=%s" % (point[1], point[0]))
-            with open(filename, "w") as f:
+            with open(filename, "w", encoding="utf-8") as f:
                 f.write("\n".join(lstout))
 
     def load(self, filename):

--- a/src/pyFAI/goniometer.py
+++ b/src/pyFAI/goniometer.py
@@ -34,7 +34,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "14/11/2025"
+__date__ = "24/02/2026"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
@@ -535,7 +535,7 @@ class Goniometer(object):
         """
         dico = self.to_dict()
         try:
-            with open(filename, "w") as f:
+            with open(filename, "w", encoding="utf-8") as f:
                 f.write(json.dumps(dico, indent=2))
         except IOError:
             logger.error("IOError while writing to file %s", filename)

--- a/src/pyFAI/gui/diffmap_widget.py
+++ b/src/pyFAI/gui/diffmap_widget.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2025"
+__date__ = "24/02/2026"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
@@ -498,7 +498,7 @@ class DiffMapWidget(qt.QWidget):
         if fname is None:
             fname = self.json_file
         config = self.get_diffmap_config()
-        with open(fname, "w") as fd:
+        with open(fname, "w", encoding="utf-8") as fd:
             fd.write(json.dumps(config.as_dict(), indent=2))
         return config
 

--- a/src/pyFAI/io/__init__.py
+++ b/src/pyFAI/io/__init__.py
@@ -42,7 +42,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "12/12/2025"
+__date__ = "24/02/2026"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 
@@ -305,7 +305,7 @@ class HDF5Writer(Writer):
         with self._sem:
             if logger.isEnabledFor(logging.DEBUG):
                 fai_cfg.save("fai_cfg.debug.json")
-                with open("lima_cfg.debug.json", "w") as w:
+                with open("lima_cfg.debug.json", "w", encoding="utf-8") as w:
                     w.write(json.dumps(self.lima_cfg, indent=4, cls=UnitEncoder))
 
             #self.fai_cfg.nbpt_rad = 1000 if self.fai_cfg.nbpt_rad is None else self.fai_cfg.nbpt_rad
@@ -404,14 +404,14 @@ class HDF5Writer(Writer):
         name += "2D" if self.fai_cfg.do_2D else "1D"
         name += " experiment"
         self.entry_grp["title"] = name
-        
+
     def _init_fiber(self):
         self.fai_cfg.npt_ip = 1000 if self.fai_cfg.npt_ip is None else self.fai_cfg.npt_ip
         self.fai_cfg.npt_oop = 1000 if self.fai_cfg.npt_oop is None else self.fai_cfg.npt_oop
-        
+
         ip = self.fai_cfg.unit_ip
         oop = self.fai_cfg.unit_oop
-        
+
         ip_name= ip.space
         oop_name = oop.space
         ip_unit = ip.unit_symbol
@@ -419,7 +419,7 @@ class HDF5Writer(Writer):
 
         if self.fai_cfg.do_2D:
             self.do2D = True
-        
+
         if self.fai_cfg.do_2D or (not self.fai_cfg.do_2D and self.fai_cfg.vertical_integration):
             self.outofplane_ds = self.nxdata_grp.require_dataset("out-of-plane", (self.fai_cfg.npt_oop,), numpy.float32)
             self.outofplane_ds.attrs.update({
@@ -471,7 +471,7 @@ class HDF5Writer(Writer):
                 axis_definition = [".", "out-of-plane"]
                 chunk = 1, self.fai_cfg.npt_oop
                 self.ndim = 2
-                
+
         utf8vlen_dtype = h5py.special_dtype(vlen=str)
         self.nxdata_grp.attrs["axes"] = numpy.array(axis_definition, dtype=utf8vlen_dtype)
 
@@ -797,7 +797,7 @@ class DefaultAiWriter(Writer):
         :param metadata: JSON serializable dictionary containing the metadata
         """
         dim1_unit = units.to_unit(dim1_unit)
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             f.write(self.make_headers(has_mask=has_mask, has_dark=has_dark,
                                       has_flat=has_flat,
                                       polarization_factor=polarization_factor,
@@ -1033,7 +1033,7 @@ class AsciiWriter(Writer):
     def write(self, data, index=0):
         filename = os.path.join(self.directory, self.prefix + (self.index_format % (self.start_index + index)) + self.extension)
         if filename:
-            with open(filename, "w") as f:
+            with open(filename, "w", encoding="utf-8") as f:
                 f.write("# Processing time: %s%s" % (get_isotime(), self.header))
                 numpy.savetxt(f, data)
 

--- a/src/pyFAI/io/diffmap_config.py
+++ b/src/pyFAI/io/diffmap_config.py
@@ -31,7 +31,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "08/10/2025"
+__date__ = "24/02/2026"
 __status__ = "development"
 __docformat__ = 'restructuredtext'
 
@@ -413,7 +413,7 @@ class DiffmapConfig:
 
     def save(self, filename):
         """Dump the content of the dataclass as JSON file"""
-        with open(filename, "w") as w:
+        with open(filename, "w", encoding="utf-8") as w:
             w.write(json.dumps(self.as_dict(), indent=2))
 
     @classmethod

--- a/src/pyFAI/io/integration_config.py
+++ b/src/pyFAI/io/integration_config.py
@@ -561,7 +561,7 @@ class WorkerConfig:
 
     def save(self, filename):
         """Dump the content of the dataclass as JSON file"""
-        with open(filename, "w") as w:
+        with open(filename, "w", encoding="utf-8") as w:
             w.write(json.dumps(self.as_dict(), indent=2))
 
     @classmethod
@@ -885,13 +885,13 @@ class WorkerFiberConfig(WorkerConfig):
     def save(self, filename, pop_azimuthal_params:bool=True):
         """Dump the content of the dataclass as JSON file"""
         config = self.as_dict()
-        
+
         # Serialize fiber units
         for key in ("unit_ip", "unit_oop"):
             if key in config:
                 unit = get_unit_fiber(**config[key])
                 config[key] = unit.get_config()
-        
+
         if pop_azimuthal_params:
             for key in ["nbpt_rad", "nbpt_azim",
                         "radial_range", "azimuth_range",
@@ -902,5 +902,5 @@ class WorkerFiberConfig(WorkerConfig):
                 if key in config:
                     config.pop(key)
 
-        with open(filename, "w") as w:
+        with open(filename, "w", encoding="utf-8") as w:
             w.write(json.dumps(config, indent=2))

--- a/src/pyFAI/opencl/test/test_openCL.py
+++ b/src/pyFAI/opencl/test/test_openCL.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "08/10/2025"
+__date__ = "24/02/2026"
 
 import unittest
 import os
@@ -98,7 +98,7 @@ class TestMask(unittest.TestCase):
                         else:
                             data.append(line.strip())
                 ds["poni"] = os.path.join(cls.tmp_dir, os.path.basename(ds["poni"]))
-                with open(ds["poni"], "w") as f:
+                with open(ds["poni"], "w", encoding="utf-8") as f:
                     f.write(os.linesep.join(data))
 
     @classmethod

--- a/src/pyFAI/spline.py
+++ b/src/pyFAI/spline.py
@@ -34,7 +34,7 @@ Mainly used at ESRF with FReLoN CCD camera.
 __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@esrf.eu"
 __license__ = "MIT"
-__date__ = "13/01/2025"
+__date__ = "24/02/2026"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 import os
@@ -583,7 +583,7 @@ class Spline(object):
             lst.append(txt)
             txt = ""
         lst.append("")
-        with open(filename, "w") as fil:
+        with open(filename, "w", encoding="utf-8") as fil:
             fil.write("\n".join(lst))
 
     def tilt(self, center=(0.0, 0.0), tiltAngle=0.0, tiltPlanRot=0.0,

--- a/src/pyFAI/test/__init__.py
+++ b/src/pyFAI/test/__init__.py
@@ -4,7 +4,7 @@
 #    Project: Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2016-2025 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2016-2026 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -32,7 +32,7 @@ __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/10/2025"
+__date__ = "24/02/2026"
 
 import unittest
 from . import utilstest

--- a/src/pyFAI/test/test_azimuthal_integrator.py
+++ b/src/pyFAI/test/test_azimuthal_integrator.py
@@ -33,7 +33,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/11/2025"
+__date__ = "24/02/2026"
 
 import unittest
 import os
@@ -92,7 +92,7 @@ class TestAzimHalfFrelon(unittest.TestCase):
                     data.append(line.strip())
         cls.poniFile = os.path.join(tmp_dir, os.path.basename(poniFile))
 
-        with open(cls.poniFile, "w") as f:
+        with open(cls.poniFile, "w", encoding="utf-8") as f:
             f.write(os.linesep.join(data))
         cls.fit2d = numpy.loadtxt(cls.fit2dFile)
         cls.ai = AzimuthalIntegrator()

--- a/src/pyFAI/test/test_bug_regression.py
+++ b/src/pyFAI/test/test_bug_regression.py
@@ -36,7 +36,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "2015-2025 European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "27/01/2026"
+__date__ = "24/02/2026"
 
 import sys
 import os
@@ -103,7 +103,7 @@ SplineFile: None
 Wavelength: 7e-11
 """
         self.ponifile = os.path.join(UtilsTest.tempdir, "bug170.poni")
-        with open(self.ponifile, "w") as poni:
+        with open(self.ponifile, "w", encoding="utf-8") as poni:
             poni.write(ponitxt)
         rng = UtilsTest.get_rng()
         self.data = rng.random((2300, 2300))

--- a/src/pyFAI/test/test_goniometer.py
+++ b/src/pyFAI/test/test_goniometer.py
@@ -33,7 +33,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jérôme.Kieffer@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "04/12/2025"
+__date__ = "24/02/2026"
 
 import os
 import math
@@ -180,7 +180,7 @@ class TestTranslation(unittest.TestCase):
         """
 
         fname = os.path.join(UtilsTest.tempdir, "extended.json")
-        with open(fname, "w") as of:
+        with open(fname, "w", encoding="utf-8") as of:
             of.write(jsons)
         gonio = Goniometer.sload(fname)
         self.assertTrue(isinstance(gonio.trans_function, ExtendedTransformation))

--- a/src/pyFAI/test/test_integrate_config.py
+++ b/src/pyFAI/test/test_integrate_config.py
@@ -32,7 +32,7 @@ __author__ = "Valentin Valls"
 __contact__ = "valentin.valls@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "28/04/2025"
+__date__ = "24/02/2026"
 
 import os
 import json
@@ -140,7 +140,7 @@ class TestRegression(unittest.TestCase):
         expected_with_gpu = ("no", "lut", "opencl")
         config = {"ai": {"method": expected_without_gpu}}
         config_file = os.path.join(utilstest.UtilsTest.tempdir, "test_2132.json")
-        with open(config_file, "w") as fp:
+        with open(config_file, "w", encoding="utf-8") as fp:
             json.dump(config, fp)
 
         # without GPU option -g

--- a/src/pyFAI/test/test_io.py
+++ b/src/pyFAI/test/test_io.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/10/2025"
+__date__ = "24/02/2026"
 
 import unittest
 import os
@@ -79,12 +79,12 @@ class TestPoniFile(unittest.TestCase):
         poni = PoniFile(self.ponifile)
         test_file1 = os.path.join(UtilsTest.tempdir, "test1.poni")
         test_file2 = os.path.join(UtilsTest.tempdir, "test2.poni")
-        with open(test_file1, "w") as fd:
+        with open(test_file1, "w", encoding="utf-8") as fd:
             poni.write(fd, comments="lorem ipsus")
         with open(test_file1, "r") as fd:
             content1 = fd.readlines()
         self.assertTrue("# lorem ipsus\n" in content1, 'Write comment as string')
-        with open(test_file2, "w") as fd:
+        with open(test_file2, "w", encoding="utf-8") as fd:
             poni.write(fd, comments=("lorem","ipsus"))
         with open(test_file2, "r") as fd:
             content2 = fd.readlines()

--- a/src/pyFAI/test/test_io_diffmap_config.py
+++ b/src/pyFAI/test/test_io_diffmap_config.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "10/10/2025"
+__date__ = "24/02/2026"
 
 import unittest
 import json
@@ -189,7 +189,7 @@ class TestDiffmapConfig(unittest.TestCase):
 
     def test_diffmap_parse(self):
         fn = os.path.join(UtilsTest.tempdir, "test_diffmap_parse.json")
-        with open(fn, "w") as w:
+        with open(fn, "w", encoding="utf-8") as w:
             w.write(test_data)
         dm = DiffMap()
         opts, config = dm.parse(sysargv=["diffmap", "--config", fn], with_config=True)
@@ -210,7 +210,7 @@ class TestDiffmapConfig(unittest.TestCase):
 
     def test_diffmap_consistency(self):
         fn = os.path.join(UtilsTest.tempdir, "test_diffmap_parse.json")
-        with open(fn, "w") as w:
+        with open(fn, "w", encoding="utf-8") as w:
             w.write(test_data)
         dm = DiffMap()
         dm.set_config(self.inp)


### PR DESCRIPTION
The purpose of this PR is basically to ensure any written text file is performed with the UTF-8 encoding.
Should address saving issues in windows computers with exotic locals.

Close #2798