### PR TITLE
Fix GUI hang and silent failures on invalid calibrant files

### DIFF
--- a/src/pyFAI/crystallography/calibrant.py
+++ b/src/pyFAI/crystallography/calibrant.py
@@ -241,6 +241,8 @@ class Calibrant:
             logger.error("No such calibrant file: %s", path)
             return
         config = self.config = CalibrantConfig.from_dspacing(path)
+        if not config.reflections:
+            raise ValueError(f"Calibrant file '{path}' contains no valid reflections")
         self._dspacing = [ref.dspacing for ref in config.reflections]
         if self._wavelength:
             self._calc_2th()

--- a/src/pyFAI/geometryRefinement.py
+++ b/src/pyFAI/geometryRefinement.py
@@ -424,15 +424,14 @@ class GeometryRefinement(AzimuthalIntegrator):
         if wavelength != self.calibrant.wavelength:
             self.calibrant.setWavelength_change2th(wavelength)
         ary = self.calibrant.get_2th()
-        if len(ary) < rings.max():
-            # complete turn ~ 2pi ~ 7: help the optimizer to find the right way
+        if rings.max() >= len(ary):
+            logger.warning(
+                "Ring %d exceeds available rings (%d) for this calibrant "
+                "at wavelength %s. Applying optimization penalty.",
+                rings.max(), len(ary) - 1, wavelength
+            )
             ary += [10.0 * (rings.max() - len(ary))] * (1 + rings.max() - len(ary))
         tth = numpy.array(ary, dtype=numpy.float64)
-        if rings.max() >= len(tth):
-            raise IndexError(
-                "Ring indices %s are not all available at this wavelength (%s)"
-                % (numpy.unique(rings), wavelength)
-            )
         return tth[rings]
 
     def calc_param7(self, param, free, const):

--- a/src/pyFAI/gui/helper/RingCalibration.py
+++ b/src/pyFAI/gui/helper/RingCalibration.py
@@ -154,11 +154,13 @@ class RingCalibration:
         self.__peakPicker = None
         self.__geoRef = None
         self.__isValid = True
+        self.__initError = None
         try:
             self.__init(peaks, method)
-        except Exception:
+        except Exception as e:
             _logger.error("Error while initializing the calibration", exc_info=True)
             self.__isValid = False
+            self.__initError = str(e)
 
     def __repr__(self):
         return f"RingCalibration:\n  PeakPicker: {self.__peakPicker}\n  GeoRef: {self.__geoRef}"
@@ -395,7 +397,6 @@ class RingCalibration:
 
         return angles
 
-
     def getBeamCenter(self):
         epsilon = 0.001
         try:
@@ -524,3 +525,7 @@ class RingCalibration:
                 bounds[name] = minValue, maxValue
         self.__geoRef.setFixed(fixed)
         self.__geoRef.setBounds(bounds)
+
+    def getInitError(self):
+        """Returns the error message from initialization, or None if successful."""
+        return self.__initError

--- a/src/pyFAI/gui/tasks/ExperimentTask.py
+++ b/src/pyFAI/gui/tasks/ExperimentTask.py
@@ -266,7 +266,61 @@ class ExperimentTask(AbstractCalibrationTask):
 
     def __calibrantChanged(self):
         settings = self.model().experimentSettingsModel()
-        self._calibrantPreview.setCalibrant(settings.calibrantModel().calibrant())
+        calibrant = settings.calibrantModel().calibrant()
+        if calibrant is not None:
+            # Validate early: a calibrant listed in the dropdown may point to a
+            # missing or empty file. Force the lazy load and reject the selection
+            # with a dialog instead of letting it crash later (preview / fitting).
+            try:
+                dspacing = calibrant.dspacing
+                if not dspacing:
+                    raise ValueError(
+                        "the calibrant file is missing or contains no d-spacing")
+            except Exception as error:
+                _logger.error("Selected calibrant could not be loaded: %s",
+                              calibrant.filename, exc_info=True)
+                # Ask the user whether to simply revert, or to also drop a
+                # user-added entry from the dropdown. "Remove" is offered only
+                # for user-added calibrants (a real filename, not a "pyfai:"
+                # resource), and we never delete the file on disk: a renamed or
+                # moved file cannot be deleted and would itself raise.
+                filename = calibrant.filename
+                is_user_added = (filename is not None
+                                 and not filename.startswith("pyfai:"))
+                msgbox = qt.QMessageBox(self)
+                msgbox.setIcon(qt.QMessageBox.Critical)
+                msgbox.setWindowTitle("Calibrant error")
+                msgbox.setText("The selected calibrant could not be loaded:\n\n%s\n\n"
+                               "Please pick another calibrant." % error)
+                revert_button = msgbox.addButton("Revert", qt.QMessageBox.RejectRole)
+                remove_button = None
+                if is_user_added:
+                    remove_button = msgbox.addButton(
+                        "Remove from list", qt.QMessageBox.AcceptRole)
+                msgbox.exec_()
+                if remove_button is not None and msgbox.clickedButton() is remove_button:
+                    self.__removeUserCalibrant(calibrant)
+                # Either way, revert the invalid selection; setCalibrant(None)
+                # re-enters this slot with calibrant=None (a harmless no-op).
+                settings.calibrantModel().setCalibrant(None)
+                return
+        self._calibrantPreview.setCalibrant(calibrant)
+
+    def __removeUserCalibrant(self, calibrant):
+        """Drop a user-added calibrant from the dropdown (in-memory only).
+
+        The file on disk is intentionally left untouched: in the typical
+        failure case the file was already renamed or moved, so deleting it
+        would raise. Only the dropdown entry and the recent list are updated.
+        """
+        filename = calibrant.filename
+        model = self._calibrant.model()
+        index = model.indexFromCalibrant(calibrant)
+        if index.isValid():
+            model.removeRow(index.row())
+        recent = self._calibrant.recentCalibrants()
+        recent = [item for item in recent if item != filename]
+        self._calibrant.setRecentCalibrants(recent)
 
     def __detectorModelUpdated(self):
         detector = self.model().experimentSettingsModel().detectorModel().detector()
@@ -456,10 +510,14 @@ class ExperimentTask(AbstractCalibrationTask):
         filename = dialog.selectedFiles()[0]
         try:
             calibrant = Calibrant(filename=filename)
+            calibrant.dspacing  # Check that d-spacing is present in the calibrant file
+            if not calibrant.dspacing:
+                raise ValueError("No d-spacing found in calibrant file")
         except Exception as e:
             _logger.error(e.args[0])
             _logger.debug("Backtrace", exc_info=True)
             # FIXME Display error dialog
+            qt.QMessageBox.critical(self, "Load calibrant", str(e.args[0]) if e.args else str(e))
             return
         except KeyboardInterrupt:
             raise

--- a/src/pyFAI/gui/tasks/GeometryTask.py
+++ b/src/pyFAI/gui/tasks/GeometryTask.py
@@ -799,6 +799,9 @@ class GeometryTask(AbstractCalibrationTask):
                                       peaks=peaks,
                                       method="massif")
 
+        if not calibration.isValid():
+            return None
+
         # Copy the default values
         self.__defaultConstraints.set(calibration.defaultGeometryConstraintsModel())
         return calibration
@@ -837,6 +840,19 @@ class GeometryTask(AbstractCalibrationTask):
             if calibration is None:
                 return
 
+            calibrant = self.model().experimentSettingsModel().calibrantModel().calibrant()
+            if calibrant is None:
+                self.__showCalibrationInputError("No calibrant is available")
+                return
+
+            available_rings = [ring for ring in calibrant.get_2th() if ring is not None]
+            if len(peaks) > 0:
+                max_ring = int(peaks[:, 2].max())
+                if max_ring >= len(available_rings):
+                    self.__showCalibrationInputWarning(
+                        "Peak ring %d exceeds calibrant range (0-%d)"
+                        % (max_ring, len(available_rings) - 1)
+                    )
             # Constraints defined by the GUI
             constraints = self.model().geometryConstraintsModel().copy(self)
             constraints.fillDefault(calibration.defaultGeometryConstraintsModel())
@@ -880,68 +896,75 @@ class GeometryTask(AbstractCalibrationTask):
         self._fitButton.setWaiting(False)
 
     def __initGeometry(self):
-        self.__initGeometryFromPeaks(useFittedGeometry=True)
+        try:
+            self.__initGeometryFromPeaks(useFittedGeometry=True)
 
-        # Save this geometry into the history
-        calibration = self.__getCalibration()
-        geometry = self.model().fittedGeometry()
-        rms = None
-        if calibration is not None and calibration.isValid():
-            rms = calibration.getRms()
-        geometryHistory = self.model().geometryHistoryModel()
-        geometryHistory.appendGeometry("Init", datetime.datetime.now(), geometry, rms)
-
-        self.__unsetProcessing()
+            # Save this geometry into the history
+            calibration = self.__getCalibration()
+            geometry = self.model().fittedGeometry()
+            rms = None
+            if calibration is not None and calibration.isValid():
+                rms = calibration.getRms()
+            geometryHistory = self.model().geometryHistoryModel()
+            geometryHistory.appendGeometry("Init", datetime.datetime.now(), geometry, rms)
+        finally:
+            self.__unsetProcessing()
 
     def __resetGeometry(self):
-        calibration = self.__getCalibration()
-        if calibration is None:
-            self.__unsetProcessing()
-            return
-        self.__initGeometryFromPeaks()
-        # write result to the fitted geometry
-        geometry = self.model().fittedGeometry()
-        calibration.toGeometryModel(geometry)
-
-        # Save this geometry into the history
-        geometryHistory = self.model().geometryHistoryModel()
-        geometryHistory.appendGeometry("Reset", datetime.datetime.now(), geometry, calibration.getRms())
-
-        self.__unsetProcessing()
-
-    def __fitGeometry(self):
-        self.__fitting = True
-        self._fitButton.setWaiting(True)
-        calibration = self.__getCalibration()
-        if calibration is None:
-            self.__unsetProcessing()
-            self._fitButton.setWaiting(False)
-            return
-        if self.__peaksInvalidated:
-            self.__initGeometryFromPeaks(useFittedGeometry=True)
-        else:
-            calibration.fromGeometryModel(self.model().fittedGeometry(), resetResidual=False)
-
-        constraints = self.model().geometryConstraintsModel().copy(self)
-        constraints.fillDefault(self.__defaultConstraints)
-        calibration.fromGeometryConstraintsModel(constraints)
-        do_parallax = self.model().experimentSettingsModel().parallaxCorrection().value()
-
-        calibration.refine(parallax=do_parallax)
-        if calibration.isValid():
-            # write result to the fitted model
+        try:
+            calibration = self.__getCalibration()
+            if calibration is None:
+                # self.__unsetProcessing()
+                return
+            self.__initGeometryFromPeaks()
+            # write result to the fitted geometry
             geometry = self.model().fittedGeometry()
             calibration.toGeometryModel(geometry)
 
             # Save this geometry into the history
             geometryHistory = self.model().geometryHistoryModel()
-            geometryHistory.appendGeometry("Fitted", datetime.datetime.now(), geometry, calibration.getRms())
-        else:
-            self.__showDialogCalibrationDiverge()
+            geometryHistory.appendGeometry("Reset", datetime.datetime.now(), geometry, calibration.getRms())
+    
+        finally:
+            self.__unsetProcessing()
 
-        self._fitButton.setWaiting(False)
-        self.__fitting = False
-        self.__unsetProcessing()
+    def __fitGeometry(self):
+        self.__fitting = True
+        self._fitButton.setWaiting(True)
+        try:
+            calibration = self.__getCalibration()
+            if calibration is None:
+                # self.__unsetProcessing()
+                # self._fitButton.setWaiting(False)
+                return
+            if self.__peaksInvalidated:
+                self.__initGeometryFromPeaks(useFittedGeometry=True)
+            else:
+                calibration.fromGeometryModel(self.model().fittedGeometry(), resetResidual=False)
+
+            constraints = self.model().geometryConstraintsModel().copy(self)
+            constraints.fillDefault(self.__defaultConstraints)
+            calibration.fromGeometryConstraintsModel(constraints)
+            do_parallax = self.model().experimentSettingsModel().parallaxCorrection().value()
+
+            calibration.refine(parallax=do_parallax)
+            if calibration.isValid():
+                # write result to the fitted model
+                geometry = self.model().fittedGeometry()
+                calibration.toGeometryModel(geometry)
+
+                # Save this geometry into the history
+                geometryHistory = self.model().geometryHistoryModel()
+                geometryHistory.appendGeometry("Fitted", datetime.datetime.now(), geometry, calibration.getRms())
+            else:
+                extra = calibration.getInitError() or str(calibration)
+                self.__showDialogCalibrationDiverge(extra)
+        except (IndexError, ValueError) as err:
+            self.__showCalibrationInputError(str(err))
+        finally:
+            self._fitButton.setWaiting(False)
+            self.__fitting = False
+            self.__unsetProcessing()
 
     def __updateResidual(self):
         """
@@ -986,6 +1009,8 @@ class GeometryTask(AbstractCalibrationTask):
                 return
 
         calibration = self.__getCalibration()
+        if calibration is None or not calibration.isValid():
+            return
         calibration.fromGeometryModel(geometry, resetResidual=True)
 
         state = self.__calibrationState
@@ -993,15 +1018,38 @@ class GeometryTask(AbstractCalibrationTask):
         now = datetime.datetime.now()
         geometryHistory.appendGeometry("Customed", now, geometry, state.getRms())
 
+    def __showCalibrationError(self, title, message):
+        qt.QMessageBox.critical(self, title, message)
+
+    def __showCalibrationInitError(self, extra=''):
+        message = "It is not possible to initialize the geometry calibration."
+        if extra:
+            message += "<br><br>" + extra.replace("\n", "<br>")
+        self.__showCalibrationError("Calibration initialization failed", message)
+
+    def __showCalibrationInputWarning(self, extra=''):
+        message = "The selected peaks are not compatible with the current calibrant. Optimization will continue with penalty values."
+        if extra:
+            message += "<br><br>" + extra.replace("\n", "<br>")
+        msgbox = qt.QMessageBox(qt.QMessageBox.Warning, "Calibration input warning", message, qt.QMessageBox.NoButton, self)
+        qt.QTimer.singleShot(5000, msgbox.close)
+        msgbox.exec_()
+
+    def __showCalibrationInputError(self, extra=''):
+        message = "The selected peaks are not compatible with the current calibrant."
+        if extra:
+            message += "<br><br>" + extra.replace("\n", "<br>")
+        self.__showCalibrationError("Calibration input error", message)
+
     def __showDialogCalibrationDiverge(self, extra:str=''):
         title = "Error while calibrating"
         message = ("It is not possible to calibrate/refine the geometry. " +
                    "The refinement <b>diverge</b>. " +
-                   "It may be due to a mistake on specified wavelength, or selected peaks. " +
-                   "<b>Check your input data</b>.")
+                   "This usually means the optimizer could not converge from the current initial geometry. " +
+                   "<b>Check your input data and constraints</b>.")
         if extra:
             message += "<br><br>" + extra.replace("\n","<br>")
-        qt.QMessageBox.critical(self, title, message)
+        self.__showCalibrationError(title, message)
 
     def __geometryUpdated(self):
         calibration = self.__getCalibration()
@@ -1009,7 +1057,8 @@ class GeometryTask(AbstractCalibrationTask):
             self.__calibrationState.reset()
             return
         if not calibration.isValid():
-            self.__showDialogCalibrationDiverge(str(calibration))
+            extra = calibration.getInitError() or str(calibration)
+            self.__showCalibrationInitError(extra)
             self.__calibrationState.reset()
             return
         geometry = self.model().fittedGeometry()

--- a/src/pyFAI/io/calibrant_config.py
+++ b/src/pyFAI/io/calibrant_config.py
@@ -239,6 +239,8 @@ class CalibrantConfig:
                                 reflection.intensity = 0.0
                         else:
                             reflection.intensity = value
+        if not self.reflections:
+            raise ValueError(f"No valid reflections found in calibrant file '{self.filename}'")
         return self
 
     def save(self, filename: str = None):


### PR DESCRIPTION
An invalid .D file (moved, renamed, or wrong format) caused the calibration GUI to hang indefinitely during fit with no error, requiring a force-close. This commit adds fail-fast validation in calibrant parsing/loading, makes ring overflow non-fatal with warning + penalty, validates calibrant on dropdown selection with actionable dialogs, captures init errors for display, and wraps GUI operations in try/finally to prevent irreversible hangs.
Fixes #2887 