### PR TITLE
deprecation: setting an ndarray shape is deprecated since numpy 2.5.0

### DIFF
--- a/src/pyFAI/average.py
+++ b/src/pyFAI/average.py
@@ -441,9 +441,9 @@ def average_dark(lstimg, center_method="mean", cutoff=None, quantiles=(0.5, 0.5)
         output = center
     else:
         std = stack.std(axis=0)
-        std.shape = shape
+        std = std.reshape(shape)
         std = std[numpy.newaxis, ...]
-        center.shape = shape
+        center = center.reshape(shape)
         center = center[numpy.newaxis, ...]
         mask = ((abs(stack - center) / std) > cutoff)
         stack[numpy.where(mask)] = 0.0

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -733,10 +733,10 @@ class Detector(metaclass=DetectorMeta):
                 p1, p2, p3 = bilinear.calc_cartesian_positions(d1c.ravel(), d2c.ravel(),
                                                                self._pixel_corners,
                                                                is_flat=self.IS_FLAT)
-                p1.shape = d1.shape
-                p2.shape = d1.shape
+                p1 = p1.reshape(d1.shape)
+                p2 = p2.reshape(d1.shape)
                 if p3 is not None:
-                    p3.shape = d1.shape
+                    p3 = p3.reshape(d1.shape)
             else:
                 i1 = d1.astype(int).clip(0, self._pixel_corners.shape[0] - 1)
                 i2 = d2.astype(int).clip(0, self._pixel_corners.shape[1] - 1)

--- a/src/pyFAI/detectors/_imxpad.py
+++ b/src/pyFAI/detectors/_imxpad.py
@@ -349,8 +349,8 @@ class Xpad_flat(ImXPadS10):
             d2 = d2 + 0.5
         if bilinear and use_cython:
             p1, p2, _p3 = bilinear.calc_cartesian_positions(d1.ravel(), d2.ravel(), corners)
-            p1.shape = d1.shape
-            p2.shape = d2.shape
+            p1 = p1.reshape(d1.shape)
+            p2 = p2.reshape(d2.shape)
         else:
             i1 = d1.astype(int).clip(0, corners.shape[0] - 1)
             i2 = d2.astype(int).clip(0, corners.shape[1] - 1)
@@ -564,9 +564,9 @@ class Cirpad(ImXPadS10):
             d2 = d2 + 0.5
         if False and use_cython:
             p1, p2, p3 = bilinear.calc_cartesian_positions(d1.ravel(), d2.ravel(), corners, is_flat=False)
-            p1.shape = d1.shape
-            p2.shape = d2.shape
-            p3.shape = d2.shape
+            p1 = p1.reshape(d1.shape)
+            p2 = p2.reshape(d2.shape)
+            p3 = p3.reshape(d2.shape)
         else:  # TODO verifiedA verifier
             i1 = d1.astype(int).clip(0, corners.shape[0] - 1)
             i2 = d2.astype(int).clip(0, corners.shape[1] - 1)

--- a/src/pyFAI/detectors/_non_flat.py
+++ b/src/pyFAI/detectors/_non_flat.py
@@ -175,9 +175,9 @@ class CylindricalDetector(Detector):
             d2 = d2 + 0.5
         if bilinear and use_cython:
             p1, p2, p3 = bilinear.calc_cartesian_positions(d1.ravel(), d2.ravel(), corners, is_flat=False)
-            p1.shape = d1.shape
-            p2.shape = d2.shape
-            p3.shape = d2.shape
+            p1 = p1.reshape(d1.shape)
+            p2 = p2.reshape(d2.shape)
+            p3 = p3.reshape(d2.shape)
         else:
             i1 = d1.astype(int).clip(0, corners.shape[0] - 1)
             i2 = d2.astype(int).clip(0, corners.shape[1] - 1)

--- a/src/pyFAI/distortion.py
+++ b/src/pyFAI/distortion.py
@@ -379,7 +379,7 @@ class Distortion(object):
                                         lut[ml, nl, k].coef = val
                                         outMax[ml, nl] = k + 1
                                 idx += 1
-                        lut.shape = (self._shape_out[0] * self._shape_out[1]), self.max_size
+                        lut = lut.reshape(self._shape_out[0] * self._shape_out[1], self.max_size)
                         self.lut = lut
         return self.lut
 
@@ -439,13 +439,13 @@ class Distortion(object):
                         out[i] = big[indptr[i]:indptr[i + 1]].sum()
         try:
             if image.ndim == 2:
-                out.shape = self._shape_out
+                out = out.reshape(self._shape_out)
             else:
-                for ds in out:
+                for i, ds in enumerate(out):
                     if ds.ndim == 2:
-                        ds.shape = self._shape_out
+                        out[i] = ds.reshape(self._shape_out)
                     else:
-                        ds.shape = self._shape_out + ds.shape[2:]
+                        out[i] = ds.reshape(self._shape_out + ds.shape[2:])
 
         except ValueError as _err:
             logger.error("Requested in_shape=%s out_shape=%s and ", self.shape_in, self.shape_out)
@@ -535,13 +535,13 @@ class Distortion(object):
                         out[i] = big[indptr[i]:indptr[i + 1]].sum()
             try:
                 if image.ndim == 2:
-                    out.shape = self._shape_out
+                    out = out.reshape(self._shape_out)
                 else:
-                    for ds in out:
+                    for i, ds in enumerate(out):
                         if ds.ndim == 2:
-                            ds.shape = self._shape_out
+                            out[i] = ds.reshape(self._shape_out)
                         else:
-                            ds.shape = self._shape_out + ds.shape[2:]
+                            out[i] = ds.reshape(self._shape_out + ds.shape[2:])
 
             except ValueError as _err:
                 logger.error("Requested in_shape=%s out_shape=%s and ", self.shape_in, self.shape_out)

--- a/src/pyFAI/distortion.py
+++ b/src/pyFAI/distortion.py
@@ -441,11 +441,16 @@ class Distortion(object):
             if image.ndim == 2:
                 out = out.reshape(self._shape_out)
             else:
+                is_immutable = isinstance(out, (tuple, frozenset))
+                if is_immutable:
+                    out = list(out)
                 for i, ds in enumerate(out):
                     if ds.ndim == 2:
                         out[i] = ds.reshape(self._shape_out)
                     else:
                         out[i] = ds.reshape(self._shape_out + ds.shape[2:])
+                if is_immutable:
+                    out = type(out)(out)
 
         except ValueError as _err:
             logger.error("Requested in_shape=%s out_shape=%s and ", self.shape_in, self.shape_out)
@@ -537,11 +542,16 @@ class Distortion(object):
                 if image.ndim == 2:
                     out = out.reshape(self._shape_out)
                 else:
+                    is_immutable = isinstance(out, (tuple, frozenset))
+                    if is_immutable:
+                        out = list(out)
                     for i, ds in enumerate(out):
                         if ds.ndim == 2:
                             out[i] = ds.reshape(self._shape_out)
                         else:
                             out[i] = ds.reshape(self._shape_out + ds.shape[2:])
+                    if is_immutable:
+                        out = type(out)(out)
 
             except ValueError as _err:
                 logger.error("Requested in_shape=%s out_shape=%s and ", self.shape_in, self.shape_out)

--- a/src/pyFAI/engines/CSC_engine.py
+++ b/src/pyFAI/engines/CSC_engine.py
@@ -151,7 +151,7 @@ class CSCIntegrator(object):
                        error_model=error_model,
                        apply_normalization=not weighted_average,
                        out=self.preprocessed)
-        prep.shape = numpy.prod(shape), 4
+        prep = prep.reshape(numpy.prod(shape), 4)
         flat_sig, flat_var, flat_nrm, flat_cnt = prep.T  # should create views!
         res = numpy.empty((numpy.prod(self.bins), 5), dtype=numpy.float32)
         res[:, 0] = self._csc.dot(flat_sig)  # Σ c·x
@@ -493,7 +493,7 @@ class CscIntegrator2d(CSCIntegrator):
         trans = CSCIntegrator.integrate(self, signal, variance, error_model, dummy, delta_dummy,
                                         dark, flat, solidangle, polarization,
                                         absorption, normalization_factor, weighted_average=weighted_average)
-        trans.shape = self.bins + (-1,)
+        trans = trans.reshape(self.bins + (-1,))
 
         signal = trans[..., 0]
         variance = trans[..., 1]

--- a/src/pyFAI/engines/CSR_engine.py
+++ b/src/pyFAI/engines/CSR_engine.py
@@ -144,7 +144,7 @@ class CSRIntegrator(object):
                        error_model=error_model,
                        apply_normalization=not weighted_average,
                        out=self.preprocessed)
-        prep.shape = numpy.prod(shape), 4
+        prep = prep.reshape(numpy.prod(shape), 4)
         flat_sig, flat_var, flat_nrm, flat_cnt = prep.T  # should create views!
         res = numpy.empty((numpy.prod(self.bins), 5), dtype=numpy.float32)
         res[:, 0] = self._csr.dot(flat_sig)  # Σ c·x
@@ -594,7 +594,7 @@ class CsrIntegrator2d(CSRIntegrator):
         trans = CSRIntegrator.integrate(self, signal, variance, error_model, dummy, delta_dummy,
                                         dark, flat, solidangle, polarization,
                                         absorption, normalization_factor, weighted_average=weighted_average)
-        trans.shape = self.bins + (-1,)
+        trans = trans.reshape(self.bins + (-1,))
 
         signal = trans[..., 0]
         variance = trans[..., 1]

--- a/src/pyFAI/engines/histogram_engine.py
+++ b/src/pyFAI/engines/histogram_engine.py
@@ -114,7 +114,7 @@ def histogram1d_engine(radial, npt,
                    apply_normalization=not weighted_average,
                    )
     radial = radial.ravel()
-    prep.shape = -1, 4
+    prep = prep.reshape(-1, 4)
     if prep.shape[0] != radial.size:
         raise RuntimeError("preprocessed array size not consistent with radial array size")
     if radial_range is None:
@@ -236,7 +236,7 @@ def histogram2d_engine(radial, azimuthal, bins,
                    )
     radial = radial.ravel()
     azimuthal = azimuthal.ravel()
-    prep.shape = -1, 4
+    prep = prep.reshape(-1, 4)
     if prep.shape[0] != radial.size or prep.shape[0] != azimuthal.size:
         raise RuntimeError("Preprocessed array size is inconsistent with radial or azimuthal array size")
     npt = tuple(max(1, i) for i in bins)

--- a/src/pyFAI/engines/preproc.py
+++ b/src/pyFAI/engines/preproc.py
@@ -243,5 +243,5 @@ def preproc(raw,
             lin = result.ravel()
             lin[...] = signal / normalization
             lin[mask] = cdummy
-            result.shape = shape
+            result = result.reshape(shape)
     return result

--- a/src/pyFAI/geometry/core.py
+++ b/src/pyFAI/geometry/core.py
@@ -369,8 +369,8 @@ class Geometry:
 
             displacement = self._parallax.correct(self.sin_incidence(d1.ravel(), d2.ravel()), self.dist)
             delta1, delta2 = displacement * r0
-            delta1.shape = p1.shape
-            delta2.shape = p2.shape
+            delta1 = delta1.reshape(p1.shape)
+            delta2 = delta2.reshape(p2.shape)
             p1 += delta1
             p2 += delta2
         return delta1, delta2
@@ -411,8 +411,8 @@ class Geometry:
             length[length == 0] = 1.0  # avoid zero division error
             r0 /= length  # normalize array r0
             delta1, delta2 = displacement * r0
-            delta1.shape = p1.shape
-            delta2.shape = p2.shape
+            delta1 = delta1.reshape(p1.shape)
+            delta2 = delta2.reshape(p2.shape)
             p1 += delta1
             p2 += delta2
         return delta1, delta2
@@ -547,9 +547,9 @@ class Geometry:
             coord_det = numpy.vstack((p1, p2, p3))
             coord_sample = numpy.dot(self.rotation_matrix(param), coord_det)
             t1, t2, t3 = coord_sample
-            t1.shape = shape
-            t2.shape = shape
-            t3.shape = shape
+            t1 = t1.reshape(shape)
+            t2 = t2.reshape(shape)
+            t3 = t3.reshape(shape)
 
             # correct orientation:
             if self.detector.orientation in (1, 2):
@@ -828,7 +828,7 @@ class Geometry:
                 orientation=self.detector.orientation,
                 chi_discontinuity_at_pi=self.chiDiscAtPi,
             )
-            chi.shape = d1.shape
+            chi = chi.reshape(d1.shape)
         else:
             _, t1, t2 = self.calc_pos_zyx(
                 d0=None, d1=d1, d2=d2, corners=False, use_cython=True, do_parallax=True
@@ -1492,10 +1492,10 @@ class Geometry:
             B = corners[..., 1, :]
             C = corners[..., 2, :]
             D = corners[..., 3, :]
-            A.shape = -1, 3
-            B.shape = -1, 3
-            C.shape = -1, 3
-            D.shape = -1, 3
+            A = A.reshape(-1, 3)
+            B = B.reshape(-1, 3)
+            C = C.reshape(-1, 3)
+            D = D.reshape(-1, 3)
             orth = numpy.cross(C - A, D - B)
             # normalize the normal vector
             length = numpy.atleast_2d(numpy.sqrt((orth * orth).sum(axis=-1))).T
@@ -2450,7 +2450,7 @@ class Geometry:
 
         ttha = self.center_array(shape, unit=dim1_unit, scale=False)
         calcimage = numpy.interp(ttha.ravel(), tth, intensity)
-        calcimage.shape = shape
+        calcimage = calcimage.reshape(shape)
         if correctSolidAngle:
             calcimage *= self.solidAngleArray(shape)
         if polarization_factor is not None:

--- a/src/pyFAI/gui/model/PeakModel.py
+++ b/src/pyFAI/gui/model/PeakModel.py
@@ -146,7 +146,7 @@ class PeakModel(AbstractModel):
         if len(new_coords) == 0:
             return
         new_coords = new_coords.view(self.__coords.dtype)
-        new_coords.shape = -1, 2
+        new_coords = new_coords.reshape(-1, 2)
         self.__coords = numpy.vstack((self.__coords, new_coords))
         self.__coords = numpy.ascontiguousarray(self.__coords)
         self.wasChanged()

--- a/src/pyFAI/integrator/common.py
+++ b/src/pyFAI/integrator/common.py
@@ -1467,7 +1467,7 @@ class Integrator(Geometry):
                                                                              polarization_checksum=polarization_crc,
                                                                              normalization_factor=normalization_factor,
                                                                              safe=safe)
-                                intensity.shape = npt
+                                intensity = intensity.reshape(npt)
                                 intensity = intensity.T
                                 bins_rad = integr.bin_centers0  # this will be copied later
                                 bins_azim = integr.bin_centers1
@@ -1558,7 +1558,7 @@ class Integrator(Geometry):
                                                                              polarization_checksum=polarization_crc,
                                                                              safe=safe,
                                                                              normalization_factor=normalization_factor)
-                                intensity.shape = npt
+                                intensity = intensity.reshape(npt)
                                 intensity = intensity.T
                                 bins_rad = integr.bin_centers0  # this will be copied later
                                 bins_azim = integr.bin_centers1

--- a/src/pyFAI/utils/mathutil.py
+++ b/src/pyFAI/utils/mathutil.py
@@ -422,7 +422,7 @@ def binning(
                 out += input_img[i :: binsize[0], j :: binsize[1]]
     else:
         temp = input_img.copy()
-        temp.shape = (outputSize[0], binsize[0], outputSize[1], binsize[1])
+        temp = temp.reshape(outputSize[0], binsize[0], outputSize[1], binsize[1])
         out = temp.sum(axis=3).sum(axis=1)
     if not norm:
         out /= binsize[0] * binsize[1]
@@ -715,7 +715,7 @@ def _compute_qth_percentile(sorted_list, q, axis, out):
         weights = numpy.array([(j - index), (index - i)], float)
         wshape = [1] * sorted_list.ndim
         wshape[axis] = 2
-        weights.shape = wshape
+        weights = weights.reshape(wshape)
         sumval = weights.sum()
 
     # Use add.reduce in both cases to coerce data type as well as


### PR DESCRIPTION
For reference: https://github.com/silx-kit/silx/issues/4602#issuecomment-4637994839