### PR TITLE
calib2 hang when wrong detector

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,5 +1,5 @@
 :Author: Jérôme Kieffer
-:Date: 18/08/2026
+:Date: 19/08/2026
 :Keywords: changelog
 
 Change-log of versions
@@ -9,6 +9,9 @@ Change-log of versions
 -------------------
 - Change of behavior of `Calibrant` which raises `ValueError` when a file exist but does not d-spacing info / `IOError` when absent
 - Fix serialization issue with Rayonix detectors (regression introduced with parallax, #2904)
+- Fix hang when changing detector (size) after a first calibration or inconsistent detector shape (#2890)
+- Test are by default without GUI output, much cleaner now.
+- Supports python 3.10-3.14, 3.14t is untested.
 
 2026.05 19/05/2026
 -------------------

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "24/02/2026"
+__date__ = "19/08/2026"
 __license__ = "MIT"
 
 import sys
@@ -374,8 +374,9 @@ else:
 epilog = """Environment variables:
 WITH_QT_TEST=False to disable graphical tests
 PYFAI_OPENCL=False to disable OpenCL tests.
-PYFAI_LOW_MEM: set to True to skip all tests >100Mb
+PYFAI_LOW_MEM=True to skip all tests >100Mb
 WITH_GL_TEST=False to disable tests using OpenGL
+QT_QPA_PLATFORM=offscreen to render all GUI tests offscreen
 """
 parser = ArgumentParser(description='Run the tests.',
                         epilog=epilog)
@@ -407,6 +408,9 @@ parser.add_argument("-v", "--verbose", default=0,
                          "including debug messages and test help strings.")
 parser.add_argument("--qt-binding", dest="qt_binding", default=None,
                     help="Force using a Qt binding, from 'PyQt5', 'PyQt6'or 'PySide6' (default)")
+parser.add_argument("--qt-screen", dest="qt_screen", default=None,
+                    help="Force using a Qt to render 'off'-screen or `on`-screen. use 'vnc' to debug")
+
 
 options = parser.parse_args()
 sys.argv = [sys.argv[0]]
@@ -438,6 +442,15 @@ if options.coverage:
     cov = coverage_class(include=[f"*/{PROJECT_NAME}/*"],
                          omit=omits)
     cov.start()
+
+if options.qt_screen:
+    env_qtplatform = os.environ.get("QT_QPA_PLATFORM")
+    if options.qt_screen.lower() == "on":
+        if env_qtplatform is None:
+            os.environ["QT_QPA_PLATFORM"] = "minimal"
+    else:
+        value = "offscreen" if options.qt_screen.lower() == "off" else options.qt_screen
+        os.environ["QT_QPA_PLATFORM"] = value
 
 if options.qt_binding:
     binding = options.qt_binding.lower()

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "19/08/2026"
+__date__ = "20/08/2026"
 __license__ = "MIT"
 
 import sys
@@ -43,6 +43,7 @@ import time
 import unittest
 import collections
 import tempfile
+import platform
 
 
 class StreamHandlerUnittestReady(logging.StreamHandler):

--- a/run_tests.py
+++ b/run_tests.py
@@ -408,8 +408,8 @@ parser.add_argument("-v", "--verbose", default=0,
                          "including debug messages and test help strings.")
 parser.add_argument("--qt-binding", dest="qt_binding", default=None,
                     help="Force using a Qt binding, from 'PyQt5', 'PyQt6'or 'PySide6' (default)")
-parser.add_argument("--qt-screen", dest="qt_screen", default=None,
-                    help="Force using a Qt to render 'off'-screen or `on`-screen. use 'vnc' to debug")
+parser.add_argument("--qt-screen", dest="qt_screen", default="off", #None,
+                    help="Force using a Qt to render 'off'-screen (default) or `on`-screen. use 'vnc' to debug")
 
 
 options = parser.parse_args()
@@ -444,12 +444,19 @@ if options.coverage:
     cov.start()
 
 if options.qt_screen:
+    system = platform.system()
+    if system == "Windows":
+        off = on = "windows"
+    else:
+        on = "minimal"
+        off = "offscreen"
+
     env_qtplatform = os.environ.get("QT_QPA_PLATFORM")
     if options.qt_screen.lower() == "on":
         if env_qtplatform is None:
-            os.environ["QT_QPA_PLATFORM"] = "minimal"
+            os.environ["QT_QPA_PLATFORM"] = on 
     else:
-        value = "offscreen" if options.qt_screen.lower() == "off" else options.qt_screen
+        value = off if options.qt_screen.lower() == "off" else options.qt_screen
         os.environ["QT_QPA_PLATFORM"] = value
 
 if options.qt_binding:

--- a/src/pyFAI/detectors/_common.py
+++ b/src/pyFAI/detectors/_common.py
@@ -33,7 +33,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "04/02/2026"
+__date__ = "19/08/2026"
 __status__ = "stable"
 
 import logging
@@ -995,7 +995,10 @@ class Detector(metaclass=DetectorMeta):
                 return False
             res = self.max_shape[0] % shape[0] + self.max_shape[1] % shape[1]
             if res != 0:
+                # do not mutate the detector on failure: it would hide the
+                # inconsistency from any subsequent check
                 logger.warning("Impossible binning: max_shape is %s, requested shape %s", self.max_shape, shape)
+                return False
 
             old_binning = self._binning
             self._binning = (bin1, bin2)
@@ -1004,7 +1007,7 @@ class Detector(metaclass=DetectorMeta):
             self._pixel2 *= (1.0 * bin2 / old_binning[1])
             self._mask = False
             self._mask_crc = None
-            return res == 0
+            return True
         else:
             logger.debug("guess_binning for generic detectors !")
             self._binning = 1, 1
@@ -1050,7 +1053,10 @@ class Detector(metaclass=DetectorMeta):
         :return: the mask with valid pixel to 0
         :rtype: numpy ndarray of int8 or None
         """
-        if not self.guess_binning(img):
+        if not self.guess_binning(img) and self.shape is None:
+            # shape-less generic detector: adapt to the image.
+            # Detectors with a defined shape are kept untouched, the static
+            # mask is returned and the caller has to deal with the mismatch.
             self.shape = img.shape
 
         static_mask = self.mask

--- a/src/pyFAI/gui/model/ExperimentSettingsModel.py
+++ b/src/pyFAI/gui/model/ExperimentSettingsModel.py
@@ -85,7 +85,7 @@ class ExperimentSettingsModel(AbstractModel):
         self.__flat.filenameChanged.connect(self.wasChanged)
 
         self.__image.changed.connect(self.__updateDetectorMask)
-        self.__detectorModel.changed.connect(self.__updateDetectorMask)
+        self.__detectorModel.changed.connect(self.__detectorUpdated)
         self.__mask.changed.connect(self.__notAnymoreADetectorMask)
 
 
@@ -98,6 +98,19 @@ class ExperimentSettingsModel(AbstractModel):
                f"self.__jsonFile: {self.__jsonFile}",
                f"parallaxCorrection: {self.__parallaxCorrection.value()}"]
         return ", ".join(res)
+
+    def __detectorUpdated(self):
+        """Handle detector change: the mask is re-initialized.
+
+        Any previous mask (customized by the user or loaded from a file) is
+        discarded and replaced by the mask of the new detector, as masks from
+        different detectors are unrelated."""
+        if self.__mask.filename() is not None or not self.__isDetectorMask:
+            _logger.warning("Detector changed: the former mask is replaced by the mask of the new detector")
+        if self.__mask.filename() is not None:
+            self.__mask.setFilename(None)
+        self.__isDetectorMask = True
+        self.__updateDetectorMask()
 
     def __updateDetectorMask(self):
         if self.mask().filename() is not None:

--- a/src/pyFAI/gui/model/ExperimentSettingsModel.py
+++ b/src/pyFAI/gui/model/ExperimentSettingsModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls", "Jérôme Kieffer"]
 __license__ = "MIT"
-__date__ = "03/11/2025"
+__date__ = "19/08/2026"
 
 import logging
 from .AbstractModel import AbstractModel
@@ -125,6 +125,13 @@ class ExperimentSettingsModel(AbstractModel):
                 mask = detector.mask
             # Here mask can be None
             # For example if image do not feet the detector
+            if mask is not None and image is not None and mask.shape != image.shape[:2]:
+                # Never store a mask inconsistent with the image: it would
+                # break any downstream processing (e.g. peak picking)
+                _logger.warning("Mask of detector %s (shape %s) does not match the image shape %s: "
+                                "no mask is applied, check the detector selection",
+                                detector.name, mask.shape, image.shape[:2])
+                mask = None
 
         if mask is not None:
             mask = mask.copy()

--- a/src/pyFAI/gui/model/ExperimentSettingsModel.py
+++ b/src/pyFAI/gui/model/ExperimentSettingsModel.py
@@ -47,6 +47,7 @@ class ExperimentSettingsModel(AbstractModel):
         self.__mask = ImageFromFilenameModel()
         self.__maskedImage = MaskedImageModel(None, self.__image, self.__mask)
         self.__isDetectorMask = True
+        self.__detectorShape = None
         self.__dark = ImageFromFilenameModel()
         self.__flat = ImageFromFilenameModel()
         self.__preprocessed_image = PreProcessedImageModel(
@@ -100,16 +101,25 @@ class ExperimentSettingsModel(AbstractModel):
         return ", ".join(res)
 
     def __detectorUpdated(self):
-        """Handle detector change: the mask is re-initialized.
+        """Handle detector change: the mask is re-initialized when the
+        detector size effectively changes.
 
-        Any previous mask (customized by the user or loaded from a file) is
-        discarded and replaced by the mask of the new detector, as masks from
-        different detectors are unrelated."""
-        if self.__mask.filename() is not None or not self.__isDetectorMask:
-            _logger.warning("Detector changed: the former mask is replaced by the mask of the new detector")
-        if self.__mask.filename() is not None:
-            self.__mask.setFilename(None)
-        self.__isDetectorMask = True
+        In this case any previous mask (customized by the user or loaded from
+        a file) is discarded and replaced by the mask of the new detector, as
+        masks of different geometries are unrelated. Selecting a detector of
+        the same size preserves a customized mask."""
+        detector = self.__detectorModel.detector()
+        shape = None if detector is None or detector.shape is None else tuple(detector.shape)
+        previousShape = self.__detectorShape
+        self.__detectorShape = shape
+        if previousShape is not None and shape is not None and shape != previousShape:
+            if self.__mask.filename() is not None or not self.__isDetectorMask:
+                _logger.warning("Detector shape changed from %s to %s: "
+                                "the former mask is replaced by the mask of the new detector",
+                                previousShape, shape)
+            if self.__mask.filename() is not None:
+                self.__mask.setFilename(None)
+            self.__isDetectorMask = True
         self.__updateDetectorMask()
 
     def __updateDetectorMask(self):

--- a/src/pyFAI/gui/tasks/ExperimentTask.py
+++ b/src/pyFAI/gui/tasks/ExperimentTask.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["Valentin Valls", "Jérôme Kieffer"]
 __license__ = "MIT"
-__date__ = "26/06/2026"
+__date__ = "19/08/2026"
 
 import numpy
 import logging
@@ -207,7 +207,7 @@ class ExperimentTask(AbstractCalibrationTask):
             warnings.append("A calibrant has to be specified")
         if wavelength is None:
             warnings.append("An energy has to be specified")
-        if image is not None and calibrantModel is not None:
+        if image is not None and detectorModel is not None:
             try:
                 detector = settings.detector()
                 binning = detector.guess_binning(image)
@@ -215,6 +215,14 @@ class ExperimentTask(AbstractCalibrationTask):
                     raise Exception("inconsistency")
             except Exception:
                 warnings.append("Inconsistency between sizes of image and detector")
+            # guess_binning mutates the detector shape even on failure, so on
+            # re-evaluation it can no longer detect the mismatch: check the
+            # actual mask stored in the model against the image instead.
+            mask = settings.mask().value()
+            if mask is not None and mask.shape != image.shape[:2]:
+                warnings.append(
+                    "Mask shape %s does not match image shape %s, "
+                    "check the detector selection" % (mask.shape, image.shape[:2]))
 
         self._globalWarnings = warnings
         self.updateNextStepStatus()

--- a/src/pyFAI/gui/tasks/PeakPickingTask.py
+++ b/src/pyFAI/gui/tasks/PeakPickingTask.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "09/04/2026"
+__date__ = "19/08/2026"
 
 import logging
 import numpy
@@ -1357,27 +1357,46 @@ class PeakPickingTask(AbstractCalibrationTask):
         pass
 
     def __createMassif(self, reconstruct=False):
-        qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
+        """Create the Massif used to pick peaks around a click.
+
+        :return: a Massif instance, or None if there is no image or if the
+            computation failed (e.g. mask and image shapes mismatch when the
+            wrong detector was selected)
+        """
         experimentSettings = self.model().experimentSettingsModel()
         image = experimentSettings.image().value()
         mask = experimentSettings.mask().value()
         if image is None:
             return None
-        massif = pyFAI.massif.Massif(image, mask)
-        massif.get_labeled_massif(reconstruct=reconstruct)
-        qt.QApplication.restoreOverrideCursor()
+        qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
+        try:
+            massif = pyFAI.massif.Massif(image, mask)
+            massif.get_labeled_massif(reconstruct=reconstruct)
+        except Exception as e:
+            if mask is not None and mask.shape != image.shape[:2]:
+                title = ("Error while preparing peak picking: the mask shape "
+                         f"{mask.shape} does not match the image shape {image.shape[:2]}. "
+                         "Check the detector selected in the experiment settings.")
+            else:
+                title = "Error while preparing peak picking"
+            MessageBox.exception(self, title, e, _logger)
+            return None
+        finally:
+            qt.QApplication.restoreOverrideCursor()
         return massif
 
     def __getMassif(self):
         if self.__ringSelectionMode.isChecked():
             if self.__massifReconstructed is None:
                 self.__massifReconstructed = self.__createMassif(reconstruct=True)
-            self.__massifReconstructed.log_info = False
+            if self.__massifReconstructed is not None:
+                self.__massifReconstructed.log_info = False
             return self.__massifReconstructed
         elif self.__arcSelectionMode.isChecked() or self.__peakSelectionMode.isChecked():
             if self.__massif is None:
                 self.__massif = self.__createMassif()
-            self.__massif.log_info = False
+            if self.__massif is not None:
+                self.__massif.log_info = False
             return self.__massif
         else:
             raise RuntimeError("No selection mode defined")
@@ -1390,7 +1409,7 @@ class PeakPickingTask(AbstractCalibrationTask):
         massif = self.__getMassif()
         if massif is None:
             # Nothing to pick
-            return
+            return []
         points = massif.find_peaks([y, x], stdout=None)
         if len(points) == 0:
             # toleration

--- a/src/pyFAI/massif.py
+++ b/src/pyFAI/massif.py
@@ -30,7 +30,7 @@ __author__ = "Jérôme Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "08/10/2025"
+__date__ = "19/08/2026"
 __status__ = "production"
 
 import sys
@@ -76,8 +76,13 @@ class Massif(object):
                 logger.error("Unable to understand this type of data %s: %s", data, error)
         self.log_info = True
         """If true, more information is displayed in the logger relative to picking."""
+        if mask is not None:
+            mask = numpy.asarray(mask)
+            if mask.shape != self.data.shape:
+                raise ValueError(f"Mask shape {mask.shape} does not match data shape {self.data.shape}: "
+                                 "check the detector definition")
         data_mask = numpy.logical_not(numpy.isfinite(self.data))
-        if (data_mask.any() is False):
+        if not data_mask.any():
             self.mask = mask
         else:
             if mask is None:

--- a/src/pyFAI/test/test_bug_regression.py
+++ b/src/pyFAI/test/test_bug_regression.py
@@ -798,7 +798,7 @@ class TestBugRegression(unittest.TestCase):
             parallax=False,
         )
         poni = PoniFile(geometry)
-        print(poni.detector)
+        # print(poni.detector)
         poni.write(StringIO())
 
 

--- a/version.py
+++ b/version.py
@@ -73,7 +73,7 @@ RELEASE_LEVEL_VALUE = {"dev": 0,
                        "final": 15}
 
 MAJOR = 2026
-MINOR = 7
+MINOR = 8
 MICRO = 0
 RELEV = "dev"  # <16
 SERIAL = 0  # <16


### PR DESCRIPTION
Make pyFAI-calib2 robust against a wrong detector choice that crashed peak picking.
close #2890