### PR TITLE
Ensure the `SensorConfig.material` is actually a `material` when possible.

### DIFF
--- a/src/pyFAI/detectors/sensors.py
+++ b/src/pyFAI/detectors/sensors.py
@@ -37,7 +37,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "04/05/2026"
+__date__ = "05/05/2026"
 __status__ = "stable"
 
 import os
@@ -165,7 +165,7 @@ ALL_MATERIALS["Se"] = Se_MATERIAL = SensorMaterial("Se", density=4.26)
 class SensorConfig:
     "class for configuration of a sensor"
     material: SensorMaterial|str
-    thickness: float=None
+    thickness: float|None=None
 
     THICKNESS_TOLERANCE: ClassVar[float] = 1e-6
 

--- a/src/pyFAI/detectors/sensors.py
+++ b/src/pyFAI/detectors/sensors.py
@@ -37,7 +37,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "28/01/2026"
+__date__ = "04/05/2026"
 __status__ = "stable"
 
 import os
@@ -168,6 +168,12 @@ class SensorConfig:
     thickness: float=None
 
     THICKNESS_TOLERANCE: ClassVar[float] = 1e-6
+
+    def __post_init__(self):
+        if isinstance(self.material, str):
+            self.material = ALL_MATERIALS.get(self.material, self.material)
+        if self.thickness is not None:
+            self.thickness = float(self.thickness)
 
     def __repr__(self):
         return json_dumps(self.as_dict(), indent=2)

--- a/src/pyFAI/test/test_parallax.py
+++ b/src/pyFAI/test/test_parallax.py
@@ -32,7 +32,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "21/11/2025"
+__date__ = "04/05/2026"
 
 import unittest
 import numpy
@@ -56,6 +56,12 @@ class TestSensorMaterial(unittest.TestCase):
         self.assertTrue(numpy.allclose(CdTe_MATERIAL.mu(40), 112.905))
         self.assertTrue(numpy.allclose(CdTe_MATERIAL.mu_en(40), 56.36475))
 
+    def test_bug_2851(self):
+        """test bug #2851: SensorConfig.from_dict() initializes the SenorMaterial
+        while the default constructor does not"""
+        c1 = SensorConfig.from_dict({"material": "Si", "thickness": 0.00045})
+        c2 = SensorConfig("Si", 0.00045)
+        self.assertEqual(c1, c2)
 
 
 class TestParallax(unittest.TestCase):


### PR DESCRIPTION
close #2851