### PR TITLE
Fix monitor_name override in pyFAI-integrate --no-gui

### DIFF
--- a/src/pyFAI/app/integrate.py
+++ b/src/pyFAI/app/integrate.py
@@ -787,7 +787,8 @@ def integrate_shell(options, args):
     with logging_utils.prepost_emit_callback(default_logger,
                                              observer.hide_info,
                                              observer.show_info):
-        wc.monitor_name = options.monitor_key
+        if options.monitor_key is not None:
+            wc.monitor_name = options.monitor_key
         filenames = args
         output = options.output
         result = process(filenames, output, wc, observer, options.write_mode)

--- a/src/pyFAI/test/test_integrate_app.py
+++ b/src/pyFAI/test/test_integrate_app.py
@@ -85,7 +85,7 @@ class TestIntegrateApp(unittest.TestCase):
         path = os.path.join(self.tempDir, filename)
         return os.path.exists(path)
 
-    def create_json(self, ponipath=None, nbpt_azim=1):
+    def create_json(self, ponipath=None, nbpt_azim=1, monitor_key=None):
         if ponipath is None:
             ponipath = UtilsTest.getimage("dummy.poni")
         data = {"poni": ponipath}
@@ -95,6 +95,8 @@ class TestIntegrateApp(unittest.TestCase):
         data["nbpt_azim"] = nbpt_azim
         data["do_2D"] = nbpt_azim > 1
         data["method"] = ("bbox", "histogram", "cython")
+        if monitor_key is not None:
+            data["monitor_name"] = monitor_key
         path = os.path.join(self.tempDir, "config.json")
         with open(path, 'w') as fp:
             json.dump(data, fp)
@@ -161,6 +163,16 @@ class TestIntegrateApp(unittest.TestCase):
         datapath = self.create_edf_file("data.edf", data, header={"my_mon": "0.5"})
         expected = numpy.array([[2.0, 33.9], [2.0, 52.0], [2., 0.]])
         options.json = self.create_json()
+        pyFAI.app.integrate.integrate_shell(options, [datapath])
+        result = numpy.loadtxt(self.get_path("data.dat"))
+        numpy.testing.assert_almost_equal(result, expected, decimal=1)
+
+    def test_integrate_monitor_from_json(self):
+        options = self.Options()
+        data = numpy.array([[0, 0], [0, 100], [0, 0]])
+        datapath = self.create_edf_file("data.edf", data, header={"my_mon": "0.5"})
+        expected = numpy.array([[2.0, 33.9], [2.0, 52.0], [2., 0.]])
+        options.json = self.create_json(monitor_key="my_mon")
         pyFAI.app.integrate.integrate_shell(options, [datapath])
         result = numpy.loadtxt(self.get_path("data.dat"))
         numpy.testing.assert_almost_equal(result, expected, decimal=1)


### PR DESCRIPTION
Fixes #2891

## Description
This MR fixes a bug introduced in v2025.03 where the `monitor_name` configuration from the JSON file was unconditionally overwritten by the `--monitor-name` CLI option, even when the CLI option was not explicitly provided.

## Changes
1. **src/pyFAI/app/integrate.py**: Modified `integrate_shell()` to only override `monitor_name` when the CLI option is explicitly provided (not None)
2. **src/pyFAI/test/test_integrate_app.py**: 
   - Enhanced `create_json()` helper to support specifying `monitor_name` in config
   - Added regression test `test_integrate_monitor_from_json()` to ensure JSON-based monitor configuration works

## Testing
- Added regression test that verifies monitor_name works when specified in JSON config
- Existing CLI monitor override tests (`test_integrate_monitor`, `test_integrate_counter_monitor`, etc.) remain unaffected and continue to work

## Backward Compatibility
- **Fully backward compatible**: Users who provide `--monitor-name` CLI option see no change
- **Fixes regression**: Users who rely on JSON config for monitor_name now work as expected

MR generated with AI